### PR TITLE
fix(aks): Fix the way that subnets are handled by the node pools

### DIFF
--- a/terraform/cluster/azure-aks/main.tf
+++ b/terraform/cluster/azure-aks/main.tf
@@ -40,7 +40,7 @@ data "azurerm_virtual_network" "vnet" {
 }
 
 data "azurerm_subnet" "private" {
-  for_each = { for subnet in data.azurerm_virtual_network.vnet.subnets : subnet => subnet if contains(split("-", subnet), "private") }
+  for_each             = { for subnet in data.azurerm_virtual_network.vnet.subnets : subnet => subnet if contains(split("-", subnet), "private") }
   name                 = each.value
   resource_group_name  = data.azurerm_virtual_network.vnet.resource_group_name
   virtual_network_name = data.azurerm_virtual_network.vnet.name
@@ -309,13 +309,13 @@ resource "azurerm_kubernetes_cluster_node_pool" "autoscaled" {
   auto_scaling_enabled  = true
   min_count             = var.autoscaled_node_pool.min_count
   max_count             = var.autoscaled_node_pool.max_count
-  vnet_subnet_id        = coalesce(
+  vnet_subnet_id = coalesce(
     var.vnet_subnet_id,
     length(data.azurerm_subnet.private) > 1 ? (
       try(data.azurerm_subnet.private[1].id, null)) : (
-        try(data.azurerm_subnet.private[0].id, null))
+    try(data.azurerm_subnet.private[0].id, null))
   )
-  orchestrator_version  = var.kubernetes_version
+  orchestrator_version = var.kubernetes_version
   # checkov:skip=CKV_AZURE_226: We are using the managed disk type to reduce costs
   os_disk_type = var.autoscaled_node_pool.os_disk_type
   # checkov:skip=CKV_AZURE_168: This is set in the variable by default to 50

--- a/terraform/cluster/azure-aks/main.tf
+++ b/terraform/cluster/azure-aks/main.tf
@@ -34,11 +34,16 @@ provider "azurerm" {
 
 data "azurerm_client_config" "current" {}
 
+data "azurerm_virtual_network" "vnet" {
+  name                = "${var.name}-${var.context_id}"
+  resource_group_name = "${var.name}-${var.context_id}"
+}
+
 data "azurerm_subnet" "private" {
-  for_each             = var.vnet_subnet_id == null ? toset([for i in range(1, 4) : tostring(i)]) : toset([])
-  name                 = "private-${each.value}-${var.context_id}"
-  resource_group_name  = "${var.vnet_module_name}-${var.context_id}"
-  virtual_network_name = "${var.vnet_module_name}-${var.context_id}"
+  for_each = { for subnet in data.azurerm_virtual_network.vnet.subnets : subnet => subnet if contains(split("-", subnet), "private") }
+  name                 = each.value
+  resource_group_name  = data.azurerm_virtual_network.vnet.resource_group_name
+  virtual_network_name = data.azurerm_virtual_network.vnet.name
 }
 
 #-----------------------------------------------------------------------------------------------------------------------
@@ -235,7 +240,7 @@ resource "azurerm_kubernetes_cluster" "main" {
     name                         = var.default_node_pool.name
     node_count                   = var.default_node_pool.node_count
     vm_size                      = var.default_node_pool.vm_size
-    vnet_subnet_id               = coalesce(var.vnet_subnet_id, try(data.azurerm_subnet.private["1"].id, null))
+    vnet_subnet_id               = coalesce(var.vnet_subnet_id, try(data.azurerm_subnet.private[0].id, null))
     orchestrator_version         = var.kubernetes_version
     only_critical_addons_enabled = var.default_node_pool.only_critical_addons_enabled
 
@@ -304,7 +309,12 @@ resource "azurerm_kubernetes_cluster_node_pool" "autoscaled" {
   auto_scaling_enabled  = true
   min_count             = var.autoscaled_node_pool.min_count
   max_count             = var.autoscaled_node_pool.max_count
-  vnet_subnet_id        = coalesce(var.vnet_subnet_id, try(data.azurerm_subnet.private["2"].id, null))
+  vnet_subnet_id        = coalesce(
+    var.vnet_subnet_id,
+    length(data.azurerm_subnet.private) > 1 ? (
+      try(data.azurerm_subnet.private[1].id, null)) : (
+        try(data.azurerm_subnet.private[0].id, null))
+  )
   orchestrator_version  = var.kubernetes_version
   # checkov:skip=CKV_AZURE_226: We are using the managed disk type to reduce costs
   os_disk_type = var.autoscaled_node_pool.os_disk_type

--- a/terraform/cluster/azure-aks/main.tf
+++ b/terraform/cluster/azure-aks/main.tf
@@ -237,10 +237,10 @@ resource "azurerm_kubernetes_cluster" "main" {
   }
 
   default_node_pool {
-    name                         = var.default_node_pool.name
-    node_count                   = var.default_node_pool.node_count
-    vm_size                      = var.default_node_pool.vm_size
-    vnet_subnet_id               = coalesce(
+    name       = var.default_node_pool.name
+    node_count = var.default_node_pool.node_count
+    vm_size    = var.default_node_pool.vm_size
+    vnet_subnet_id = coalesce(
       var.vnet_subnet_id,
       try(element([for s in data.azurerm_subnet.private : s.id], 0), null)
     )

--- a/terraform/cluster/azure-aks/test.tftest.hcl
+++ b/terraform/cluster/azure-aks/test.tftest.hcl
@@ -5,9 +5,21 @@ mock_provider "azurerm" {
       object_id = "22222222-2222-2222-2222-222222222222"
     }
   }
+  mock_data "azurerm_virtual_network" {
+    defaults = {
+      subnets             = ["private-1-test", "private-2-test", "private-3-test", "public-1-test", "public-2-test", "isolated-1-test", "isolated-2-test"]
+      resource_group_name = "example-resource-group"
+      name                = "vnet-test"
+      id                  = "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Network/virtualNetworks/vnet-test"
+    }
+  }
   mock_data "azurerm_subnet" {
     defaults = {
-      id = "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/subnet-test"
+      name                 = "private-1-test"
+      resource_group_name  = "example-resource-group"
+      virtual_network_name = "vnet-test"
+      address_prefixes     = ["10.0.0.0/24"]
+      id                   = "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/subnet-test"
     }
   }
 }


### PR DESCRIPTION
Fixes the following error on nightly integration tests:

```
│ Error: Subnet (Subscription: "***"
│ Resource Group Name: "network-ws64b8cd"
│ Virtual Network Name: "network-ws64b8cd"
│ Subnet Name: "private-3-ws64b8cd") was not found
│ 
│   with module.main.data.azurerm_subnet.private["3"],
│   on ../../../../../.oci_extracted/ghcr.io-windsorcli/core-latest/terraform/cluster/azure-aks/main.tf line 37, in data "azurerm_subnet" "private":
│   37: data "azurerm_subnet" "private" {
│ 
╵
╷
│ Error: Subnet (Subscription: "***"
│ Resource Group Name: "network-ws64b8cd"
│ Virtual Network Name: "network-ws64b8cd"
│ Subnet Name: "private-2-ws64b8cd") was not found
│ 
│   with module.main.data.azurerm_subnet.private["2"],
│   on ../../../../../.oci_extracted/ghcr.io-windsorcli/core-latest/terraform/cluster/azure-aks/main.tf line 37, in data "azurerm_subnet" "private":
│   37: data "azurerm_subnet" "private" {
│ 
╵
```