### PR TITLE
Pin windsor action to v0.7.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -140,9 +140,9 @@ jobs:
         run: mkdir -p support-bundles
 
       - name: Install Windsor CLI
-        uses: windsorcli/action@main
+        uses: windsorcli/action@v0.5.0
         with:
-          ref: main
+          ref: v0.7.1
           context: local
 
       - name: Create .docker-cache directory


### PR DESCRIPTION
Pins the windsor cli to v0.7.1. This unblocks CI tests that are breaking due to upstream CLI incompatibilities.

Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>