### PR TITLE
chore(ci): Separate terraform tests and use task

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,13 +75,6 @@ jobs:
       - name: Run terraform fmt
         run: terraform fmt -check -recursive
 
-      - name: Run Terraform Tests
-        run: |
-          find terraform -type f -name '*.tftest.hcl' | while read testfile; do
-            testdir=$(dirname "$testfile")
-            (cd "$testdir" && terraform init -input=false && terraform test)
-          done
-
       - name: Checkov GitHub Action
         uses: bridgecrewio/checkov-action@68260132005eaae0e6f84c7a73cc3b1532f678bf # v12.3058.0
         with:
@@ -93,6 +86,27 @@ jobs:
         uses: github/codeql-action/upload-sarif@cf1bb45a277cb3c205638b2cd5c984db1c46a412 # v4.31.7
         with:
           sarif_file: results.sarif
+
+  terraform-tests:
+    name: Terraform Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          # renovate: datasource=github-releases depName=terraform package=hashicorp/terraform
+          terraform_version: 1.14.1
+
+      - name: Install Task
+        uses: go-task/setup-task@0ab1b2a65bc55236a3bc64cde78f80e20e8885c2 # v1.0.0
+        with:
+          version: 3.x
+
+      - name: Run Terraform Tests
+        run: task test
 
   integration:
     name: Integration Tests


### PR DESCRIPTION
Calls `task test` for testing terraform, permitting tests to fail on warnings.

Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>