### PR TITLE
feat(csi): Set a default storage class on AWS

### DIFF
--- a/contexts/_template/blueprint.jsonnet
+++ b/contexts/_template/blueprint.jsonnet
@@ -202,7 +202,8 @@ local repositoryUrl = if rawProvider == "local" then "http://git.test/git/" + hl
     {
       name: "csi",
       path: "csi",
-      cleanup: ["pvcs"]
+      cleanup: ["pvcs"],
+      components: ["aws-ebs"]
     }
   ] else if provider == "local" then [
     {

--- a/kustomize/csi/aws-ebs/default-storageclass.yaml
+++ b/kustomize/csi/aws-ebs/default-storageclass.yaml
@@ -1,0 +1,13 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: single
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: ebs.csi.aws.com
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  type: gp3
+  encrypted: "true"
+  fsType: ext4
+reclaimPolicy: Delete

--- a/kustomize/csi/aws-ebs/kustomization.yaml
+++ b/kustomize/csi/aws-ebs/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - default-storage-class.yaml


### PR DESCRIPTION
Many resources depend on a block storage device available as the default. This ensures such a device is created for AWS setups.