### PR TITLE
Enable DNS locally

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
     uses: windsorcli/blueprint/.github/workflows/checkov.yaml@37a5386198caa29f87531d09003512adc5407702 # v0.1.0
 
   ci:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest-4-cores
 
     env:
       KUBECONFIG: ${{ github.workspace }}/contexts/local/.kube/config

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,9 +59,9 @@ jobs:
 
       # Install Windsor CLI
       - name: Install Windsor CLI
-        uses: windsorcli/action/.github/actions/windsorcli@078842a08b468bd2278563bbc929e9d968095988 # v0.2.0
+        uses: windsorcli/action/.github/actions/windsorcli@8473f4294ee3f10b81b229f8c67079cb685d3136 # main
         with:
-          version: ${{ env.WINDSORCLI_VERSION }}
+          ref: main
           install_folder: ${{ github.workspace }}/bin
           context: local
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,7 @@ jobs:
 
       # Install Windsor CLI
       - name: Install Windsor CLI
-        uses: windsorcli/action@8473f4294ee3f10b81b229f8c67079cb685d3136 # main
+        uses: windsorcli/action@main
         with:
           ref: main
           context: local

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,13 +23,7 @@ jobs:
     uses: windsorcli/blueprint/.github/workflows/checkov.yaml@37a5386198caa29f87531d09003512adc5407702 # v0.1.0
 
   ci:
-    runs-on: ubuntu-latest
-    services:
-      docker:
-        image: docker:dind
-        options: --privileged --shm-size=2g
-        volumes:
-          - /var/run/docker.sock:/var/run/docker.sock:ro
+    runs-on: ubuntu-latest-8-cores
 
     env:
       KUBECONFIG: ${{ github.workspace }}/contexts/local/.kube/config
@@ -41,25 +35,23 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
-
       - name: Create .docker-cache directory
-        run: mkdir -p .docker-cache
+        run: mkdir -p .windsor/.docker-cache
 
       - name: Cache .docker-cache
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
-          path: .docker-cache
+          path: .windsor/.docker-cache
           key: docker-cache-${{ runner.os }}-${{ github.sha }}
           restore-keys: docker-cache-${{ runner.os }}-
 
       # Install Aqua
-      - name: Install Aqua on Linux/macOS
+      - name: Install Aqua
         uses: aquaproj/aqua-installer@5e54e5cee8a95ee2ce7c04cb993da6dfad13e59c # v3.1.2
         with:
           aqua_version: v2.50.0
           
-      - name: Set aqua path on Linux/macOS
+      - name: Set aqua path
         run: |
           echo "${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin" >> $GITHUB_PATH
 
@@ -76,12 +68,12 @@ jobs:
           context: local
 
       # Windsor Up
-      - name: Windsor Up on Linux/macOS
+      - name: Windsor Up
         run: |
-          windsor init local --set dns.enabled=false
+          windsor init local
           windsor up --install --verbose
 
       # Windsor Down
-      - name: Windsor Down on Linux/macOS
+      - name: Windsor Down
         run: |
           windsor down --clean

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,6 @@ jobs:
       TALOSCONFIG: ${{ github.workspace }}/contexts/local/.talos/config
       PRIVATE_DOMAIN_NAME: private.test
       DNS_SERVER_IP: "10.5.255.200"
-      WINDSORCLI_VERSION: "v0.5.1"
 
     steps:
       - name: Checkout code
@@ -69,8 +68,7 @@ jobs:
       # Windsor Up
       - name: Windsor Up on Linux/macOS
         run: |
-          windsor init local
-
+          windsor init local --set dns.enabled=false
           windsor up --install --verbose
 
       # Windsor Down

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ permissions:
 
 env:
   WINDSOR_PROJECT_ROOT: ${{ github.workspace }}
+  DOCKER_HOST: unix:///var/run/docker.sock
 
 jobs:
   # Blueprint Checks
@@ -23,7 +24,7 @@ jobs:
     uses: windsorcli/blueprint/.github/workflows/checkov.yaml@37a5386198caa29f87531d09003512adc5407702 # v0.1.0
 
   ci:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest
 
     env:
       KUBECONFIG: ${{ github.workspace }}/contexts/local/.kube/config

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
 
       # Install Windsor CLI
       - name: Install Windsor CLI
-        uses: windsorcli/action/.github/actions/windsorcli@8473f4294ee3f10b81b229f8c67079cb685d3136 # main
+        uses: windsorcli/action@8473f4294ee3f10b81b229f8c67079cb685d3136 # main
         with:
           ref: main
           install_folder: ${{ github.workspace }}/bin

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,7 @@ jobs:
       # Windsor Up
       - name: Windsor Up
         run: |
