### PR TITLE
AKS: Migrate from Azure NPM to Cilium

### DIFF
--- a/terraform/cluster/azure-aks/main.tf
+++ b/terraform/cluster/azure-aks/main.tf
@@ -266,7 +266,7 @@ resource "azurerm_kubernetes_cluster" "main" {
   }
 
   network_profile {
-    network_plugin = "cilium"
+    network_plugin = "azure"
     network_policy = "cilium"
     service_cidr   = var.service_cidr
     dns_service_ip = var.dns_service_ip

--- a/terraform/cluster/azure-aks/main.tf
+++ b/terraform/cluster/azure-aks/main.tf
@@ -266,8 +266,8 @@ resource "azurerm_kubernetes_cluster" "main" {
   }
 
   network_profile {
-    network_plugin = "azure"
-    network_policy = "azure"
+    network_plugin = "cilium"
+    network_policy = "cilium"
     service_cidr   = var.service_cidr
     dns_service_ip = var.dns_service_ip
   }


### PR DESCRIPTION
Azure NPM is deprecated and will be removed in Sept 2028
