### PR TITLE
fix(template): Exclude backend from default config

### DIFF
--- a/contexts/_template/blueprint.jsonnet
+++ b/contexts/_template/blueprint.jsonnet
@@ -18,9 +18,6 @@ local repositoryConfig = {
 local terraformConfigs = {
   "aws": [
     {
-      path: "backend/s3",
-    },
-    {
       path: "network/aws-vpc",
     },
     {
@@ -36,9 +33,6 @@ local terraformConfigs = {
     }
   ],
   "azure": [
-    {
-      path: "backend/azurerm",
-    },
     {
       path: "network/azure-vnet",
     },


### PR DESCRIPTION
We shouldn't assume a terraform backend in the blueprint itself. We'll determine this through other means. This breaks automatic rollout as we don't yet support true bootstrapping. So, a generated `backend.tfvars` file caused failures for aws and azure.