### PR TITLE
Adjust external-dns and reduce etcd replicas

### DIFF
--- a/kustomize/dns/coredns/etcd/ha/patches/helm-release.yaml
+++ b/kustomize/dns/coredns/etcd/ha/patches/helm-release.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: system-dns
 spec:
   values:
+    replicaCount: 3
     affinity:
       podAntiAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:

--- a/kustomize/dns/coredns/etcd/helm-release.yaml
+++ b/kustomize/dns/coredns/etcd/helm-release.yaml
@@ -15,10 +15,8 @@ spec:
         kind: HelmRepository
         name: coredns-etcd-bitnami
         namespace: system-gitops
-  values:      
-    # global:
-    #   storageClass: single
-    replicaCount: 3
+  values:
+    replicaCount: 1
     securityContext:
       fsGroup: 1000
     # Modifies the liveness probe to behave like the other probes. Endpoint healthchecks with mTLS are not supported by k8s.

--- a/kustomize/dns/external-dns/coredns/patches/helm-release.yaml
+++ b/kustomize/dns/external-dns/coredns/patches/helm-release.yaml
@@ -5,7 +5,8 @@
     namespace: system-dns
 - op: add
   path: /spec/values/provider
-  value: coredns
+  value:
+    name: coredns
 - op: add
   path: /spec/values/env/-
   value:


### PR DESCRIPTION
Adjusts the config value for external-dns provider and reduce coredns etcd replicas to 1 by default.