### PR TITLE
fix(config): Set correct default loadbalancer IPs

### DIFF
--- a/contexts/_template/schema.yaml
+++ b/contexts/_template/schema.yaml
@@ -28,7 +28,7 @@ properties:
       cidr_block:
         type: string
         pattern: "^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"
-        default: "10.0.0.0/16"
+        default: "10.5.0.0/16"
         description: Primary network CIDR block
       loadbalancer_ips:
         type: object
@@ -36,12 +36,12 @@ properties:
           start:
             type: string
             pattern: "^([0-9]{1,3}\\.){3}[0-9]{1,3}$"
-            default: "10.0.0.100"
+            default: "10.5.1.10"
             description: Load balancer IP pool start
           end:
             type: string
             pattern: "^([0-9]{1,3}\\.){3}[0-9]{1,3}$"
-            default: "10.0.0.200"
+            default: "10.5.1.100"
             description: Load balancer IP pool end
         additionalProperties: false
     additionalProperties: false


### PR DESCRIPTION
Load balancer IP defaults should sit in the same range as the network cidr.

Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>