### PR TITLE
refactor(aks): simplify identity management with optional user-assigned identities

### DIFF
--- a/docs/terraform/cluster/azure-aks.md
+++ b/docs/terraform/cluster/azure-aks.md
@@ -57,7 +57,6 @@ No modules.
 | [azurerm_role_assignment.azurerm_disk_encryption_set_key_vault_access](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.control_plane_managed_identity_operator_on_kubelet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.des_reader](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
-| [azurerm_user_assigned_identity.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
 | [local_file.kube_config](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [random_string.key](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [time_static.expiry](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/static) | resource |

--- a/docs/terraform/cluster/azure-aks.md
+++ b/docs/terraform/cluster/azure-aks.md
@@ -52,11 +52,6 @@ No modules.
 | [azurerm_kubernetes_cluster_node_pool.autoscaled](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster_node_pool) | resource |
 | [azurerm_log_analytics_workspace.aks_logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_resource_group.aks](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
-| [azurerm_role_assignment.aks_network_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.aks_vmss_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.azurerm_disk_encryption_set_key_vault_access](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.control_plane_managed_identity_operator_on_kubelet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.des_reader](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [local_file.kube_config](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [random_string.key](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [time_static.expiry](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/static) | resource |
@@ -67,7 +62,6 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_additional_cluster_identity_ids"></a> [additional\_cluster\_identity\_ids](#input\_additional\_cluster\_identity\_ids) | Additional user assigned identity IDs for the AKS cluster | `list(string)` | `[]` | no |
 | <a name="input_auto_scaler_profile"></a> [auto\_scaler\_profile](#input\_auto\_scaler\_profile) | Configuration for the AKS cluster's auto-scaler | <pre>object({<br/>    balance_similar_node_groups      = bool<br/>    max_graceful_termination_sec     = number<br/>    scale_down_delay_after_add       = string<br/>    scale_down_delay_after_delete    = string<br/>    scale_down_delay_after_failure   = string<br/>    scan_interval                    = string<br/>    scale_down_unneeded              = string<br/>    scale_down_unready               = string<br/>    scale_down_utilization_threshold = string<br/>  })</pre> | <pre>{<br/>  "balance_similar_node_groups": true,<br/>  "max_graceful_termination_sec": 600,<br/>  "scale_down_delay_after_add": "10m",<br/>  "scale_down_delay_after_delete": "10s",<br/>  "scale_down_delay_after_failure": "3m",<br/>  "scale_down_unneeded": "10m",<br/>  "scale_down_unready": "20m",<br/>  "scale_down_utilization_threshold": "0.5",<br/>  "scan_interval": "10s"<br/>}</pre> | no |
 | <a name="input_automatic_upgrade_channel"></a> [automatic\_upgrade\_channel](#input\_automatic\_upgrade\_channel) | The automatic upgrade channel for the AKS cluster | `string` | `"stable"` | no |
 | <a name="input_autoscaled_node_pool"></a> [autoscaled\_node\_pool](#input\_autoscaled\_node\_pool) | Configuration for the autoscaled node pool | <pre>object({<br/>    enabled                 = bool<br/>    name                    = string<br/>    vm_size                 = string<br/>    mode                    = string<br/>    os_disk_type            = string<br/>    max_pods                = number<br/>    host_encryption_enabled = bool<br/>    min_count               = number<br/>    max_count               = number<br/>  })</pre> | <pre>{<br/>  "enabled": true,<br/>  "host_encryption_enabled": true,<br/>  "max_count": 3,<br/>  "max_pods": 110,<br/>  "min_count": 1,<br/>  "mode": "User",<br/>  "name": "autoscaled",<br/>  "os_disk_type": "Managed",<br/>  "vm_size": "Standard_D2s_v3"<br/>}</pre> | no |
@@ -79,6 +73,9 @@ No modules.
 | <a name="input_dns_service_ip"></a> [dns\_service\_ip](#input\_dns\_service\_ip) | IP address for Kubernetes DNS service | `string` | `"10.96.0.10"` | no |
 | <a name="input_endpoint_private_access"></a> [endpoint\_private\_access](#input\_endpoint\_private\_access) | Whether to enable private access to the Kubernetes API server | `bool` | `false` | no |
 | <a name="input_expiration_date"></a> [expiration\_date](#input\_expiration\_date) | The expiration date for the AKS cluster's key vault | `string` | `null` | no |
+| <a name="input_kubelet_client_id"></a> [kubelet\_client\_id](#input\_kubelet\_client\_id) | Client ID of the user-assigned identity to use for the kubelet. If not provided, the cluster will use the system-assigned identity. | `string` | `null` | no |
+| <a name="input_kubelet_object_id"></a> [kubelet\_object\_id](#input\_kubelet\_object\_id) | Object ID of the user-assigned identity to use for the kubelet. If not provided, the cluster will use the system-assigned identity. | `string` | `null` | no |
+| <a name="input_kubelet_user_assigned_identity_id"></a> [kubelet\_user\_assigned\_identity\_id](#input\_kubelet\_user\_assigned\_identity\_id) | Resource ID of the user-assigned identity to use for the kubelet. If not provided, the cluster will use the system-assigned identity. | `string` | `null` | no |
 | <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Version of Kubernetes to use | `string` | `"1.32"` | no |
 | <a name="input_local_account_disabled"></a> [local\_account\_disabled](#input\_local\_account\_disabled) | Whether to disable local accounts for the AKS cluster | `bool` | `false` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the resource | `string` | `"cluster"` | no |
@@ -92,6 +89,7 @@ No modules.
 | <a name="input_sku_tier"></a> [sku\_tier](#input\_sku\_tier) | The SKU tier for the AKS cluster | `string` | `"Standard"` | no |
 | <a name="input_soft_delete_retention_days"></a> [soft\_delete\_retention\_days](#input\_soft\_delete\_retention\_days) | The number of days to retain the AKS cluster's key vault | `number` | `7` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to the resources | `map(string)` | `{}` | no |
+| <a name="input_user_assigned_identity_ids"></a> [user\_assigned\_identity\_ids](#input\_user\_assigned\_identity\_ids) | User assigned identity IDs for the AKS cluster. If provided, the cluster will use only user-assigned identities. | `list(string)` | `[]` | no |
 | <a name="input_vnet_module_name"></a> [vnet\_module\_name](#input\_vnet\_module\_name) | Name on the VNET module | `string` | `"network"` | no |
 | <a name="input_vnet_subnet_id"></a> [vnet\_subnet\_id](#input\_vnet\_subnet\_id) | ID of the subnet | `string` | `null` | no |
 | <a name="input_workload_autoscaler_profile"></a> [workload\_autoscaler\_profile](#input\_workload\_autoscaler\_profile) | Configuration for the AKS cluster's workload autoscaler | <pre>object({<br/>    keda_enabled                    = bool<br/>    vertical_pod_autoscaler_enabled = bool<br/>  })</pre> | <pre>{<br/>  "keda_enabled": false,<br/>  "vertical_pod_autoscaler_enabled": false<br/>}</pre> | no |

--- a/terraform/cluster/azure-aks/variables.tf
+++ b/terraform/cluster/azure-aks/variables.tf
@@ -199,9 +199,9 @@ variable "expiration_date" {
   default     = null
 }
 
-variable "additional_cluster_identity_ids" {
+variable "user_assigned_identity_ids" {
   type        = list(string)
-  description = "Additional user assigned identity IDs for the AKS cluster"
+  description = "User assigned identity IDs for the AKS cluster. If provided, the cluster will use only user-assigned identities."
   default     = []
 }
 
@@ -233,4 +233,22 @@ variable "endpoint_private_access" {
   description = "Whether to enable private access to the Kubernetes API server"
   type        = bool
   default     = false
+}
+
+variable "kubelet_client_id" {
+  description = "Client ID of the user-assigned identity to use for the kubelet. If not provided, the cluster will use the system-assigned identity."
+  type        = string
+  default     = null
+}
+
+variable "kubelet_object_id" {
+  description = "Object ID of the user-assigned identity to use for the kubelet. If not provided, the cluster will use the system-assigned identity."
+  type        = string
+  default     = null
+}
+
+variable "kubelet_user_assigned_identity_id" {
+  description = "Resource ID of the user-assigned identity to use for the kubelet. If not provided, the cluster will use the system-assigned identity."
+  type        = string
+  default     = null
 }


### PR DESCRIPTION
Simplifies AKS identity management by:
- Making user-assigned identities optional (defaults to system-assigned)
- Supporting external kubelet identity configuration
- Removing automatic role assignments
- Adding test coverage for both identity types