### PR TITLE
fix(template): Template gitops dev credentials correctly

### DIFF
--- a/contexts/_template/blueprint.jsonnet
+++ b/contexts/_template/blueprint.jsonnet
@@ -70,11 +70,6 @@ local concat(arrays) = std.foldl(function(x, y) x + y, arrays, []);
     {
       path: "gitops/flux",
       destroy: false,
-      values: if rawProvider == "local" then {
-        git_username: "local",
-        git_password: "local",
-        webhook_token: "abcdef123456",
-      } else {},
     },
   ],
   kustomize:

--- a/contexts/_template/terraform/gitops/flux.jsonnet
+++ b/contexts/_template/terraform/gitops/flux.jsonnet
@@ -1,0 +1,13 @@
+local context = std.extVar("context");
+local hlp = std.extVar("helpers");
+
+local gitUsername = hlp.getString(context, "git.livereload.username", null);
+local gitPassword = hlp.getString(context, "git.livereload.password", null);
+local webhook_token = if hlp.has(context, "git.livereload") then "abcdef123456" else null;
+
+local result = {};
+
+result +
+  (if gitUsername != null then { git_username: gitUsername } else {}) +
+  (if gitPassword != null then { git_password: gitPassword } else {}) +
+  (if webhook_token != null then { webhook_token: webhook_token } else {})


### PR DESCRIPTION
Templating blueprint values directly in the blueprint.jsonnet is no longer supported. These have been moved to an individual `flux.jsonnet`.