### PR TITLE
Fixes field is immutable issue when copying ca cert configmap

### DIFF
--- a/kustomize/pki/resources/private-issuer/ca/copy-root-cert-job.yaml
+++ b/kustomize/pki/resources/private-issuer/ca/copy-root-cert-job.yaml
@@ -22,7 +22,9 @@ spec:
             while [ $i -le 10 ]; do
               if kubectl get secret private-ca-cert -n system-pki; then
                 kubectl get secret private-ca-cert -n system-pki -o jsonpath='{.data.ca\.crt}' | base64 --decode > /mnt/ca.crt;
-                kubectl create configmap private-ca-cert --from-file=ca.crt=/mnt/ca.crt -n system-pki-trust --dry-run=client -o yaml | kubectl apply -f -;
+                if ! kubectl get configmap private-ca-cert -n system-pki-trust >/dev/null 2>&1; then
+                  kubectl create configmap private-ca-cert --from-file=ca.crt=/mnt/ca.crt -n system-pki-trust --dry-run=client -o yaml | kubectl apply -f -;
+                fi;
                 break;
               else
                 echo "waiting for secret";


### PR DESCRIPTION
Issue:
```
system-gitops   pki-resources         21h     False   Job/system-pki/copy-root-cert-job dry-run failed (Invalid): Job.batch "copy-root-cert-job" is invalid: spec.template: Invalid value: core.PodTemplateSpec{ObjectMeta:v1.ObjectMeta{Name:"", GenerateName:"", Namespace:"", SelfLink:"", UID:"", ResourceVersion:"", Generation:0, CreationTimestamp:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), DeletionTimestamp:<nil>, DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string{"batch.kubernetes.io/controller-uid":"8c1e48ff-a35f-4085-9995-72b8c0896973", "batch.kubernetes.io/job-name":"copy-root-cert-job", "controller-uid":"8c1e48ff-a35f-4085-9995-72b8c0896973", "job-name":"copy-root-cert-job"}, Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ManagedFields:[]v1.ManagedFieldsEntry(nil)}, Spec:core.PodSpec{Volumes:[]core.Volume{core.Volume{Name:"cert-volume", VolumeSource:core.VolumeSource{HostPath:(*core.HostPathVolumeSource)(nil), EmptyDir:(*core.EmptyDirVolumeSource)(0xc015ed7878), GCEPersistentDisk:(*core.GCEPersistentDiskVolumeSource)(nil), AWSElasticBlockStore:(*core.AWSElasticBlockStoreVolumeSource)(nil), GitRepo:(*core.GitRepoVolumeSource)(nil), Secret:(*core.SecretVolumeSource)(nil), NFS:(*core.NFSVolumeSource)(nil), ISCSI:(*core.ISCSIVolumeSource)(nil), Glusterfs:(*core.GlusterfsVolumeSource)(nil), PersistentVolumeClaim:(*core.PersistentVolumeClaimVolumeSource)(nil), RBD:(*core.RBDVolumeSource)(nil), Quobyte:(*core.QuobyteVolumeSource)(nil), FlexVolume:(*core.FlexVolumeSource)(nil), Cinder:(*core.CinderVolumeSource)(nil), CephFS:(*core.CephFSVolumeSource)(nil), Flocker:(*core.FlockerVolumeSource)(nil), DownwardAPI:(*core.DownwardAPIVolumeSource)(nil), FC:(*core.FCVolumeSource)(nil), AzureFile:(*core.AzureFileVolumeSource)(nil), ConfigMap:(*core.ConfigMapVolumeSource)(nil), VsphereVolume:(*core.VsphereVirtualDiskVolumeSource)(nil), AzureDisk:(*core.AzureDiskVolumeSource)(nil), PhotonPersistentDisk:(*core.PhotonPersistentDiskVolumeSource)(nil), Projected:(*core.ProjectedVolumeSource)(nil), PortworxVolume:(*core.PortworxVolumeSource)(nil), ScaleIO:(*core.ScaleIOVolumeSource)(nil), StorageOS:(*core.StorageOSVolumeSource)(nil), CSI:(*core.CSIVolumeSource)(nil), Ephemeral:(*core.EphemeralVolumeSource)(nil), Image:(*core.ImageVolumeSource)(nil)}}}, InitContainers:[]core.Container(nil), Containers:[]core.Container{core.Container{Name:"copy-root-cert", Image:"bitnami/kubectl:1.33.1", Command:[]string{"/bin/sh", "-c", "set -e\n\ni=1\nwhile [ $i -le 10 ]; do\n  if kubectl get secret private-ca-cert -n system-pki; then\n    kubectl get secret private-ca-cert -n system-pki -o jsonpath='{.data.ca\\.crt}' | base64 --decode > /mnt/ca.crt;\n    kubectl create configmap private-ca-cert --from-file=ca.crt=/mnt/ca.crt -n system-pki-trust --dry-run=client -o yaml | kubectl apply -f -;\n    break;\n  else\n    echo \"waiting for secret\";\n    sleep 6;\n  fi;\n  i=$((i + 1))\n  if [ $i -gt 10 ]; then\n    echo \"Failed to retrieve secret after 10 attempts\" >&2;\n    exit 1;\n  fi;\ndone;\n"}, Args:[]string(nil), WorkingDir:"", Ports:[]core.ContainerPort(nil), EnvFrom:[]core.EnvFromSource(nil), Env:[]core.EnvVar(nil), Resources:core.ResourceRequirements{Limits:core.ResourceList(nil), Requests:core.ResourceList(nil), Claims:[]core.ResourceClaim(nil)}, ResizePolicy:[]core.ContainerResizePolicy(nil), RestartPolicy:(*core.ContainerRestartPolicy)(nil), VolumeMounts:[]core.VolumeMount{core.VolumeMount{Name:"cert-volume", ReadOnly:false, RecursiveReadOnly:(*core.RecursiveReadOnlyMode)(nil), MountPath:"/mnt", SubPath:"", MountPropagation:(*core.MountPropagationMode)(nil), SubPathExpr:""}}, VolumeDevices:[]core.VolumeDevice(nil), LivenessProbe:(*core.Probe)(nil), ReadinessProbe:(*core.Probe)(nil), StartupProbe:(*core.Probe)(nil), Lifecycle:(*core.Lifecycle)(nil), TerminationMessagePath:"/dev/termination-log", TerminationMessagePolicy:"File", ImagePullPolicy:"IfNotPresent", SecurityContext:(*core.SecurityContext)(nil), Stdin:false, StdinOnce:false, TTY:false}}, EphemeralContainers:[]core.EphemeralContainer(nil), RestartPolicy:"OnFailure", TerminationGracePeriodSeconds:(*int64)(0xc01e9cf258), ActiveDeadlineSeconds:(*int64)(nil), DNSPolicy:"ClusterFirst", NodeSelector:map[string]string(nil), ServiceAccountName:"copy-root-cert", AutomountServiceAccountToken:(*bool)(nil), NodeName:"", SecurityContext:(*core.PodSecurityContext)(0xc01e3c4960), ImagePullSecrets:[]core.LocalObjectReference(nil), Hostname:"", Subdomain:"", SetHostnameAsFQDN:(*bool)(nil), Affinity:(*core.Affinity)(nil), SchedulerName:"default-scheduler", Tolerations:[]core.Toleration(nil), HostAliases:[]core.HostAlias(nil), PriorityClassName:"", Priority:(*int32)(nil), PreemptionPolicy:(*core.PreemptionPolicy)(nil), DNSConfig:(*core.PodDNSConfig)(nil), ReadinessGates:[]core.PodReadinessGate(nil), RuntimeClassName:(*string)(nil), Overhead:core.ResourceList(nil), EnableServiceLinks:(*bool)(nil), TopologySpreadConstraints:[]core.TopologySpreadConstraint(nil), OS:(*core.PodOS)(nil), SchedulingGates:[]core.PodSchedulingGate(nil), ResourceClaims:[]core.PodResourceClaim(nil), Resources:(*core.ResourceRequirements)(nil)}}: field is immutable...
```