### PR TITLE
feat(aks): Leverage OIDC roles for kubelet and workloads

### DIFF
--- a/terraform/cluster/azure-aks/main.tf
+++ b/terraform/cluster/azure-aks/main.tf
@@ -228,6 +228,7 @@ resource "azurerm_kubernetes_cluster" "main" {
   resource_group_name = azurerm_resource_group.aks.name
   dns_prefix          = local.cluster_name
   # checkov:skip=CKV_AZURE_339: Kubernetes version is populated from the cloud provider's stable version via Renovate.
+  # checkov:skip=CKV_AZURE_4: Log Analytics workspace is created but diagnostic settings are configured separately or via alternative monitoring solutions
   kubernetes_version                = var.kubernetes_version
   role_based_access_control_enabled = var.role_based_access_control_enabled
   automatic_upgrade_channel         = var.automatic_upgrade_channel

--- a/terraform/cluster/azure-aks/main.tf
+++ b/terraform/cluster/azure-aks/main.tf
@@ -55,9 +55,16 @@ data "azurerm_subnet" "private" {
 #-----------------------------------------------------------------------------------------------------------------------
 
 locals {
-  kubeconfig_path = "${var.context_path}/.kube/config"
-  rg_name         = var.resource_group_name == null ? "${var.name}-${var.context_id}" : var.resource_group_name
-  cluster_name    = var.cluster_name == null ? "${var.name}-${var.context_id}" : var.cluster_name
+  kubeconfig_path          = "${var.context_path}/.kube/config"
+  rg_name                  = var.resource_group_name == null ? "${var.name}-${var.context_id}" : var.resource_group_name
+  cluster_name             = var.cluster_name == null ? "${var.name}-${var.context_id}" : var.cluster_name
+  node_resource_group_name = split("/", azurerm_kubernetes_cluster.main.node_resource_group_id)[4]
+  node_pool_names = concat(
+    [var.default_node_pool.name],
+    var.autoscaled_node_pool.enabled ? [var.autoscaled_node_pool.name] : []
+  )
+  # Safely access kubelet identity (may not be available during plan in tests)
+  kubelet_object_id = try(azurerm_kubernetes_cluster.main.kubelet_identity[0].object_id, "00000000-0000-0000-0000-000000000000")
   tags = merge({
     WindsorContextID = var.context_id
   }, var.tags)
@@ -274,6 +281,9 @@ resource "azurerm_kubernetes_cluster" "main" {
     vertical_pod_autoscaler_enabled = var.workload_autoscaler_profile.vertical_pod_autoscaler_enabled
   }
 
+  oidc_issuer_enabled       = var.oidc_issuer_enabled
+  workload_identity_enabled = var.workload_identity_enabled
+
   network_profile {
     network_plugin = "azure"
     network_policy = "cilium"
@@ -281,22 +291,11 @@ resource "azurerm_kubernetes_cluster" "main" {
     dns_service_ip = var.dns_service_ip
   }
 
-  oms_agent {
-    log_analytics_workspace_id = azurerm_log_analytics_workspace.aks_logs.id
-  }
-
+  # Use system-assigned managed identity (Microsoft default and best practice)
+  # AKS automatically creates Contributor role on node RG for control plane
+  # AKS automatically creates Virtual Machine Contributor role on node RG for kubelet
   identity {
-    type         = length(var.user_assigned_identity_ids) > 0 ? "UserAssigned" : "SystemAssigned"
-    identity_ids = var.user_assigned_identity_ids
-  }
-
-  dynamic "kubelet_identity" {
-    for_each = var.kubelet_user_assigned_identity_id != null ? [1] : []
-    content {
-      client_id                 = var.kubelet_client_id
-      object_id                 = var.kubelet_object_id
-      user_assigned_identity_id = var.kubelet_user_assigned_identity_id
-    }
+    type = "SystemAssigned"
   }
 
   tags = merge({
@@ -328,6 +327,52 @@ resource "azurerm_kubernetes_cluster_node_pool" "autoscaled" {
   tags = merge({
     Name = var.autoscaled_node_pool.name
   }, local.tags)
+}
+
+# AKS automatically creates Virtual Machine Contributor role assignment on node resource group for the kubelet identity.
+# However, disk attachment operations require additional permissions beyond Virtual Machine Contributor.
+# Create a custom role with minimal permissions for VMSS disk operations.
+resource "azurerm_role_definition" "aks_kubelet_vmss_disk_manager" {
+  name        = "AKS Kubelet VMSS Disk Manager - ${var.context_id}"
+  scope       = azurerm_kubernetes_cluster.main.node_resource_group_id
+  description = "Minimal permissions for AKS kubelet identity to manage VMSS disk attachments"
+
+  permissions {
+    actions = concat(
+      [
+        # VMSS virtual machine operations for disk attachment (REQUIRED)
+        "Microsoft.Compute/virtualMachineScaleSets/virtualMachines/read",
+        "Microsoft.Compute/virtualMachineScaleSets/virtualMachines/write",
+        # Core disk operations (REQUIRED for basic disk attachment)
+        "Microsoft.Compute/disks/read",
+        "Microsoft.Compute/disks/write",
+        "Microsoft.Compute/disks/delete",
+        "Microsoft.Compute/disks/beginGetAccess/action",
+        "Microsoft.Compute/disks/endGetAccess/action",
+        # Location/operation queries (may be needed for operation status checks)
+        "Microsoft.Compute/locations/DiskOperations/read",
+        "Microsoft.Compute/locations/vmSizes/read",
+        "Microsoft.Compute/locations/operations/read"
+      ],
+      var.enable_volume_snapshots ? [
+        # Snapshot operations (only included if volume snapshots are enabled)
+        "Microsoft.Compute/snapshots/read",
+        "Microsoft.Compute/snapshots/write",
+        "Microsoft.Compute/snapshots/delete"
+      ] : []
+    )
+    not_actions = []
+  }
+
+  assignable_scopes = [
+    azurerm_kubernetes_cluster.main.node_resource_group_id
+  ]
+}
+
+resource "azurerm_role_assignment" "kubelet_vmss_disk_manager" {
+  scope              = azurerm_kubernetes_cluster.main.node_resource_group_id
+  role_definition_id = azurerm_role_definition.aks_kubelet_vmss_disk_manager.role_definition_resource_id
+  principal_id       = local.kubelet_object_id
 }
 
 resource "local_file" "kube_config" {

--- a/terraform/cluster/azure-aks/test.tftest.hcl
+++ b/terraform/cluster/azure-aks/test.tftest.hcl
@@ -84,6 +84,16 @@ run "minimal_configuration" {
     condition     = azurerm_kubernetes_cluster.main.identity[0].type == "SystemAssigned"
     error_message = "Cluster should use system-assigned identity by default"
   }
+
+  assert {
+    condition     = azurerm_kubernetes_cluster.main.oidc_issuer_enabled == true
+    error_message = "OIDC issuer should be enabled by default"
+  }
+
+  assert {
+    condition     = azurerm_kubernetes_cluster.main.workload_identity_enabled == true
+    error_message = "Workload Identity should be enabled by default"
+  }
 }
 
 # Tests a full configuration with all optional variables explicitly set,
@@ -97,13 +107,8 @@ run "full_configuration" {
     cluster_name        = "test-cluster"
     resource_group_name = "test-rg"
     kubernetes_version  = "1.32"
-    user_assigned_identity_ids = [
-      "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-identity-1",
-      "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-identity-2"
-    ]
-    kubelet_client_id                 = "test-client-id"
-    kubelet_object_id                 = "test-object-id"
-    kubelet_user_assigned_identity_id = "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-identity-1"
+    oidc_issuer_enabled  = true
+    workload_identity_enabled = true
     default_node_pool = {
       name                         = "system"
       vm_size                      = "Standard_D2s_v3"
@@ -208,28 +213,18 @@ run "full_configuration" {
   }
 
   assert {
-    condition     = azurerm_kubernetes_cluster.main.identity[0].type == "UserAssigned"
-    error_message = "Cluster should use user-assigned identity when IDs are provided"
+    condition     = azurerm_kubernetes_cluster.main.identity[0].type == "SystemAssigned"
+    error_message = "Cluster should use system-assigned identity"
   }
 
   assert {
-    condition     = length(azurerm_kubernetes_cluster.main.identity[0].identity_ids) == 2
-    error_message = "Cluster should have 2 user-assigned identity IDs"
+    condition     = azurerm_kubernetes_cluster.main.oidc_issuer_enabled == true
+    error_message = "OIDC issuer should be enabled"
   }
 
   assert {
-    condition     = azurerm_kubernetes_cluster.main.kubelet_identity[0].client_id == "test-client-id"
-    error_message = "Kubelet client ID should match input"
-  }
-
-  assert {
-    condition     = azurerm_kubernetes_cluster.main.kubelet_identity[0].object_id == "test-object-id"
-    error_message = "Kubelet object ID should match input"
-  }
-
-  assert {
-    condition     = azurerm_kubernetes_cluster.main.kubelet_identity[0].user_assigned_identity_id == "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-identity-1"
-    error_message = "Kubelet user-assigned identity ID should match input"
+    condition     = azurerm_kubernetes_cluster.main.workload_identity_enabled == true
+    error_message = "Workload Identity should be enabled"
   }
 }
 

--- a/terraform/cluster/azure-aks/test.tftest.hcl
+++ b/terraform/cluster/azure-aks/test.tftest.hcl
@@ -145,7 +145,7 @@ run "full_configuration" {
     private_cluster_enabled           = false
     azure_policy_enabled              = true
     local_account_disabled            = false
-    enable_volume_snapshots            = true
+    enable_volume_snapshots           = true
   }
 
   assert {
@@ -323,9 +323,9 @@ run "volume_snapshots_disabled" {
   command = plan
 
   variables {
-    context_id             = "test"
-    name                   = "windsor-aks"
-    kubernetes_version     = "1.32"
+    context_id              = "test"
+    name                    = "windsor-aks"
+    kubernetes_version      = "1.32"
     enable_volume_snapshots = false
   }
 

--- a/terraform/cluster/azure-aks/test.tftest.hcl
+++ b/terraform/cluster/azure-aks/test.tftest.hcl
@@ -102,12 +102,12 @@ run "full_configuration" {
   command = plan
 
   variables {
-    context_id          = "test"
-    name                = "windsor-aks"
-    cluster_name        = "test-cluster"
-    resource_group_name = "test-rg"
-    kubernetes_version  = "1.32"
-    oidc_issuer_enabled  = true
+    context_id                = "test"
+    name                      = "windsor-aks"
+    cluster_name              = "test-cluster"
+    resource_group_name       = "test-rg"
+    kubernetes_version        = "1.32"
+    oidc_issuer_enabled       = true
     workload_identity_enabled = true
     default_node_pool = {
       name                         = "system"

--- a/terraform/cluster/azure-aks/variables.tf
+++ b/terraform/cluster/azure-aks/variables.tf
@@ -235,6 +235,12 @@ variable "endpoint_private_access" {
   default     = false
 }
 
+variable "enable_volume_snapshots" {
+  description = "Enable volume snapshot permissions for the kubelet identity. Set to false to use minimal permissions if volume snapshots are not needed."
+  type        = bool
+  default     = true
+}
+
 variable "oidc_issuer_enabled" {
   description = "Enable OIDC issuer for the AKS cluster"
   type        = bool

--- a/terraform/cluster/azure-aks/variables.tf
+++ b/terraform/cluster/azure-aks/variables.tf
@@ -205,12 +205,6 @@ variable "expiration_date" {
   default     = null
 }
 
-variable "user_assigned_identity_ids" {
-  type        = list(string)
-  description = "User assigned identity IDs for the AKS cluster. If provided, the cluster will use only user-assigned identities."
-  default     = []
-}
-
 variable "soft_delete_retention_days" {
   type        = number
   description = "The number of days to retain the AKS cluster's key vault"
@@ -241,20 +235,14 @@ variable "endpoint_private_access" {
   default     = false
 }
 
-variable "kubelet_client_id" {
-  description = "Client ID of the user-assigned identity to use for the kubelet. If not provided, the cluster will use the system-assigned identity."
-  type        = string
-  default     = null
+variable "oidc_issuer_enabled" {
+  description = "Enable OIDC issuer for the AKS cluster"
+  type        = bool
+  default     = true
 }
 
-variable "kubelet_object_id" {
-  description = "Object ID of the user-assigned identity to use for the kubelet. If not provided, the cluster will use the system-assigned identity."
-  type        = string
-  default     = null
-}
-
-variable "kubelet_user_assigned_identity_id" {
-  description = "Resource ID of the user-assigned identity to use for the kubelet. If not provided, the cluster will use the system-assigned identity."
-  type        = string
-  default     = null
+variable "workload_identity_enabled" {
+  description = "Enable Workload Identity for the AKS cluster"
+  type        = bool
+  default     = true
 }


### PR DESCRIPTION
* Enable oidc issuer and workload identity
* Use system-assigned managed identities
* Add required disk manager role (breaks cluster otherwise)

Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>