### PR TITLE
fix(kustomize): Revert to use capitalized ENV values for post-build substitutions

### DIFF
--- a/kustomize/csi/openebs/dynamic-localpv/storageclass.yaml
+++ b/kustomize/csi/openebs/dynamic-localpv/storageclass.yaml
@@ -9,7 +9,7 @@ metadata:
       - name: StorageType
         value: hostpath
       - name: BasePath
-        value: ${local_volume_path:-/var/local}
+        value: ${LOCAL_VOLUME_PATH:-/var/local}
 provisioner: openebs.io/local
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
@@ -25,7 +25,7 @@ metadata:
       - name: StorageType
         value: hostpath
       - name: BasePath
-        value: ${local_volume_path:-/var/local}
+        value: ${LOCAL_VOLUME_PATH:-/var/local}
 provisioner: openebs.io/local
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer

--- a/kustomize/demo/bookinfo/ingress/ingress.yaml
+++ b/kustomize/demo/bookinfo/ingress/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo-bookinfo
 spec:
   rules:
-  - host: bookinfo.${external_domain:-test}
+  - host: bookinfo.${DOMAIN:-test}
     http:
       paths:
       - path: /

--- a/kustomize/demo/static/ingress/ingress.yaml
+++ b/kustomize/demo/static/ingress/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo-static
 spec:
   rules:
-  - host: static.${external_domain:-test}
+  - host: static.${DOMAIN:-test}
     http:
       paths:
       - path: /

--- a/kustomize/dns/coredns/etcd/certificates.yaml
+++ b/kustomize/dns/coredns/etcd/certificates.yaml
@@ -11,10 +11,10 @@ spec:
     kind: ClusterIssuer
   commonName: etcd-peer
   dnsNames:
-    - "etcd.system-dns.svc.${DOMAIN:-cluster.local}"
-    - "*.etcd.system-dns.svc.${DOMAIN:-cluster.local}"
-    - "etcd-headless.system-dns.svc.${DOMAIN:-cluster.local}"
-    - "*.etcd-headless.system-dns.svc.${DOMAIN:-cluster.local}"
+    - "etcd.system-dns.svc.cluster.local"
+    - "*.etcd.system-dns.svc.cluster.local"
+    - "etcd-headless.system-dns.svc.cluster.local"
+    - "*.etcd-headless.system-dns.svc.cluster.local"
   usages:
     - digital signature
     - key encipherment
@@ -33,10 +33,10 @@ spec:
     kind: ClusterIssuer
   commonName: etcd
   dnsNames:
-    - "etcd.system-dns.svc.${DOMAIN:-cluster.local}"
-    - "*.etcd.system-dns.svc.${DOMAIN:-cluster.local}"
-    - "etcd-headless.system-dns.svc.${DOMAIN:-cluster.local}"
-    - "*.etcd-headless.system-dns.svc.${DOMAIN:-cluster.local}"
+    - "etcd.system-dns.svc.cluster.local"
+    - "*.etcd.system-dns.svc.cluster.local"
+    - "etcd-headless.system-dns.svc.cluster.local"
+    - "*.etcd-headless.system-dns.svc.cluster.local"
   usages:
     - server auth
     - client auth

--- a/kustomize/dns/coredns/etcd/certificates.yaml
+++ b/kustomize/dns/coredns/etcd/certificates.yaml
@@ -11,10 +11,10 @@ spec:
     kind: ClusterIssuer
   commonName: etcd-peer
   dnsNames:
-    - "etcd.system-dns.svc.${CLUSTER_DOMAIN:-cluster.local}"
-    - "*.etcd.system-dns.svc.${CLUSTER_DOMAIN:-cluster.local}"
-    - "etcd-headless.system-dns.svc.${CLUSTER_DOMAIN:-cluster.local}"
-    - "*.etcd-headless.system-dns.svc.${CLUSTER_DOMAIN:-cluster.local}"
+    - "etcd.system-dns.svc.${DOMAIN:-cluster.local}"
+    - "*.etcd.system-dns.svc.${DOMAIN:-cluster.local}"
+    - "etcd-headless.system-dns.svc.${DOMAIN:-cluster.local}"
+    - "*.etcd-headless.system-dns.svc.${DOMAIN:-cluster.local}"
   usages:
     - digital signature
     - key encipherment
