### PR TITLE
feat(database): Add support for cloudnative-pg

### DIFF
--- a/contexts/_template/features/addon-database.yaml
+++ b/contexts/_template/features/addon-database.yaml
@@ -28,6 +28,6 @@ kustomize:
   # CloudNativePG Grafana dashboard
   - name: observability
     path: observability
-    when: addons.database.postgres.driver == 'cloudnativepg'
+    when: addons.database.postgres.driver == 'cloudnativepg' && addons.observability.enabled == true
     components:
       - grafana/cloudnativepg

--- a/contexts/_template/features/addon-database.yaml
+++ b/contexts/_template/features/addon-database.yaml
@@ -1,0 +1,33 @@
+kind: Feature
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: database
+  description: PostgreSQL database service with CloudNativePG
+
+when: addons.database.postgres.enabled == true || dev == true
+
+kustomize:
+
+  # CloudNativePG operator base
+  - name: database
+    path: database
+    when: addons.database.postgres.driver == 'cloudnativepg' || dev == true
+    dependsOn:
+      - csi
+    components:
+      - cloudnativepg
+      - cloudnativepg/prometheus
+
+  # High availability configuration
+  - name: database
+    path: database
+    when: addons.database.postgres.driver == 'cloudnativepg' && ha == true
+    components:
+      - cloudnativepg/ha
+
+  # CloudNativePG Grafana dashboard
+  - name: observability
+    path: observability
+    when: addons.database.postgres.driver == 'cloudnativepg'
+    components:
+      - grafana/cloudnativepg

--- a/contexts/_template/schema.yaml
+++ b/contexts/_template/schema.yaml
@@ -10,6 +10,12 @@ properties:
     default: false
     description: Enable development mode with additional observability and debugging tools
 
+  # High availability mode
+  ha:
+    type: boolean
+    default: false
+    description: Enable high availability mode for all components (multiple replicas, PDBs, etc.)
+
   # Core infrastructure provider (determines basic stack)
   provider:
     type: string
@@ -250,6 +256,24 @@ properties:
               - minio
             default: minio
             description: Object storage driver
+        additionalProperties: false
+      database:
+        type: object
+        properties:
+          postgres:
+            type: object
+            properties:
+              enabled:
+                type: boolean
+                default: false
+                description: Enable PostgreSQL database service
+              driver:
+                type: string
+                enum:
+                  - cloudnativepg
+                default: cloudnativepg
+                description: PostgreSQL database driver
+            additionalProperties: false
         additionalProperties: false
     additionalProperties: false
 

--- a/kustomize/database/cloudnativepg/ha/kustomization.yaml
+++ b/kustomize/database/cloudnativepg/ha/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: patches/helm-release.yaml
+

--- a/kustomize/database/cloudnativepg/ha/patches/helm-release.yaml
+++ b/kustomize/database/cloudnativepg/ha/patches/helm-release.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cloudnativepg
+  namespace: system-database
+spec:
+  values:
+    operator:
+      replicaCount: 2
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                      - cloudnative-pg
+              topologyKey: kubernetes.io/hostname
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+      updateStrategy:
+        rollingUpdate:
+          maxUnavailable: 1
+

--- a/kustomize/database/cloudnativepg/helm-release.yaml
+++ b/kustomize/database/cloudnativepg/helm-release.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cloudnativepg
+  namespace: system-database
+spec:
+  interval: 5m
+  timeout: 10m
+  chart:
+    spec:
+      chart: cloudnative-pg
+      # renovate: datasource=helm depName=cloudnative-pg package=cloudnative-pg helmRepo=https://cloudnative-pg.github.io/charts
+      version: "0.25.0"
+      sourceRef:
+        kind: HelmRepository
+        name: cloudnativepg
+        namespace: system-gitops
+  values:
+    config:
+      clusterWide: true
+    operator:
+      image:
+        # renovate: datasource=docker depName=ghcr.io/cloudnative-pg/cloudnative-pg package=ghcr.io/cloudnative-pg/cloudnative-pg
+        tag: v1.27.1@sha256:613668dc869777a9ef1c9954642ba9378f54838ed80db91eba39a6ad7ad5cb4a
+      resources:
+        requests:
+          cpu: 250m
+          memory: 256Mi
+        limits:
+          memory: 256Mi
+      securityContext:
+        runAsNonRoot: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
+      webhook:
+        enabled: true
+        failurePolicy: Fail
+      updateStrategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxUnavailable: 0

--- a/kustomize/database/cloudnativepg/helm-repository.yaml
+++ b/kustomize/database/cloudnativepg/helm-repository.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: cloudnativepg
+  namespace: system-gitops
+spec:
+  interval: 10m
+  timeout: 3m
+  url: https://cloudnative-pg.github.io/charts

--- a/kustomize/database/cloudnativepg/kustomization.yaml
+++ b/kustomize/database/cloudnativepg/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - helm-repository.yaml
+  - helm-release.yaml

--- a/kustomize/database/cloudnativepg/prometheus/kustomization.yaml
+++ b/kustomize/database/cloudnativepg/prometheus/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: patches/helm-release.yaml

