### PR TITLE
feature(aks): Harden and extend AKS for production readiness

### DIFF
--- a/aqua.yaml
+++ b/aqua.yaml
@@ -32,3 +32,4 @@ packages:
   - name: evilmartians/lefthook@v2.0.8
   - name: bridgecrewio/checkov@3.2.495
   - name: kubernetes-sigs/krew@v0.4.5
+  - name: Azure/kubelogin@v0.2.13

--- a/contexts/_template/blueprint.yaml
+++ b/contexts/_template/blueprint.yaml
@@ -3,11 +3,6 @@ apiVersion: blueprints.windsorcli.dev/v1alpha1
 metadata:
   name: template
   description: Base blueprint template for core services
-repository:
-  url: ""
-  ref:
-    branch: main
-  secretName: flux-system
 sources: []
 terraform: []
 kustomize: []

--- a/contexts/_template/features/provider-azure.yaml
+++ b/contexts/_template/features/provider-azure.yaml
@@ -35,5 +35,23 @@ kustomize:
   path: csi
   dependsOn:
   - policy-resources
+  components:
+  - azure-disk
   cleanup:
   - pvcs
+
+# Telemetry - exclude metrics-server as AKS provides it natively
+- name: telemetry-resources
+  path: telemetry/resources
+  strategy: replace
+  dependsOn:
+  - telemetry-base
+  - csi
+  components:
+  - prometheus
+  - prometheus/flux
+  - fluentbit
+  - fluentbit/containerd
+  - fluentbit/fluentd
+  - fluentbit/kubernetes
+  - fluentbit/systemd

--- a/kustomize/csi/azure-disk/kustomization.yaml
+++ b/kustomize/csi/azure-disk/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - storageclass.yaml

--- a/kustomize/csi/azure-disk/storageclass.yaml
+++ b/kustomize/csi/azure-disk/storageclass.yaml
@@ -1,0 +1,14 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: single
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: disk.csi.azure.com
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  skuName: Premium_LRS
+  cachingMode: ReadWrite
+  fsType: ext4
+reclaimPolicy: Delete

--- a/terraform/cluster/azure-aks/.terraform.lock.hcl
+++ b/terraform/cluster/azure-aks/.terraform.lock.hcl
@@ -32,21 +32,21 @@ provider "registry.terraform.io/hashicorp/azurerm" {
 }
 
 provider "registry.terraform.io/hashicorp/local" {
-  version = "2.5.3"
+  version = "2.6.1"
   hashes = [
-    "h1:MCzg+hs1/ZQ32u56VzJMWP9ONRQPAAqAjuHuzbyshvI=",
-    "zh:284d4b5b572eacd456e605e94372f740f6de27b71b4e1fd49b63745d8ecd4927",
-    "zh:40d9dfc9c549e406b5aab73c023aa485633c1b6b730c933d7bcc2fa67fd1ae6e",
-    "zh:6243509bb208656eb9dc17d3c525c89acdd27f08def427a0dce22d5db90a4c8b",
+    "h1:DbiR/D2CPigzCGweYIyJH0N0x04oyI5xiZ9wSW/s3kQ=",
+    "zh:10050d08f416de42a857e4b6f76809aae63ea4ec6f5c852a126a915dede814b4",
+    "zh:2df2a3ebe9830d4759c59b51702e209fe053f47453cb4688f43c063bac8746b7",
+    "zh:2e759568bcc38c86ca0e43701d34cf29945736fdc8e429c5b287ddc2703c7b18",
+    "zh:6a62a34e48500ab4aea778e355e162ebde03260b7a9eb9edc7e534c84fbca4c6",
+    "zh:74373728ba32a1d5450a3a88ac45624579e32755b086cd4e51e88d9aca240ef6",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:885d85869f927853b6fe330e235cd03c337ac3b933b0d9ae827ec32fa1fdcdbf",
-    "zh:bab66af51039bdfcccf85b25fe562cbba2f54f6b3812202f4873ade834ec201d",
-    "zh:c505ff1bf9442a889ac7dca3ac05a8ee6f852e0118dd9a61796a2f6ff4837f09",
-    "zh:d36c0b5770841ddb6eaf0499ba3de48e5d4fc99f4829b6ab66b0fab59b1aaf4f",
-    "zh:ddb6a407c7f3ec63efb4dad5f948b54f7f4434ee1a2607a49680d494b1776fe1",
-    "zh:e0dafdd4500bec23d3ff221e3a9b60621c5273e5df867bc59ef6b7e41f5c91f6",
-    "zh:ece8742fd2882a8fc9d6efd20e2590010d43db386b920b2a9c220cfecc18de47",
-    "zh:f4c6b3eb8f39105004cf720e202f04f57e3578441cfb76ca27611139bc116a82",
+    "zh:8dddae588971a996f622e7589cd8b9da7834c744ac12bfb59c97fa77ded95255",
+    "zh:946f82f66353bb97aefa8d95c4ca86db227f9b7c50b82415289ac47e4e74d08d",
+    "zh:e9a5c09e6f35e510acf15b666fd0b34a30164cecdcd81ce7cda0f4b2dade8d91",
+    "zh:eafe5b873ef42b32feb2f969c38ff8652507e695620cbaf03b9db714bee52249",
+    "zh:ec146289fa27650c9d433bb5c7847379180c0b7a323b1b94e6e7ad5d2a7dbe71",
+    "zh:fc882c35ce05631d76c0973b35adde26980778fc81d9da81a2fade2b9d73423b",
   ]
 }
 

--- a/terraform/network/azure-vnet/main.tf
+++ b/terraform/network/azure-vnet/main.tf
@@ -125,7 +125,22 @@ resource "azurerm_nat_gateway_public_ip_association" "main" {
   public_ip_address_id = azurerm_public_ip.nat[count.index].id
 }
 
-# Associate NAT Gateway with private subnet
+resource "azurerm_route_table" "private" {
+  count               = var.vnet_zones
+  name                = "${var.name}-private-${count.index + 1}-${var.context_id}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  tags = merge({
+    Name = "${var.name}-private-${count.index + 1}-${var.context_id}"
+  }, local.tags)
+}
+
+resource "azurerm_subnet_route_table_association" "private" {
+  count          = var.vnet_zones
+  subnet_id      = azurerm_subnet.private[count.index].id
+  route_table_id = azurerm_route_table.private[count.index].id
+}
+
 resource "azurerm_subnet_nat_gateway_association" "private" {
   count          = var.enable_nat_gateway ? var.vnet_zones : 0
   subnet_id      = azurerm_subnet.private[count.index].id


### PR DESCRIPTION
The AKS module required a few enhancements to prepare it for production use. These include:

* Introducing the `single` storage class for consistency with EKS
* Allow toggling disk encryption
* Enable azure monitor diagnostics
* Enable toggling container insights
* Allow configuring various k8s API access schemes
* Enable multiple AZs
* Use workload identity
* Include image cleaner
* Expand cilium configuration
* Default to outbound type  to use `userAssignedNATGateway`
* Add `Network Contributor` role to cluster to support the custom VNet
* Add disk management role so nodes can manage disks, snapshots
* Allow toggling disk encryption
* Default to OIDC based access to k8s api, and default to assigning an AKS admin role to the active user applying the terraform
* Include kubelogin in aqua as it's required to connect to the k8s api

Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>