### PR TITLE
fix(aks): Fix reference to vnet name

### DIFF
--- a/terraform/cluster/azure-aks/main.tf
+++ b/terraform/cluster/azure-aks/main.tf
@@ -35,8 +35,8 @@ provider "azurerm" {
 data "azurerm_client_config" "current" {}
 
 data "azurerm_virtual_network" "vnet" {
-  name                = "${var.name}-${var.context_id}"
-  resource_group_name = "${var.name}-${var.context_id}"
+  name                = "${var.vnet_module_name}-${var.context_id}"
+  resource_group_name = "${var.vnet_module_name}-${var.context_id}"
 }
 
 locals {


### PR DESCRIPTION
Using `var.vnet_module_name` rather than `var.name` when referencing `data.azurerm_virtual_network.vnet`.

Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>