### PR TITLE
ci(publish): Publish "latest" tag from main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -186,7 +186,7 @@ jobs:
   publish:
     name: Publish OCI Package
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -207,5 +207,12 @@ jobs:
       - name: Publish to OCI Registry
         env:
           TAG: ${{ github.ref_name }}
+        run: |
+          windsor push oci://ghcr.io/windsorcli/core:${TAG}
+
+      - name: Publish Latest Tag
+        if: github.ref == 'refs/heads/main'
+        env:
+          TAG: latest
         run: |
           windsor push oci://ghcr.io/windsorcli/core:${TAG}


### PR DESCRIPTION
The main branch will now always publish an OCI artifact tagged with `latest`.