### PR TITLE
chore: v0.9.0 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 .windsor/
 .volumes/
 terraform/**/backend_override.tf
-terraform/**/provider_override.tf
 contexts/**/.terraform/
 contexts/**/.tfstate/
 contexts/**/.kube/
@@ -12,6 +11,7 @@ contexts/**/.talos/
 contexts/**/.aws/
 contexts/**/.omni/
 contexts/**/.azure/
+contexts/**/.gcp/
 
 # macOS system files
 **/.DS_Store

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -33,3 +33,4 @@ packages:
   - name: bridgecrewio/checkov@3.2.495
   - name: kubernetes-sigs/krew@v0.4.5
   - name: Azure/kubelogin@v0.2.13
+  - name: twistedpair/google-cloud-sdk@549.0.1

--- a/contexts/_template/features/local-dev.yaml
+++ b/contexts/_template/features/local-dev.yaml
@@ -7,10 +7,8 @@ metadata:
 when: dev == true && provider == 'generic'
 
 terraform:
-- path: gitops/flux
-  destroy: false
-  dependsOn:
-  - cluster/talos
+- name: gitops
+  path: gitops/flux
   inputs:
     git_username: ${git.livereload.username}
     git_password: ${git.livereload.password}

--- a/contexts/_template/features/provider-aws.yaml
+++ b/contexts/_template/features/provider-aws.yaml
@@ -7,14 +7,24 @@ metadata:
 when: provider == 'aws'
 
 terraform:
-- path: network/aws-vpc
+- name: network
+  path: network/aws-vpc
   inputs:
     cidr_block: ${network.cidr_block}
     domain_name: ${dns?.domain ?? ""}
-- path: cluster/aws-eks
-- path: cluster/aws-eks/additions
+- name: cluster
+  path: cluster/aws-eks
+  dependsOn:
+  - network
+- name: cluster-additions
+  path: cluster/aws-eks/additions
+  dependsOn:
+  - cluster
   destroy: false
-- path: gitops/flux
+- name: gitops
+  path: gitops/flux
+  dependsOn:
+  - cluster
   destroy: false
 
 kustomize:

--- a/contexts/_template/features/provider-azure.yaml
+++ b/contexts/_template/features/provider-azure.yaml
@@ -7,12 +7,19 @@ metadata:
 when: provider == 'azure'
 
 terraform:
-- path: network/azure-vnet
+- name: network
+  path: network/azure-vnet
   inputs:
     vnet_cidr: ${network.cidr_block}
-- path: cluster/azure-aks
-- path: gitops/flux
+- name: cluster
+  path: cluster/azure-aks
+  dependsOn:
+  - network
+- name: gitops
+  path: gitops/flux
   destroy: false
+  dependsOn:
+  - cluster
 
 kustomize:
 
@@ -43,15 +50,6 @@ kustomize:
 # Telemetry - exclude metrics-server as AKS provides it natively
 - name: telemetry-resources
   path: telemetry/resources
-  strategy: replace
-  dependsOn:
-  - telemetry-base
-  - csi
+  strategy: remove
   components:
-  - prometheus
-  - prometheus/flux
-  - fluentbit
-  - fluentbit/containerd
-  - fluentbit/fluentd
-  - fluentbit/kubernetes
-  - fluentbit/systemd
+  - metrics-server

--- a/contexts/_template/features/provider-generic.yaml
+++ b/contexts/_template/features/provider-generic.yaml
@@ -7,7 +7,8 @@ metadata:
 when: provider == 'generic'
 
 terraform:
-- path: cluster/talos
+- name: cluster
+  path: cluster/talos
   parallelism: 1
   inputs:
     cluster_endpoint: ${cluster.endpoint ?? ("https://" + split(values(cluster.controlplanes.nodes)[0].endpoint, ":")[0] + ":6443")}
@@ -17,9 +18,10 @@ terraform:
     common_config_patches: ${jsonnet("../configs/talos-generic.jsonnet").common_config_patches}
     worker_config_patches: ${jsonnet("../configs/talos-generic.jsonnet").worker_config_patches}
     controlplane_config_patches: ${jsonnet("../configs/talos-generic.jsonnet").controlplane_config_patches}
-- path: gitops/flux
+- name: gitops
+  path: gitops/flux
   dependsOn:
-  - cluster/talos
+  - cluster
   destroy: false
 
 kustomize:

--- a/contexts/_template/metadata.yaml
+++ b/contexts/_template/metadata.yaml
@@ -1,1 +1,1 @@
-cliVersion: ">=0.8.0"
+cliVersion: ">=0.9.0"

--- a/terraform/cluster/talos/.terraform.lock.hcl
+++ b/terraform/cluster/talos/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/local" {
   version = "2.6.1"
   hashes = [
     "h1:DbiR/D2CPigzCGweYIyJH0N0x04oyI5xiZ9wSW/s3kQ=",
+    "h1:Ey2jPUGfuahWUs8w82yeZKBMYqh9SM3e6J+EQt7QTKk=",
     "zh:10050d08f416de42a857e4b6f76809aae63ea4ec6f5c852a126a915dede814b4",
     "zh:2df2a3ebe9830d4759c59b51702e209fe053f47453cb4688f43c063bac8746b7",
     "zh:2e759568bcc38c86ca0e43701d34cf29945736fdc8e429c5b287ddc2703c7b18",
@@ -23,6 +24,7 @@ provider "registry.terraform.io/hashicorp/local" {
 provider "registry.terraform.io/hashicorp/null" {
   version = "3.2.4"
   hashes = [
+    "h1:+Ag4hSb4qQjNtAS6gj2+gsGl7v0iB/Bif6zZZU8lXsw=",
     "h1:L5V05xwp/Gto1leRryuesxjMfgZwjb7oool4WS1UEFQ=",
     "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update templates for Windsor CLI v0.9 with named Terraform blocks and dependencies, adjust Azure telemetry, add Google Cloud SDK, and ignore GCP context files.
> 
> - **Templates/Features**:
>   - Refactor Terraform blocks in `features/provider-aws.yaml`, `features/provider-azure.yaml`, `features/provider-generic.yaml`, and `features/local-dev.yaml` to use named modules with explicit `dependsOn` (e.g., `network -> cluster -> additions -> gitops`).
>   - Azure: change `telemetry-resources` to `strategy: remove` and limit components to `metrics-server`.
> - **Metadata**:
>   - Bump `contexts/_template/metadata.yaml` `cliVersion` to `">=0.9.0"`.
> - **Tooling**:
>   - Add `twistedpair/google-cloud-sdk@549.0.1` in `aqua.yaml`.
> - **Repo hygiene**:
>   - Ignore `contexts/**/.gcp/` in `.gitignore`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 825656ce942179473b638eb6e99c3230202999b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->