### PR TITLE
feat(cert-manager): add startup probe with optimized settings for webhook stability

### DIFF
--- a/kustomize/pki/base/cert-manager/helm-release.yaml
+++ b/kustomize/pki/base/cert-manager/helm-release.yaml
@@ -19,3 +19,10 @@ spec:
   values:
     crds:
       enabled: true
+    webhook:
+      startupProbe:
+        enabled: true
+        initialDelaySeconds: 10
+        periodSeconds: 5
+        timeoutSeconds: 1
+        failureThreshold: 12


### PR DESCRIPTION
Adds a startup probe to cert-manager webhook with optimized timing to improve stability during pod initialization. The probe helps prevent premature readiness checks while minimizing total startup time.