--- a/kustomize/database/cloudnativepg/prometheus/patches/helm-release.yaml
+++ b/kustomize/database/cloudnativepg/prometheus/patches/helm-release.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cloudnativepg
+  namespace: system-database
+spec:
+  dependsOn:
+    - name: kube-prometheus-stack
+      namespace: system-telemetry
+  values:
+    monitoring:
+      podMonitorEnabled: true

--- a/kustomize/database/kustomization.yaml
+++ b/kustomize/database/kustomization.yaml
@@ -1,0 +1,2 @@
+resources: 
+  - namespace.yaml

--- a/kustomize/database/namespace.yaml
+++ b/kustomize/database/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: system-database
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/warn: baseline

--- a/kustomize/demo/database/cluster.yaml
+++ b/kustomize/demo/database/cluster.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: demo-cluster
+  namespace: demo-database
+spec:
+  instances: 1
+  postgresql:
+    parameters:
+      max_connections: "100"
+  storage:
+    size: 1Gi
+  monitoring:
+    enablePodMonitor: true

--- a/kustomize/demo/database/kustomization.yaml
+++ b/kustomize/demo/database/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - namespace.yaml
+  - cluster.yaml

--- a/kustomize/demo/database/namespace.yaml
+++ b/kustomize/demo/database/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: demo-database
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/warn: baseline

--- a/kustomize/observability/grafana/cloudnativepg/kustomization.yaml
+++ b/kustomize/observability/grafana/cloudnativepg/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - target:
+      group: helm.toolkit.fluxcd.io
+      version: v2
+      kind: HelmRelease
+      name: grafana
+      namespace: system-observability
+    path: patches/patch.json
+  - target:
+      group: helm.toolkit.fluxcd.io
+      version: v2
+      kind: HelmRelease
+      name: grafana
+      namespace: system-observability
+    path: patches/helm-release.yaml

--- a/kustomize/observability/grafana/cloudnativepg/patches/helm-release.yaml
+++ b/kustomize/observability/grafana/cloudnativepg/patches/helm-release.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: grafana
+  namespace: system-observability
+spec:
+  values:
+    dashboards:
+      grafana-dashboards-databases:
+        cloudnativepg:
+          url: https://raw.githubusercontent.com/cloudnative-pg/grafana-dashboards/main/charts/cluster/grafana-dashboard.json
+          token: ''
+

--- a/kustomize/observability/grafana/cloudnativepg/patches/patch.json
+++ b/kustomize/observability/grafana/cloudnativepg/patches/patch.json
@@ -1,0 +1,18 @@
+[
+  {
+    "op": "add",
+    "path": "/spec/values/dashboardProviders/dashboardproviders.yaml/providers/-",
+    "value": {
+      "name": "grafana-dashboards-databases",
+      "orgId": 1,
+      "folder": "Databases",
+      "type": "file",
+      "disableDeletion": true,
+      "editable": false,
+      "options": {
+        "path": "/var/lib/grafana/dashboards/grafana-dashboards-databases"
+      }
+    }
+  }
+]
+

--- a/kustomize/observability/grafana/helm-release.yaml
+++ b/kustomize/observability/grafana/helm-release.yaml
@@ -23,6 +23,12 @@ spec:
     downloadDashboardsImage:
       # renovate: datasource=docker depName=curlimages/curl package=curlimages/curl
       tag: 8.17.0@sha256:935d9100e9ba842cdb060de42472c7ca90cfe9a7c96e4dacb55e79e560b3ff40
+    sidecar:
+      dashboards:
+        enabled: true
+        label: grafana_dashboard
+        labelValue: "1"
+        folder: /var/lib/grafana/dashboards/sidecar
     dashboardProviders:
       dashboardproviders.yaml:
         apiVersion: 1


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a CloudNativePG-based PostgreSQL addon (with HA option), Prometheus/Grafana integration, schema updates, and a demo cluster.
> 
> - **Database addon (CloudNativePG)**:
>   - Adds operator via Flux `HelmRepository` and `HelmRelease` in `kustomize/database/cloudnativepg/*`.
>   - New feature gate `contexts/_template/features/addon-database.yaml` to enable when `addons.database.postgres.enabled` or `dev`.
> - **High availability**:
>   - HA component `kustomize/database/cloudnativepg/ha` sets operator `replicaCount`, anti-affinity, PDB, and rolling updates.
> - **Monitoring & observability**:
>   - Prometheus: enables `podMonitorEnabled` and adds dependency on `kube-prometheus-stack` via `cloudnativepg/prometheus` component.
>   - Grafana: adds CloudNativePG dashboard and provider in `kustomize/observability/grafana/cloudnativepg/*`; enables dashboards sidecar in `kustomize/observability/grafana/helm-release.yaml`.
> - **Schema updates**:
>   - Adds top-level `ha` flag.
>   - Extends `addons.database.postgres` with `enabled` and `driver` (`cloudnativepg`) in `contexts/_template/schema.yaml`.
> - **Kustomize scaffolding**:
>   - New `system-database` namespace (`kustomize/database/*`).
>   - Demo: `kustomize/demo/database/*` with a sample `Cluster` CR.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5968ec2e0ac0a1bf6849cacd4afd6c1d9852360. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->