### PR TITLE
AKS: default max pods && autoscale node group default subnet

### DIFF
--- a/terraform/cluster/azure-aks/main.tf
+++ b/terraform/cluster/azure-aks/main.tf
@@ -35,8 +35,8 @@ provider "azurerm" {
 data "azurerm_client_config" "current" {}
 
 data "azurerm_subnet" "private" {
-  count                = var.vnet_subnet_id == null ? 1 : 0
-  name                 = "private-1-${var.context_id}"
+  for_each = var.vnet_subnet_id == null ? toset([for i in range(1, 4) : tostring(i)]) : toset([])
+  name                 = "private-${each.value}-${var.context_id}"
   resource_group_name  = "${var.vnet_module_name}-${var.context_id}"
   virtual_network_name = "${var.vnet_module_name}-${var.context_id}"
 }
@@ -235,7 +235,7 @@ resource "azurerm_kubernetes_cluster" "main" {
     name                         = var.default_node_pool.name
     node_count                   = var.default_node_pool.node_count
     vm_size                      = var.default_node_pool.vm_size
-    vnet_subnet_id               = coalesce(var.vnet_subnet_id, try(data.azurerm_subnet.private[0].id, null))
+    vnet_subnet_id               = coalesce(var.vnet_subnet_id, try(data.azurerm_subnet.private["1"].id, null))
     orchestrator_version         = var.kubernetes_version
     only_critical_addons_enabled = var.default_node_pool.only_critical_addons_enabled
 
@@ -304,7 +304,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "autoscaled" {
   auto_scaling_enabled  = true
   min_count             = var.autoscaled_node_pool.min_count
   max_count             = var.autoscaled_node_pool.max_count
-  vnet_subnet_id        = coalesce(var.vnet_subnet_id, try(data.azurerm_subnet.private[1].id, null))
+  vnet_subnet_id        = coalesce(var.vnet_subnet_id, try(data.azurerm_subnet.private["2"].id, null))
   orchestrator_version  = var.kubernetes_version
   # checkov:skip=CKV_AZURE_226: We are using the managed disk type to reduce costs
   os_disk_type = var.autoscaled_node_pool.os_disk_type

--- a/terraform/cluster/azure-aks/main.tf
+++ b/terraform/cluster/azure-aks/main.tf
@@ -304,7 +304,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "autoscaled" {
   auto_scaling_enabled  = true
   min_count             = var.autoscaled_node_pool.min_count
   max_count             = var.autoscaled_node_pool.max_count
-  vnet_subnet_id        = coalesce(var.vnet_subnet_id, try(data.azurerm_subnet.private[0].id, null))
+  vnet_subnet_id        = coalesce(var.vnet_subnet_id, try(data.azurerm_subnet.private[1].id, null))
   orchestrator_version  = var.kubernetes_version
   # checkov:skip=CKV_AZURE_226: We are using the managed disk type to reduce costs
   os_disk_type = var.autoscaled_node_pool.os_disk_type

--- a/terraform/cluster/azure-aks/main.tf
+++ b/terraform/cluster/azure-aks/main.tf
@@ -35,7 +35,7 @@ provider "azurerm" {
 data "azurerm_client_config" "current" {}
 
 data "azurerm_subnet" "private" {
-  for_each = var.vnet_subnet_id == null ? toset([for i in range(1, 4) : tostring(i)]) : toset([])
+  for_each             = var.vnet_subnet_id == null ? toset([for i in range(1, 4) : tostring(i)]) : toset([])
   name                 = "private-${each.value}-${var.context_id}"
   resource_group_name  = "${var.vnet_module_name}-${var.context_id}"
   virtual_network_name = "${var.vnet_module_name}-${var.context_id}"

--- a/terraform/cluster/azure-aks/variables.tf
+++ b/terraform/cluster/azure-aks/variables.tf
@@ -78,7 +78,7 @@ variable "default_node_pool" {
     name                         = "system"
     vm_size                      = "Standard_D2s_v3"
     os_disk_type                 = "Managed"
-    max_pods                     = 110
+    max_pods                     = 48
     host_encryption_enabled      = true
     min_count                    = 1
     max_count                    = 3
@@ -106,7 +106,7 @@ variable "autoscaled_node_pool" {
     vm_size                 = "Standard_D2s_v3"
     mode                    = "User"
     os_disk_type            = "Managed"
-    max_pods                = 110
+    max_pods                = 48
     host_encryption_enabled = true
     min_count               = 1
     max_count               = 3


### PR DESCRIPTION
We ran into issues when updating the cluster to use Cilium network policy where both node pools with `Max Pods = 110` does not leave enough room in the /24 subnet. This configuration situation would likely cause issues in other upgrade operations states as well.  

The intent of these changes is to reduce that risk by: 
1. Limiting the default max pods to 48 per node on both `system` and `autoscaled` node pools (This should still be adequate for default use cases).
2. Adjusting the `autoscaled` node pool to use a different subnet than the `system` node pool.

The result is that each node pool would use its own subnet and each subnet would have space for up to 5 nodes (10 nodes total by default). 