### PR TITLE
chore: Don't autogenerate docs on precommit

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -5,10 +5,6 @@ pre-commit:
       glob: "*.{tf,tfvars}"
       run: terraform fmt {staged_files}
       stage_fixed: true
-    terraform-docs:
-      glob: "*.{tf,tfvars}"
-      run: task docs
-      stage_fixed: true
 
 pre-push:
   parallel: true


### PR DESCRIPTION
Removing automatic docs generation on pre-commit. This has been annoying and not effective as it adds README files for irrelevant changes.

Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>