### PR TITLE
feat(csi): Allow parameterizing storage type names

### DIFF
--- a/contexts/_template/features/provider-aws.yaml
+++ b/contexts/_template/features/provider-aws.yaml
@@ -39,5 +39,5 @@ kustomize:
   - policy-resources
   components:
   - aws-ebs
-  cleanup:
-  - pvcs
+  substitutions:
+    single_storage_type: ${cluster.storage?.single_storage_type ?? "gp3"}

--- a/contexts/_template/features/provider-azure.yaml
+++ b/contexts/_template/features/provider-azure.yaml
@@ -35,5 +35,7 @@ kustomize:
   path: csi
   dependsOn:
   - policy-resources
-  cleanup:
-  - pvcs
+  components:
+  - azure-disk
+  substitutions:
+    single_storage_type: ${cluster.storage?.single_storage_type ?? "StandardSSD_LRS"}

--- a/contexts/_template/schema.yaml
+++ b/contexts/_template/schema.yaml
@@ -152,6 +152,13 @@ properties:
             default: ["/var/mnt/local"]
             description: Additional volume mounts for workers
         additionalProperties: false
+      storage:
+        type: object
+        properties:
+          single_storage_type:
+            type: string
+            description: Storage type for the single storage class (e.g., gp3 for AWS, StandardSSD_LRS for Azure)
+        additionalProperties: false
     additionalProperties: false
 
   # DNS configuration

--- a/kustomize/csi/azure-disk/kustomization.yaml
+++ b/kustomize/csi/azure-disk/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - storageclass.yaml

--- a/kustomize/csi/azure-disk/storageclass.yaml
+++ b/kustomize/csi/azure-disk/storageclass.yaml
@@ -4,11 +4,11 @@ metadata:
   name: single
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
-provisioner: ebs.csi.aws.com
+provisioner: disk.csi.azure.com
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
 parameters:
-  type: ${single_storage_type:-gp3}
-  encrypted: "true"
+  skuName: ${single_storage_type:-StandardSSD_LRS}
+  cachingMode: ReadWrite
   fsType: ext4
 reclaimPolicy: Delete


### PR DESCRIPTION
It's now possible to define the storage class type for both aks and eks via `values.yaml` as `cluster.storage.single_storage_type`. Example:

```
cluster:
  storage:
    single_storage_type: eb3
```

Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>