@@ -33,10 +33,10 @@ spec:
     kind: ClusterIssuer
   commonName: etcd
   dnsNames:
-    - "etcd.system-dns.svc.${CLUSTER_DOMAIN:-cluster.local}"
-    - "*.etcd.system-dns.svc.${CLUSTER_DOMAIN:-cluster.local}"
-    - "etcd-headless.system-dns.svc.${CLUSTER_DOMAIN:-cluster.local}"
-    - "*.etcd-headless.system-dns.svc.${CLUSTER_DOMAIN:-cluster.local}"
+    - "etcd.system-dns.svc.${DOMAIN:-cluster.local}"
+    - "*.etcd.system-dns.svc.${DOMAIN:-cluster.local}"
+    - "etcd-headless.system-dns.svc.${DOMAIN:-cluster.local}"
+    - "*.etcd-headless.system-dns.svc.${DOMAIN:-cluster.local}"
   usages:
     - server auth
     - client auth

--- a/kustomize/dns/external-dns/coredns/patches/helm-release.yaml
+++ b/kustomize/dns/external-dns/coredns/patches/helm-release.yaml
@@ -6,7 +6,7 @@
   path: /spec/values/env/-
   value:
     name: ETCD_URLS
-    value: https://etcd.system-dns.svc.${DOMAIN:-cluster.local}:2379
+    value: https://etcd.system-dns.svc.cluster.local:2379
 - op: add
   path: /spec/values/env/-
   value:
@@ -26,7 +26,7 @@
   path: /spec/values/env/-
   value:
     name: ETCD_TLS_SERVER_NAME
-    value: etcd.system-dns.svc.${DOMAIN:-cluster.local}
+    value: etcd.system-dns.svc.cluster.local
 - op: add
   path: /spec/values/extraVolumes/-
   value:

--- a/kustomize/dns/external-dns/coredns/patches/helm-release.yaml
+++ b/kustomize/dns/external-dns/coredns/patches/helm-release.yaml
@@ -6,7 +6,7 @@
   path: /spec/values/env/-
   value:
     name: ETCD_URLS
-    value: https://etcd.system-dns.svc.${CLUSTER_DOMAIN:-cluster.local}:2379
+    value: https://etcd.system-dns.svc.${DOMAIN:-cluster.local}:2379
 - op: add
   path: /spec/values/env/-
   value:
@@ -26,7 +26,7 @@
   path: /spec/values/env/-
   value:
     name: ETCD_TLS_SERVER_NAME
-    value: etcd.system-dns.svc.${CLUSTER_DOMAIN:-cluster.local}
+    value: etcd.system-dns.svc.${DOMAIN:-cluster.local}
 - op: add
   path: /spec/values/extraVolumes/-
   value:

--- a/kustomize/dns/external-dns/helm-release.yaml
+++ b/kustomize/dns/external-dns/helm-release.yaml
@@ -23,4 +23,4 @@ spec:
     extraVolumeMounts: []
     sources: []
     domainFilters:
-      - "${external_domain:-test}"
+      - "${DOMAIN:-test}"

--- a/kustomize/dns/external-dns/route53/patches/helm-release.yaml
+++ b/kustomize/dns/external-dns/route53/patches/helm-release.yaml
@@ -24,7 +24,7 @@ spec:
     policy: sync
     registry: txt
     domainFilters:
-      - ${external_domain:-test}
+      - ${DOMAIN:-test}
     serviceAccount:
       create: true
       name: external-dns

