### PR TITLE
Enable patching of private issuer configmap

### DIFF
--- a/kustomize/pki/resources/private-issuer/ca/rbac.yaml
+++ b/kustomize/pki/resources/private-issuer/ca/rbac.yaml
@@ -31,7 +31,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
-  verbs: ["get", "create", "update"]
+  verbs: ["get", "create", "update", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
Fixes this issue:

```
NAME              TYPE                DATA   AGE
private-ca-cert   kubernetes.io/tls   3      35d
Error from server (Forbidden): error when applying patch:
{"metadata":{"creationTimestamp":null}}
to:
Resource: "/v1, Resource=configmaps", GroupVersionKind: "/v1, Kind=ConfigMap"
Name: "private-ca-cert", Namespace: "system-pki-trust"
for: "STDIN": error when patching "STDIN": configmaps "private-ca-cert" is forbidden: User "system:serviceaccount:system-pki:copy-root-cert" cannot patch resource "configmaps" in API group "" in the namespace "system-pki-trust"
```
