### PR TITLE
Wait and run terraform tests in parallel

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -150,7 +150,7 @@ jobs:
       - name: Windsor Up
         run: |
           windsor init local --set dns.enabled=false
-          windsor up --install --verbose
+          windsor up --install --verbose --wait
 
       - name: Collect Windsor State
         if: always()

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -3,64 +3,67 @@ version: '3'
 tasks:
   scan:
     desc: Scan for security vulnerabilities
+    silent: true
     cmds:
-      - source .venv/bin/activate && checkov -d {{.CLI_ARGS | default "terraform/"}} 2>/dev/null
+      - cmd: source .venv/bin/activate && checkov -d {{.CLI_ARGS | default "terraform/"}} 2>/dev/null
 
   test:
     desc: Run Terraform tests (all or specific module)
+    silent: true
     cmds:
-      - |
-        MODULE={{.CLI_ARGS | default "terraform"}}
-        if [ -d "$MODULE" ]; then
-          # Create a temporary directory for test results
-          TEMP_DIR=$(mktemp -d)
-          # Find all test files and run them in parallel
-          find "$MODULE" -type f -name '*.tftest.hcl' | while read testfile; do
-            testdir=$(dirname "$testfile")
-            (
-              cd "$testdir" && \
-              terraform init -input=false -reconfigure && \
-              terraform test > "$TEMP_DIR/$(basename "$testfile").log" 2>&1 || \
-              echo "FAILED: $testfile" >> "$TEMP_DIR/failures"
-            ) &
-          done
-          # Wait for all background jobs to complete
-          wait
-          # Check if any tests failed
-          if [ -f "$TEMP_DIR/failures" ]; then
-            echo "Test failures:"
-            cat "$TEMP_DIR/failures"
-            echo "Test logs:"
-            find "$TEMP_DIR" -name "*.log" -type f -exec echo "=== {} ===" \; -exec cat {} \;
+      - cmd: |
+          MODULE={{.CLI_ARGS | default "terraform"}}
+          if [ -d "$MODULE" ]; then
+            # Create a temporary directory for test results
+            TEMP_DIR=$(mktemp -d)
+            # Find all test files and run them in parallel
+            find "$MODULE" -type f -name '*.tftest.hcl' | while read testfile; do
+              testdir=$(dirname "$testfile")
+              (
+                cd "$testdir" && \
+                echo "Running tests in $testdir..." && \
+                terraform init -input=false -reconfigure && \
+                terraform test || \
+                echo "FAILED: $testfile" >> "$TEMP_DIR/failures"
+              ) &
+            done
+            # Wait for all background jobs to complete
+            wait
+            # Check if any tests failed
+            if [ -f "$TEMP_DIR/failures" ]; then
+              echo "Test failures:"
+              cat "$TEMP_DIR/failures"
+              rm -rf "$TEMP_DIR"
+              exit 1
+            fi
             rm -rf "$TEMP_DIR"
+          else
+            echo "Module path '$MODULE' does not exist."
             exit 1
           fi
-          rm -rf "$TEMP_DIR"
-        else
-          echo "Module path '$MODULE' does not exist."
-          exit 1
-        fi
 
   fmt:
     desc: Check Terraform formatting
+    silent: true
     cmds:
-      - terraform fmt -recursive
+      - cmd: terraform fmt -recursive
 
   docs:
     desc: Generate Terraform documentation
+    silent: true
     cmds:
