### PR TITLE
Use --reset with windsor init

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -149,7 +149,7 @@ jobs:
 
       - name: Windsor Up
         run: |
-          windsor init local --set dns.enabled=false
+          windsor init local --set dns.enabled=false --reset
           windsor up --install --verbose --wait
 
       - name: Collect Windsor State


### PR DESCRIPTION
Now that we don't overwrite `windsor.yaml`, tests fail as DNS is enabled, which conflicts with the hosted github actions environment. By passing the `--reset` flag it ensures the file is written appropriately.