### PR TITLE
fix(coredns): Prevent loop when forwarding to self-hosted dns

### DIFF
--- a/kustomize/dns/coredns/etcd/patches/helm-release.yaml
+++ b/kustomize/dns/coredns/etcd/patches/helm-release.yaml
@@ -25,7 +25,7 @@ spec:
               tls /etc/coredns/tls/tls.crt /etc/coredns/tls/tls.key /etc/coredns/tls/ca.crt
               fallthrough
           - name: forward
-            parameters: . /etc/resolv.conf
+            parameters: . 1.1.1.1 8.8.8.8
           - name: loop
           - name: reload
           - name: prometheus


### PR DESCRIPTION
When we forward from local to the self-hosted coredns service running in the cluster, we were seeing DNS loop errors. This was caused by forwarding to `resolve.conf` which is not appropriate for this service.