### PR TITLE
Add kyverno policy enforcement

### DIFF
--- a/contexts/default/blueprint.yaml
+++ b/contexts/default/blueprint.yaml
@@ -17,30 +17,45 @@ terraform:
 - path: cluster/talos
 - path: gitops/flux
 kustomize:
+- name: policy-base
+  path: policy/base
+  components:
+  - kyverno
+- name: policy-resources
+  path: policy/resources
+  dependsOn:
+  - policy-base
 - name: pki-base
   path: pki/base
+  dependsOn:
+  - policy-resources
   components:
   - cert-manager
 - name: pki-resources
   path: pki/resources
   dependsOn:
   - pki-base
+  - policy-resources
   components:
   - public-issuer/selfsigned
 - name: lb-base
   path: lb/base
+  dependsOn:
+  - policy-resources
   components:
   - metallb
 - name: lb-resources
   path: lb/resources
   dependsOn:
   - lb-base
+  - policy-resources
   components:
   - metallb/layer2
 - name: ingress-base
   path: ingress/base
   dependsOn:
   - pki-resources
+  - policy-resources
   components:
   - nginx
   - nginx/nodeport-web
@@ -49,5 +64,6 @@ kustomize:
   path: gitops/flux
   dependsOn:
   - ingress-base
+  - policy-resources
   components:
   - webhook

--- a/kustomize/policy/base/kustomization.yaml
+++ b/kustomize/policy/base/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - namespace.yaml

--- a/kustomize/policy/base/kyverno/helm-release.yaml
+++ b/kustomize/policy/base/kyverno/helm-release.yaml
@@ -1,0 +1,17 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kyverno
+  namespace: system-policy
+spec:
+  interval: 5m
+  timeout: 5m
+  chart:
+    spec:
+      chart: kyverno
+      # renovate: datasource=helm depName=kyverno package=kyverno helmRepo=https://kyverno.github.io/kyverno/
+      version: 3.2.7
+      sourceRef:
+        kind: HelmRepository
+        name: kyverno
+        namespace: system-gitops

--- a/kustomize/policy/base/kyverno/helm-repository.yaml
+++ b/kustomize/policy/base/kyverno/helm-repository.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: kyverno
+  namespace: system-gitops
+spec:
+  interval: 10m
+  timeout: 3m
+  url: https://kyverno.github.io/kyverno

--- a/kustomize/policy/base/kyverno/kustomization.yaml
+++ b/kustomize/policy/base/kyverno/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - helm-repository.yaml
+  - helm-release.yaml

--- a/kustomize/policy/base/namespace.yaml
+++ b/kustomize/policy/base/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: system-policy
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/warn: baseline

--- a/kustomize/policy/resources/kustomization.yaml
+++ b/kustomize/policy/resources/kustomization.yaml
@@ -1,0 +1,1 @@
+resources: []

--- a/kustomize/policy/resources/kyverno/basic/cluster-policies.yaml
+++ b/kustomize/policy/resources/kyverno/basic/cluster-policies.yaml
@@ -1,0 +1,29 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: audit-resource-limits-requests
+spec:
+  validationFailureAction: audit
+  background: false
+  rules:
+    - name: check-resource-limits-requests
+      match:
+        resources:
+          kinds:
+            - Pod
+      preconditions:
+        all:
+          - key: "{{request.namespace}}"
+            operator: NotEquals
+            value: "kube-system"
+      validate:
+        message: "Resource limits and requests must be set on all containers."
+        anyPattern:
+          - spec:
+              containers:
+                - resources:
+                    requests:
+                      memory: "?*"
+                      cpu: "?*"
+                    limits:
+                      memory: "?*"

--- a/kustomize/policy/resources/kyverno/basic/kustomization.yaml
+++ b/kustomize/policy/resources/kyverno/basic/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - cluster-policies.yaml

--- a/kustomize/policy/resources/kyverno/kustomization.yaml
+++ b/kustomize/policy/resources/kyverno/kustomization.yaml
@@ -1,0 +1,3 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources: []


### PR DESCRIPTION
We use kyverno to implement guardrails, but also as a kind of Swiss Army Knife for edge cases where we can uses mutating webhooks to modify resources, _e.g._, resources created by Helm charts.