--- a/kustomize/ingress/nginx/loadbalancer/patches/helm-release.yaml
+++ b/kustomize/ingress/nginx/loadbalancer/patches/helm-release.yaml
@@ -9,4 +9,4 @@ spec:
     controller:
       service:
         type: LoadBalancer
-        loadBalancerIP: ${loadbalancer_ip}
+        loadBalancerIP: ${LOADBALANCER_IP_START}

--- a/kustomize/observability/elasticsearch/certificates.yaml
+++ b/kustomize/observability/elasticsearch/certificates.yaml
@@ -14,13 +14,13 @@ spec:
     - "elasticsearch-master"
     - "elasticsearch-master.system-observability"
     - "elasticsearch-master.system-observability.svc"
-    - "elasticsearch-master.system-observability.svc.${CLUSTER_DOMAIN:-cluster.local}"
-    - "*.elasticsearch-master.system-observability.svc.${CLUSTER_DOMAIN:-cluster.local}"
+    - "elasticsearch-master.system-observability.svc.${DOMAIN:-cluster.local}"
+    - "*.elasticsearch-master.system-observability.svc.${DOMAIN:-cluster.local}"
     - "elasticsearch-master-headless"
     - "elasticsearch-master-headless.system-observability"
     - "elasticsearch-master-headless.system-observability.svc"
-    - "elasticsearch-master-headless.system-observability.svc.${CLUSTER_DOMAIN:-cluster.local}"
-    - "*.elasticsearch-master-headless.system-observability.svc.${CLUSTER_DOMAIN:-cluster.local}"
+    - "elasticsearch-master-headless.system-observability.svc.${DOMAIN:-cluster.local}"
+    - "*.elasticsearch-master-headless.system-observability.svc.${DOMAIN:-cluster.local}"
   usages:
     - server auth
     - client auth

--- a/kustomize/observability/elasticsearch/certificates.yaml
+++ b/kustomize/observability/elasticsearch/certificates.yaml
@@ -14,13 +14,13 @@ spec:
     - "elasticsearch-master"
     - "elasticsearch-master.system-observability"
     - "elasticsearch-master.system-observability.svc"
-    - "elasticsearch-master.system-observability.svc.${DOMAIN:-cluster.local}"
-    - "*.elasticsearch-master.system-observability.svc.${DOMAIN:-cluster.local}"
+    - "elasticsearch-master.system-observability.svc.cluster.local"
+    - "*.elasticsearch-master.system-observability.svc.cluster.local"
     - "elasticsearch-master-headless"
     - "elasticsearch-master-headless.system-observability"
     - "elasticsearch-master-headless.system-observability.svc"
-    - "elasticsearch-master-headless.system-observability.svc.${DOMAIN:-cluster.local}"
-    - "*.elasticsearch-master-headless.system-observability.svc.${DOMAIN:-cluster.local}"
+    - "elasticsearch-master-headless.system-observability.svc.cluster.local"
+    - "*.elasticsearch-master-headless.system-observability.svc.cluster.local"
   usages:
     - server auth
     - client auth

--- a/kustomize/observability/grafana/ingress/ingress.yaml
+++ b/kustomize/observability/grafana/ingress/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: system-observability
 spec:
   rules:
-  - host: grafana.${external_domain:-test}
+  - host: grafana.${DOMAIN:-test}
     http:
       paths:
       - path: /

--- a/kustomize/observability/kibana/ingress/ingress.yaml
+++ b/kustomize/observability/kibana/ingress/ingress.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  - host: kibana.${external_domain:-test}
+  - host: kibana.${DOMAIN:-test}
     http:
       paths:
       - path: /


### PR DESCRIPTION
We moved forward to leverage the new post-build subtitution format. This will not be ready until the next version of the CLI release. This PR reverts to use:

- `LOADBALANCER_IP_START`
- `LOCAL_VOLUME_PATH`
- `DOMAIN`
- `REGISTRY_URL`

Signed-off-by: Ryan VanGundy 
<85766511+rmvangun@users.noreply.github.com>