-          windsor init local
+          windsor init local --set dns.enabled=false
           windsor up --install --verbose
 
       # Windsor Down

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,12 @@ jobs:
 
   ci:
     runs-on: ubuntu-latest
+    services:
+      docker:
+        image: docker:dind
+        options: --privileged --shm-size=2g
+        volumes:
+          - /var/run/docker.sock:/var/run/docker.sock:ro
 
     env:
       KUBECONFIG: ${{ github.workspace }}/contexts/local/.kube/config

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 env:
   WINDSOR_PROJECT_ROOT: ${{ github.workspace }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
       - name: Create .docker-cache directory
         run: mkdir -p .docker-cache
 
@@ -62,7 +64,6 @@ jobs:
         uses: windsorcli/action@8473f4294ee3f10b81b229f8c67079cb685d3136 # main
         with:
           ref: main
-          install_folder: ${{ github.workspace }}/bin
           context: local
 
       # Windsor Up

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
     uses: windsorcli/blueprint/.github/workflows/checkov.yaml@37a5386198caa29f87531d09003512adc5407702 # v0.1.0
 
   ci:
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest-8-cores
 
     env:
       KUBECONFIG: ${{ github.workspace }}/contexts/local/.kube/config

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ contexts/**/.tfstate/
 contexts/**/.kube/
 contexts/**/.talos/
 contexts/**/.aws/
+contexts/**/.omni/

--- a/contexts/local/blueprint.yaml
+++ b/contexts/local/blueprint.yaml
@@ -14,24 +14,19 @@ sources:
   ref:
     branch: main
 terraform:
-- source: core
-  path: cluster/talos
-- source: core
-  path: gitops/flux
+- path: cluster/talos
+- path: gitops/flux
 kustomize:
 - name: policy-base
   path: policy/base
-  source: core
   components:
   - kyverno
 - name: policy-resources
   path: policy/resources
-  source: core
   dependsOn:
   - policy-base
 - name: csi
   path: csi
-  source: core
   dependsOn:
   - policy-resources
   force: true
@@ -40,7 +35,6 @@ kustomize:
   - openebs/dynamic-localpv
 - name: ingress-base
   path: ingress/base
-  source: core
   dependsOn:
   - pki-resources
   force: true
@@ -52,7 +46,6 @@ kustomize:
   - nginx/web
 - name: pki-base
   path: pki/base
-  source: core
   dependsOn:
   - policy-resources
   force: true
@@ -61,7 +54,6 @@ kustomize:
   - trust-manager
 - name: pki-resources
   path: pki/resources
-  source: core
   dependsOn:
   - pki-base
   force: true
@@ -70,7 +62,6 @@ kustomize:
   - public-issuer/selfsigned
 - name: dns
   path: dns
-  source: core
   dependsOn:
   - ingress-base
   - pki-base
@@ -84,7 +75,6 @@ kustomize:
   - external-dns/ingress
 - name: gitops
   path: gitops/flux
-  source: core
   dependsOn:
   - ingress-base
   force: true
@@ -92,7 +82,6 @@ kustomize:
   - webhook
 - name: demo
   path: demo/bookinfo
-  source: core
   dependsOn:
   - ingress-base
   force: true

--- a/contexts/local/terraform/cluster/talos.tfvars
+++ b/contexts/local/terraform/cluster/talos.tfvars
@@ -2,20 +2,20 @@
 // Module source: github.com/windsorcli/core//terraform/cluster/talos?ref=main
 
 // The external controlplane API endpoint of the kubernetes API
-cluster_endpoint = "https://controlplane-1.test:6443"
+cluster_endpoint = "https://127.0.0.1:6443"
 
 // The name of the cluster
 cluster_name = "talos"
 
 // A YAML string of common config patches to apply
-common_config_patches = "\"cluster\":\n  \"apiServer\":\n    \"certSANs\":\n    - \"localhost\"\n    - \"controlplane-1.test\"\n  \"extraManifests\":\n  - \"https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml\"\n\"machine\":\n  \"certSANs\":\n  - \"localhost\"\n  - \"controlplane-1.test\"\n  \"kubelet\":\n    \"extraArgs\":\n      \"rotate-server-certificates\": \"true\"\n  \"network\":\n    \"interfaces\":\n    - \"ignore\": true\n      \"interface\": \"eth0\"\n  \"registries\":\n    \"mirrors\":\n      \"docker.io\":\n        \"endpoints\":\n        - \"http://registry-1.docker.test:5000\"\n      \"gcr.io\":\n        \"endpoints\":\n        - \"http://gcr.test:5000\"\n      \"ghcr.io\":\n        \"endpoints\":\n        - \"http://ghcr.test:5000\"\n      \"quay.io\":\n        \"endpoints\":\n        - \"http://quay.test:5000\"\n      \"registry.k8s.io\":\n        \"endpoints\":\n        - \"http://registry.k8s.test:5000\"\n      \"registry.test\":\n        \"endpoints\":\n        - \"http://registry.test:5000\""
+common_config_patches = "\"cluster\":\n  \"apiServer\":\n    \"certSANs\":\n    - \"localhost\"\n    - \"127.0.0.1\"\n  \"extraManifests\":\n  - \"https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml\"\n\"machine\":\n  \"certSANs\":\n  - \"localhost\"\n  - \"127.0.0.1\"\n  \"kubelet\":\n    \"extraArgs\":\n      \"rotate-server-certificates\": \"true\"\n  \"network\":\n    \"interfaces\":\n    - \"ignore\": true\n      \"interface\": \"eth0\"\n  \"registries\":\n    \"mirrors\":\n      \"docker.io\":\n        \"endpoints\":\n        - \"http://registry-1.docker.test:5000\"\n      \"gcr.io\":\n        \"endpoints\":\n        - \"http://gcr.test:5000\"\n      \"ghcr.io\":\n        \"endpoints\":\n        - \"http://ghcr.test:5000\"\n      \"quay.io\":\n        \"endpoints\":\n        - \"http://quay.test:5000\"\n      \"registry.k8s.io\":\n        \"endpoints\":\n        - \"http://registry.k8s.test:5000\"\n      \"registry.test\":\n        \"endpoints\":\n        - \"http://registry.test:5000\""
 
 // A YAML string of controlplane config patches to apply
 controlplane_config_patches = ""
 
 // Machine config details for control planes
 controlplanes = [{
-  endpoint = "controlplane-1.test:50000"
+  endpoint = "127.0.0.1:50000"
   node     = "controlplane-1"
 }]
 
@@ -24,6 +24,6 @@ worker_config_patches = "\"machine\":\n  \"kubelet\":\n    \"extraMounts\":\n   
 
 // Machine config details for workers
 workers = [{
-  endpoint = "worker-1.test:50001"
+  endpoint = "127.0.0.1:50001"
   node     = "worker-1"
 }]

--- a/contexts/local/terraform/cluster/talos.tfvars
+++ b/contexts/local/terraform/cluster/talos.tfvars
@@ -1,20 +1,22 @@
 // Managed by Windsor CLI: This file is partially managed by the windsor CLI. Your changes will not be overwritten.
-// Module source: github.com/windsorcli/core//terraform/cluster/talos?ref=v0.2.0
+// Module source: github.com/windsorcli/core//terraform/cluster/talos?ref=main
 
 // The external controlplane API endpoint of the kubernetes API
-cluster_endpoint = "https://127.0.0.1:6443"
+cluster_endpoint = "https://controlplane-1.test:6443"
 
 // The name of the cluster
 cluster_name = "talos"
 
 // A YAML string of common config patches to apply
-common_config_patches = "\"cluster\":\n  \"apiServer\":\n    \"certSANs\":\n    - \"localhost\"\n    - \"127.0.0.1\"\n  \"extraManifests\":\n  - \"https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml\"\n\"machine\":\n  \"certSANs\":\n  - \"localhost\"\n  - \"127.0.0.1\"\n  \"features\":\n    \"hostDNS\":\n      \"forwardKubeDNSToHost\": true\n  \"kubelet\":\n    \"extraArgs\":\n      \"rotate-server-certificates\": \"true\"\n  \"network\":\n    \"interfaces\":\n    - \"ignore\": true\n      \"interface\": \"eth0\"\n  \"registries\":\n    \"mirrors\":\n      \"docker.io\":\n        \"endpoints\":\n        - \"http://registry-1.docker.test:5000\"\n      \"gcr.io\":\n        \"endpoints\":\n        - \"http://gcr.test:5000\"\n      \"ghcr.io\":\n        \"endpoints\":\n        - \"http://ghcr.test:5000\"\n      \"quay.io\":\n        \"endpoints\":\n        - \"http://quay.test:5000\"\n      \"registry.k8s.io\":\n        \"endpoints\":\n        - \"http://registry.k8s.test:5000\"\n      \"registry.test\":\n        \"endpoints\":\n        - \"http://registry.test:5000\""
+common_config_patches = "\"cluster\":\n  \"apiServer\":\n    \"certSANs\":\n    - \"localhost\"\n    - \"controlplane-1.test\"\n  \"extraManifests\":\n  - \"https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml\"\n\"machine\":\n  \"certSANs\":\n  - \"localhost\"\n  - \"controlplane-1.test\"\n  \"kubelet\":\n    \"extraArgs\":\n      \"rotate-server-certificates\": \"true\"\n  \"network\":\n    \"interfaces\":\n    - \"ignore\": true\n      \"interface\": \"eth0\"\n  \"registries\":\n    \"mirrors\":\n      \"docker.io\":\n        \"endpoints\":\n        - \"http://registry-1.docker.test:5000\"\n      \"gcr.io\":\n        \"endpoints\":\n        - \"http://gcr.test:5000\"\n      \"ghcr.io\":\n        \"endpoints\":\n        - \"http://ghcr.test:5000\"\n      \"quay.io\":\n        \"endpoints\":\n        - \"http://quay.test:5000\"\n      \"registry.k8s.io\":\n        \"endpoints\":\n        - \"http://registry.k8s.test:5000\"\n      \"registry.test\":\n        \"endpoints\":\n        - \"http://registry.test:5000\""
+
+// A YAML string of controlplane config patches to apply
+controlplane_config_patches = ""
 
 // Machine config details for control planes
 controlplanes = [{
-  endpoint = "127.0.0.1:50000"
-  hostname = "controlplane-1.test"
-  node     = "127.0.0.1"
+  endpoint = "controlplane-1.test:50000"
+  node     = "controlplane-1"
 }]
 
 // A YAML string of worker config patches to apply
@@ -22,7 +24,6 @@ worker_config_patches = "\"machine\":\n  \"kubelet\":\n    \"extraMounts\":\n   
 
 // Machine config details for workers
 workers = [{
-  endpoint = "127.0.0.1:50001"
-  hostname = "worker-1.test"
-  node     = "127.0.0.1"
+  endpoint = "worker-1.test:50001"
+  node     = "worker-1"
 }]

--- a/terraform/cluster/talos/.terraform.lock.hcl
+++ b/terraform/cluster/talos/.terraform.lock.hcl
@@ -1,6 +1,28 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.96.0"
+  hashes = [
+    "h1:a/VEUu6BGQSPlUAzbN+zqaDCdi0QGh/VzBgo2gCran0=",
+    "zh:3f7e734abb9d647c851f5cb987837d7c073c9cbf1f520a031027d827f93d3b68",
+    "zh:5ca9400360a803a11cf432ca203be9f09da8fff9c96110a83c9029102b18c9d5",
+    "zh:5d421f475d467af182a527b7a61d50105dc63394316edf1c775ef736f84b941c",
+    "zh:68f2328e7f3e7666835d6815b39b46b08954a91204f82a6f648c928a0b09a744",
+    "zh:6a4170e7e2764df2968d1df65efebda55273dfc36dc6741207afb5e4b7e85448",
+    "zh:73f2a15bee21f7c92a071e2520216d0a40041aca52c0f6682e540da8ffcfada4",
+    "zh:9843d6973aedfd4cbaafd7110420d0c4c1d7ef4a2eeff508294c3adcc3613145",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9d1abd6be717c42f2a6257ee227d3e9548c31f01c976ed7b32b2745a63659a67",
+    "zh:a70d642e323021d54a92f0daa81d096cb5067cb99ce116047a42eb1cb1d579a0",
+    "zh:b9a2b293208d5a0449275fae463319e0998c841e0bcd4014594a49ba54bb70d6",
+    "zh:ce0b0eb7ac24ff58c20efcb526c3f792a95be3617c795b45bbeea9f302903ae7",
+    "zh:dbbf98b3cd8003833c472bdb89321c17a9bbdc1b785e7e3d75f8af924ee5a0e4",
+    "zh:df86cf9311a4be8bb4a251196650653f97e01fbf5fe72deecc8f28a35a5352ae",
+    "zh:f92992881afd9339f3e539fcd90cfc1e9ed1356b5e760bbcc804314c3cd6837f",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/local" {
   version = "2.5.2"
   hashes = [

--- a/windsor.yaml
+++ b/windsor.yaml
@@ -1,6 +1,7 @@
 version: v1alpha1
 contexts:
   local:
+    blueprint: full
     docker:
       enabled: true
       registries:
@@ -34,6 +35,7 @@ contexts:
       driver: docker-desktop
     cluster:
       enabled: true
+      platform: local
       driver: talos
       controlplanes:
         count: 1
@@ -53,5 +55,7 @@ contexts:
     network:
       cidr_block: 10.5.0.0/16
     dns:
-      enabled: false
+      enabled: true
       domain: test
+      forward:
+      - 10.5.0.1:8053


### PR DESCRIPTION
Re-enables the `windsor up` action in CI. Also leverages `--set dns.enabled=false` to disable DNS during CI.