-      - rm -rf docs/terraform/*
-      - |
-        find terraform -type d -exec test -e '{}/main.tf' -a -e '{}/variables.tf' \; -print | while read -r dir; do
-          if [[ "$dir" == *"/modules/"* ]]; then
-            continue
-          fi
-          rel_path="${dir#terraform/}"
-          output_file="docs/terraform/$rel_path.md"
-          mkdir -p "$(dirname "$output_file")"
-          if [ -f "$dir/README.md" ]; then
-            cat "$dir/README.md" > "$output_file"
-            echo >> "$output_file"
-          fi
-          docker run --rm -v "$(pwd):/src" -w "/src/$dir" quay.io/terraform-docs/terraform-docs:0.20.0 markdown . >> "$output_file"
-        done
+      - cmd: rm -rf docs/terraform/*
+      - cmd: |
+          find terraform -type d -exec test -e '{}/main.tf' -a -e '{}/variables.tf' \; -print | while read -r dir; do
+            if [[ "$dir" == *"/modules/"* ]]; then
+              continue
+            fi
+            rel_path="${dir#terraform/}"
+            output_file="docs/terraform/$rel_path.md"
+            mkdir -p "$(dirname "$output_file")"
+            if [ -f "$dir/README.md" ]; then
+              cat "$dir/README.md" > "$output_file"
+              echo >> "$output_file"
+            fi
+            docker run --rm -v "$(pwd):/src" -w "/src/$dir" quay.io/terraform-docs/terraform-docs:0.20.0 markdown . >> "$output_file"
+          done

--- a/contexts/local/blueprint.yaml
+++ b/contexts/local/blueprint.yaml
@@ -14,39 +14,33 @@ sources:
   ref:
     branch: main
 terraform:
-- source: core
-  path: cluster/talos
-- source: core
-  path: gitops/flux
+- path: cluster/talos
+- path: gitops/flux
   destroy: false
 kustomize:
 - name: telemetry-base
   path: telemetry/base
-  source: core
   components:
   - prometheus
   - prometheus/flux
 - name: telemetry-resources
   path: telemetry/resources
-  source: core
   dependsOn:
   - telemetry-base
   components:
+  - metrics-server
   - prometheus
   - prometheus/flux
 - name: policy-base
   path: policy/base
-  source: core
   components:
   - kyverno
 - name: policy-resources
   path: policy/resources
-  source: core
   dependsOn:
   - policy-base
 - name: csi
   path: csi
-  source: core
   dependsOn:
   - policy-resources
   force: true
@@ -55,7 +49,6 @@ kustomize:
   - openebs/dynamic-localpv
 - name: ingress-base
   path: ingress/base
-  source: core
   dependsOn:
   - pki-resources
   force: true
@@ -67,7 +60,6 @@ kustomize:
   - nginx/web
 - name: pki-base
   path: pki/base
-  source: core
   dependsOn:
   - policy-resources
   force: true
@@ -76,7 +68,6 @@ kustomize:
   - trust-manager
 - name: pki-resources
   path: pki/resources
-  source: core
   dependsOn:
   - pki-base
   force: true
@@ -85,7 +76,6 @@ kustomize:
   - public-issuer/selfsigned
 - name: dns
   path: dns
-  source: core
   dependsOn:
   - pki-base
   force: true
@@ -98,7 +88,6 @@ kustomize:
   - external-dns/ingress
 - name: gitops
   path: gitops/flux
-  source: core
   dependsOn:
   - ingress-base
   force: true

--- a/contexts/local/terraform/cluster/talos.tfvars
+++ b/contexts/local/terraform/cluster/talos.tfvars
@@ -32,10 +32,15 @@ common_config_patches = <<EOF
     "certSANs":
     - "localhost"
     - "127.0.0.1"
+  "extraManifests":
+  - "https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml"
 "machine":
   "certSANs":
   - "localhost"
   - "127.0.0.1"
+  "kubelet":
+    "extraArgs":
+      "rotate-server-certificates": "true"
   "network":
     "interfaces":
     - "ignore": true
@@ -78,4 +83,3 @@ worker_config_patches = <<EOF
       "source": "/var/local"
       "type": "bind"
 EOF
-

--- a/docs/terraform/cluster/talos.md
+++ b/docs/terraform/cluster/talos.md
@@ -9,7 +9,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_local"></a> [local](#provider\_local) | 2.5.2 |
+| <a name="provider_local"></a> [local](#provider\_local) | 2.5.3 |
 | <a name="provider_null"></a> [null](#provider\_null) | 3.2.4 |
 | <a name="provider_talos"></a> [talos](#provider\_talos) | 0.8.1 |
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -4,6 +4,11 @@ pre-commit:
     terraform-fmt:
       glob: "*.{tf,tfvars}"
       run: terraform fmt {staged_files}
+      stage_fixed: true
+    terraform-docs:
+      glob: "*.{tf,tfvars}"
+      run: task docs
+      stage_fixed: true
 
 pre-push:
   parallel: true
@@ -11,6 +16,3 @@ pre-push:
     terraform-test:
       glob: "*.{tf,tfvars}"
       run: task test
-    terraform-docs:
-      glob: "*.{tf,tfvars}"
-      run: task docs

--- a/terraform/cluster/talos/.terraform.lock.hcl
+++ b/terraform/cluster/talos/.terraform.lock.hcl
@@ -2,22 +2,21 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/local" {
-  version = "2.5.2"
+  version = "2.5.3"
   hashes = [
-    "h1:6XyefmvbkprppmYbGmMcQW5NB4w6C363SSShzuhF4R0=",
-    "h1:IyFbOIO6mhikFNL/2h1iZJ6kyN3U00jgkpCLUCThAfE=",
-    "zh:136299545178ce281c56f36965bf91c35407c11897f7082b3b983d86cb79b511",
-    "zh:3b4486858aa9cb8163378722b642c57c529b6c64bfbfc9461d940a84cd66ebea",
-    "zh:4855ee628ead847741aa4f4fc9bed50cfdbf197f2912775dd9fe7bc43fa077c0",
-    "zh:4b8cd2583d1edcac4011caafe8afb7a95e8110a607a1d5fb87d921178074a69b",
-    "zh:52084ddaff8c8cd3f9e7bcb7ce4dc1eab00602912c96da43c29b4762dc376038",
-    "zh:71562d330d3f92d79b2952ffdda0dad167e952e46200c767dd30c6af8d7c0ed3",
+    "h1:MCzg+hs1/ZQ32u56VzJMWP9ONRQPAAqAjuHuzbyshvI=",
+    "zh:284d4b5b572eacd456e605e94372f740f6de27b71b4e1fd49b63745d8ecd4927",
+    "zh:40d9dfc9c549e406b5aab73c023aa485633c1b6b730c933d7bcc2fa67fd1ae6e",
+    "zh:6243509bb208656eb9dc17d3c525c89acdd27f08def427a0dce22d5db90a4c8b",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:805f81ade06ff68fa8b908d31892eaed5c180ae031c77ad35f82cb7a74b97cf4",
-    "zh:8b6b3ebeaaa8e38dd04e56996abe80db9be6f4c1df75ac3cccc77642899bd464",
-    "zh:ad07750576b99248037b897de71113cc19b1a8d0bc235eb99173cc83d0de3b1b",
-    "zh:b9f1c3bfadb74068f5c205292badb0661e17ac05eb23bfe8bd809691e4583d0e",
-    "zh:cc4cbcd67414fefb111c1bf7ab0bc4beb8c0b553d01719ad17de9a047adff4d1",
+    "zh:885d85869f927853b6fe330e235cd03c337ac3b933b0d9ae827ec32fa1fdcdbf",
+    "zh:bab66af51039bdfcccf85b25fe562cbba2f54f6b3812202f4873ade834ec201d",
+    "zh:c505ff1bf9442a889ac7dca3ac05a8ee6f852e0118dd9a61796a2f6ff4837f09",
+    "zh:d36c0b5770841ddb6eaf0499ba3de48e5d4fc99f4829b6ab66b0fab59b1aaf4f",
+    "zh:ddb6a407c7f3ec63efb4dad5f948b54f7f4434ee1a2607a49680d494b1776fe1",
+    "zh:e0dafdd4500bec23d3ff221e3a9b60621c5273e5df867bc59ef6b7e41f5c91f6",
+    "zh:ece8742fd2882a8fc9d6efd20e2590010d43db386b920b2a9c220cfecc18de47",
+    "zh:f4c6b3eb8f39105004cf720e202f04f57e3578441cfb76ca27611139bc116a82",
   ]
 }
 


### PR DESCRIPTION
Runs terraform tests in parallel, so that you can see all failures at once. And it makes it a little faster. This was important as we also enabled the `--wait` flag, so that we validate that all kustomizations have run successfully.