### PR TITLE
fix(flux): Add reasonable timing parameters

### DIFF
--- a/contexts/_template/features/addon-database.yaml
+++ b/contexts/_template/features/addon-database.yaml
@@ -8,26 +8,28 @@ when: addons?.database?.postgres?.enabled == true || dev == true
 
 kustomize:
 
-  # CloudNativePG operator base
-  - name: database
-    path: database
-    when: addons?.database?.postgres?.driver == 'cloudnativepg' || dev == true
-    dependsOn:
-      - csi
-    components:
-      - cloudnativepg
-      - cloudnativepg/prometheus
+# CloudNativePG operator base
+- name: database
+  path: database
+  when: addons?.database?.postgres?.driver == 'cloudnativepg' || dev == true
+  timeout: 15m
+  interval: 10m
+  dependsOn:
+    - csi
+  components:
+    - cloudnativepg
+    - cloudnativepg/prometheus
 
-  # High availability configuration
-  - name: database
-    path: database
-    when: addons?.database?.postgres?.driver == 'cloudnativepg' && ha == true
-    components:
-      - cloudnativepg/ha
+# High availability configuration
+- name: database
+  path: database
+  when: addons?.database?.postgres?.driver == 'cloudnativepg' && ha == true
+  components:
+    - cloudnativepg/ha
 
-  # CloudNativePG Grafana dashboard
-  - name: observability
-    path: observability
-    when: addons?.database?.postgres?.driver == 'cloudnativepg' && addons?.observability?.enabled == true
-    components:
-      - grafana/cloudnativepg
+# CloudNativePG Grafana dashboard
+- name: observability
+  path: observability
+  when: addons?.database?.postgres?.driver == 'cloudnativepg' && addons?.observability?.enabled == true
+  components:
+    - grafana/cloudnativepg

--- a/contexts/_template/features/addon-object-store.yaml
+++ b/contexts/_template/features/addon-object-store.yaml
@@ -12,6 +12,8 @@ kustomize:
   - name: object-store-base
     path: object-store/base
     when: addons?.object_store?.driver == 'minio'
+    timeout: 10m
+    interval: 5m
     dependsOn:
       - csi
       - ingress

--- a/contexts/_template/features/addon-observability.yaml
+++ b/contexts/_template/features/addon-observability.yaml
@@ -7,77 +7,85 @@ metadata:
 when: addons?.observability?.enabled == true || dev == true
 
 kustomize:
-  # Dashboards
-  - name: observability
-    path: observability
-    dependsOn:
-      - ingress
-    components:
-      - grafana
-      - grafana/ingress
-      - grafana/prometheus
-      - grafana/node
-      - grafana/kubernetes
-      - grafana/flux
-    substitutions:
-      external_domain: ${dns?.domain}
 
-  # FluentD outputs
-  - name: observability
-    path: observability
-    when: addons?.observability?.logs_driver == 'stdout'
-    dependsOn:
-      - telemetry-base
-    components:
-      - fluentd
-      - fluentd/filters/otel
-      - fluentd/outputs/stdout
+# Dashboards
+- name: observability
+  path: observability
+  timeout: 15m
+  interval: 10m
+  dependsOn:
+    - ingress
+  components:
+    - grafana
+    - grafana/ingress
+    - grafana/prometheus
+    - grafana/node
+    - grafana/kubernetes
+    - grafana/flux
+  substitutions:
+    external_domain: ${dns?.domain}
 
-  # Quickwit log storage
-  - name: observability
-    path: observability
-    when: addons?.observability?.logs_driver == 'quickwit'
-    dependsOn:
-      - csi
-      - telemetry-base
-    components:
-      - fluentd
-      - fluentd/filters/otel
-      - fluentd/outputs/quickwit
-      - quickwit
-      - quickwit/pvc
-      - grafana/quickwit
+# FluentD outputs
+- name: observability
+  path: observability
+  when: addons?.observability?.logs_driver == 'stdout'
+  dependsOn:
+    - telemetry-base
+  components:
+    - fluentd
+    - fluentd/filters/otel
+    - fluentd/outputs/stdout
 
-  # Elasticsearch + Kibana
-  - name: observability
-    path: observability
-    when: addons?.observability?.logs_driver == 'elasticsearch'
-    dependsOn:
-      - csi
-      - ingress
-    components:
-      - elasticsearch
-      - kibana
-      - kibana/ingress
-    substitutions:
-      external_domain: ${dns?.domain}
+# Quickwit log storage
+- name: observability
+  path: observability
+  when: addons?.observability?.logs_driver == 'quickwit'
+  dependsOn:
+    - csi
+    - telemetry-base
+  components:
+    - fluentd
+    - fluentd/filters/otel
+    - fluentd/outputs/quickwit
+    - quickwit
+    - quickwit/pvc
+    - grafana/quickwit
 
-  # Elasticsearch telemetry
-  - name: telemetry-base
-    path: telemetry/base
-    when: addons?.observability?.logs_driver == 'elasticsearch'
-    strategy: replace
-    components:
-      - prometheus
-      - prometheus/flux
-      - filebeat
-  - name: telemetry-resources
-    path: telemetry/resources
-    when: addons?.observability?.logs_driver == 'elasticsearch'
-    strategy: replace
-    dependsOn:
-      - telemetry-base
-    components:
-      - metrics-server
-      - prometheus
-      - prometheus/flux
+# Elasticsearch + Kibana
+- name: observability
+  path: observability
+  when: addons?.observability?.logs_driver == 'elasticsearch'
+  dependsOn:
+    - csi
+    - ingress
+  components:
+    - elasticsearch
+    - kibana
+    - kibana/ingress
+  substitutions:
+    external_domain: ${dns?.domain}
+
+# Elasticsearch telemetry
+- name: telemetry-base
+  path: telemetry/base
+  when: addons?.observability?.logs_driver == 'elasticsearch'
+  timeout: 30m
+  interval: 10m
+  strategy: replace
+  components:
+    - prometheus
+    - prometheus/flux
+    - filebeat
+
+- name: telemetry-resources
+  path: telemetry/resources
+  when: addons?.observability?.logs_driver == 'elasticsearch'
+  timeout: 10m
+  interval: 5m
+  strategy: replace
+  dependsOn:
+    - telemetry-base
+  components:
+    - metrics-server
+    - prometheus
+    - prometheus/flux

--- a/contexts/_template/features/addon-private-ca.yaml
+++ b/contexts/_template/features/addon-private-ca.yaml
@@ -11,11 +11,15 @@ kustomize:
 # PKI
 - name: pki-base
   path: pki/base
+  timeout: 10m
+  interval: 5m
   components:
-  - trust-manager
+    - trust-manager
 - name: pki-resources
   path: pki/resources
   dependsOn:
-  - pki-base
+    - pki-base
+  timeout: 5m
+  interval: 5m
   components:
-  - private-issuer/ca
+    - private-issuer/ca

--- a/contexts/_template/features/addon-private-dns.yaml
+++ b/contexts/_template/features/addon-private-dns.yaml
@@ -7,30 +7,33 @@ metadata:
 when: addons?.private_dns?.enabled == true || dev == true
 
 kustomize:
-  # CoreDNS server for private DNS zones
-  - name: dns
-    path: dns
-    dependsOn:
-      - pki-base
-    components:
-      - coredns
-      - coredns/etcd
-      - external-dns
-      - external-dns/coredns
-      - external-dns/ingress
-    substitutions:
-      external_domain: ${dns?.domain}
 
-  - name: dns
-    path: dns
-    when: vm?.driver == 'docker-desktop'
-    components:
-      - external-dns/localhost
+# CoreDNS server for private DNS zones
+- name: dns
+  path: dns
+  dependsOn:
+    - pki-base
+  timeout: 10m
+  interval: 5m
+  components:
+    - coredns
+    - coredns/etcd
+    - external-dns
+    - external-dns/coredns
+    - external-dns/ingress
+  substitutions:
+    external_domain: ${dns?.domain}
 
-  - name: ingress
-    path: ingress
-    when: ingress?.enabled == true && ingress?.driver == 'nginx'
-    dependsOn:
-      - pki-base
-    components:
-      - nginx/coredns
+- name: dns
+  path: dns
+  when: vm?.driver == 'docker-desktop'
+  components:
+    - external-dns/localhost
+
+- name: ingress
+  path: ingress
+  when: ingress?.enabled == true && ingress?.driver == 'nginx'
+  dependsOn:
+    - pki-base
+  components:
+    - nginx/coredns

--- a/contexts/_template/features/base.yaml
+++ b/contexts/_template/features/base.yaml
@@ -12,38 +12,49 @@ kustomize:
 - name: policy-base
   path: policy/base
   components:
-  - kyverno
+    - kyverno
+  timeout: 30m
+  interval: 5m
+
 - name: policy-resources
   path: policy/resources
   dependsOn:
-  - policy-base
+    - policy-base
+  timeout: 5m
+  interval: 5m
 
 # PKI
 - name: pki-base
   path: pki/base
   dependsOn:
-  - policy-resources
+    - policy-resources
   components:
-  - cert-manager
+    - cert-manager
+  timeout: 20m
+  interval: 5m
 
 # Telemetry (metrics + logs with fluentbit by default)
 - name: telemetry-base
   path: telemetry/base
   components:
-  - prometheus
-  - prometheus/flux
-  - fluentbit
-  - fluentbit/prometheus
+    - prometheus
+    - prometheus/flux
+    - fluentbit
+    - fluentbit/prometheus
+  timeout: 30m
+  interval: 10m
 - name: telemetry-resources
   path: telemetry/resources
   dependsOn:
-  - telemetry-base
+    - telemetry-base
   components:
-  - metrics-server
-  - prometheus
-  - prometheus/flux
-  - fluentbit
-  - fluentbit/containerd
-  - fluentbit/fluentd
-  - fluentbit/kubernetes
-  - fluentbit/systemd
+    - metrics-server
+    - prometheus
+    - prometheus/flux
+    - fluentbit
+    - fluentbit/containerd
+    - fluentbit/fluentd
+    - fluentbit/kubernetes
+    - fluentbit/systemd
+  timeout: 10m
+  interval: 5m

--- a/contexts/_template/features/local-dev.yaml
+++ b/contexts/_template/features/local-dev.yaml
@@ -30,3 +30,5 @@ kustomize:
   - pki-base
   components:
   - nginx/nodeport
+  timeout: 10m
+  interval: 5m

--- a/contexts/_template/features/provider-aws.yaml
+++ b/contexts/_template/features/provider-aws.yaml
@@ -15,16 +15,16 @@ terraform:
 - name: cluster
   path: cluster/aws-eks
   dependsOn:
-  - network
+    - network
 - name: cluster-additions
   path: cluster/aws-eks/additions
   dependsOn:
-  - cluster
+    - cluster
   destroy: false
 - name: gitops
   path: gitops/flux
   dependsOn:
-  - cluster
+    - cluster
   destroy: false
 
 kustomize:
@@ -34,20 +34,24 @@ kustomize:
   path: ingress
   when: ingress?.enabled == true && ingress?.driver == 'nginx'
   dependsOn:
-  - pki-base
+    - pki-base
   components:
-  - nginx
-  - nginx/web
+    - nginx
+    - nginx/web
   cleanup:
-  - loadbalancers
-  - ingresses
+    - loadbalancers
+    - ingresses
+  timeout: 10m
+  interval: 5m
 
 # CSI
 - name: csi
   path: csi
   dependsOn:
-  - policy-resources
+    - policy-resources
   components:
-  - aws-ebs
+    - aws-ebs
+  timeout: 5m
+  interval: 5m
   substitutions:
     single_storage_type: ${cluster.storage?.single_storage_type ?? "gp3"}

--- a/contexts/_template/features/provider-azure.yaml
+++ b/contexts/_template/features/provider-azure.yaml
@@ -14,12 +14,12 @@ terraform:
 - name: cluster
   path: cluster/azure-aks
   dependsOn:
-  - network
+    - network
 - name: gitops
   path: gitops/flux
   destroy: false
   dependsOn:
-  - cluster
+    - cluster
 
 kustomize:
 
@@ -28,22 +28,26 @@ kustomize:
   path: ingress
   when: ingress?.enabled == true && ingress?.driver == 'nginx'
   dependsOn:
-  - pki-base
+    - pki-base
   components:
-  - nginx
-  - nginx/coredns
-  - nginx/web
+    - nginx
+    - nginx/coredns
+    - nginx/web
   cleanup:
-  - loadbalancers
-  - ingresses
+    - loadbalancers
+    - ingresses
+  timeout: 10m
+  interval: 5m
 
 # CSI
 - name: csi
   path: csi
   dependsOn:
-  - policy-resources
+    - policy-resources
   components:
-  - azure-disk
+    - azure-disk
+  timeout: 5m
+  interval: 5m
   substitutions:
     single_storage_type: ${cluster.storage?.single_storage_type ?? "StandardSSD_LRS"}
 
@@ -52,4 +56,6 @@ kustomize:
   path: telemetry/resources
   strategy: remove
   components:
-  - metrics-server
+    - metrics-server
+  timeout: 5m
+  interval: 5m

--- a/contexts/_template/features/provider-generic.yaml
+++ b/contexts/_template/features/provider-generic.yaml
@@ -21,7 +21,7 @@ terraform:
 - name: gitops
   path: gitops/flux
   dependsOn:
-  - cluster
+    - cluster
   destroy: false
 
 kustomize:
@@ -30,57 +30,67 @@ kustomize:
 - name: csi
   path: csi
   dependsOn:
-  - policy-resources
+    - policy-resources
   components:
-  - openebs
-  - openebs/dynamic-localpv
-  cleanup:
-  - pvcs
+    - openebs
+    - openebs/dynamic-localpv
   substitutions:
     local_volume_path: ${cluster.workers.volumes[0]}
+  cleanup:
+    - pvcs
+  timeout: 20m
+  interval: 5m
 
 # Load Balancer
 - name: lb-base
   path: lb/base
   when: vm?.driver != 'docker-desktop'
   dependsOn:
-  - policy-resources
+    - policy-resources
   components:
   - metallb
+  timeout: 10m
+  interval: 5m
 
 - name: lb-resources
   path: lb/resources
   when: vm?.driver != 'docker-desktop'
   dependsOn:
-  - lb-base
+    - lb-base
   components:
-  - metallb/layer2
+    - metallb/layer2
   substitutions:
     loadbalancer_ip: ${network.loadbalancer_ips.start}
+  timeout: 5m
+  interval: 5m
 
 # Ingress
 - name: ingress
   path: ingress
   when: vm?.driver != 'docker-desktop'
   dependsOn:
-  - pki-base
+    - pki-base
   components:
-  - nginx
-  - nginx/web
+    - nginx
+    - nginx/web
+  timeout: 10m
+  interval: 5m
   cleanup:
-  - loadbalancers
-  - ingresses
+    - loadbalancers
+    - ingresses
 
 # Ingress
 - name: ingress
   path: ingress
   when: ingress?.enabled == true && ingress?.driver == 'nginx'
   dependsOn:
-  - pki-base
+    - pki-base
   components:
-  - nginx
-  - nginx/coredns
-  - nginx/web
+    - nginx
+    - nginx/coredns
+    - nginx/web
   cleanup:
-  - loadbalancers
-  - ingresses
+    - loadbalancers
+    - ingresses
+  timeout: 10m
+  interval: 5m

--- a/kustomize/GUIDELINES.md
+++ b/kustomize/GUIDELINES.md
@@ -1,0 +1,79 @@
+# Kustomize Timeout and Interval Guidelines
+
+## Quick Reference
+
+### Timeout Formula
+
+```
+timeout = (number_of_images × 4-5min) + 50% buffer
+```
+
+| Images | Timeout |
+|--------|---------|
+| 1 | 10m |
+| 2 | 10m |
+| 3-4 | 20m |
+| 5+ | 30m |
+
+### Interval Guidelines
+
+| Component Type | Interval |
+|---------------|----------|
+| Critical path (blocks others) | 5m |
+| Standard | 5m |
+| Heavy/stable (Prometheus, Grafana, etc.) | 10m |
+| HelmRepositories | 10m |
+
+## HelmRelease Configuration
+
+### Counting Images
+
+Count all container images explicitly configured in the HelmRelease `values` section:
+- Main application image
+- Sidecar images
+- Init container images
+- Operator images (if separate from main)
+
+**Example:**
+```yaml
+values:
+  image:
+    tag: v1.0.0          # 1 image
+  sidecar:
+    image:
+      tag: v2.0.0        # +1 image = 2 total → 10m timeout
+```
+
+### Setting Timeout and Interval
+
+Configure in `kustomize/*/helm-release.yaml`:
+
+```yaml
+spec:
+  interval: 5m          # Standard: 5m, Heavy: 10m
+  timeout: 10m          # Based on image count (see table above)
+```
+
+## HelmRepository Configuration
+
+Set `interval: 10m` in all `kustomize/*/helm-repository.yaml` files:
+
+```yaml
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+spec:
+  interval: 10m
+```
+
+## Kustomization Configuration
+
+Set in `contexts/_template/features/*.yaml`:
+
+**Kustomization timeout = max(contained HelmRelease timeouts)**
+
+```yaml
+kustomize:
+- name: policy-base
+  timeout: 30m          # Max of contained HelmReleases
+  interval: 5m            # Standard: 5m, Heavy: 10m
+```

--- a/kustomize/csi/openebs/helm-release.yaml
+++ b/kustomize/csi/openebs/helm-release.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: system-csi
 spec:
   interval: 5m
-  timeout: 5m
+  timeout: 20m
   chart:
     spec:
       chart: openebs

--- a/kustomize/lb/base/metallb/helm-release.yaml
+++ b/kustomize/lb/base/metallb/helm-release.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: system-lb
 spec:
   interval: 5m
-  timeout: 5m
+  timeout: 10m
   chart:
     spec:
       chart: metallb

--- a/kustomize/observability/elasticsearch/helm-release.yaml
+++ b/kustomize/observability/elasticsearch/helm-release.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: system-observability
 spec:
   interval: 15m
+  timeout: 10m
   chart:
     spec:
       chart: elasticsearch

--- a/kustomize/observability/elasticsearch/helm-repository.yaml
+++ b/kustomize/observability/elasticsearch/helm-repository.yaml
@@ -4,5 +4,5 @@ metadata:
   name: elastic-elasticsearch
   namespace: system-observability
 spec:
-  interval: 1h
+  interval: 10m
   url: https://helm.elastic.co

--- a/kustomize/observability/fluentd/helm-release.yaml
+++ b/kustomize/observability/fluentd/helm-release.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: system-observability
 spec:
   interval: 5m
-  timeout: 5m
+  timeout: 20m
   chart:
     spec:
       chart: charts/fluent-operator

--- a/kustomize/observability/kibana/helm-release.yaml
+++ b/kustomize/observability/kibana/helm-release.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: system-observability
 spec:
   interval: 5m
+  timeout: 10m
   chart:
     spec:
       chart: kibana

--- a/kustomize/observability/kibana/helm-repository.yaml
+++ b/kustomize/observability/kibana/helm-repository.yaml
@@ -4,5 +4,5 @@ metadata:
   name: elastic-kibana
   namespace: system-observability
 spec:
-  interval: 1h
+  interval: 10m
   url: https://helm.elastic.co

--- a/kustomize/pki/base/cert-manager/helm-release.yaml
+++ b/kustomize/pki/base/cert-manager/helm-release.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: system-pki
 spec:
   interval: 5m
-  timeout: 5m
+  timeout: 20m
   chart:
     spec:
       chart: cert-manager

--- a/kustomize/policy/base/kyverno/helm-release.yaml
+++ b/kustomize/policy/base/kyverno/helm-release.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: system-policy
 spec:
   interval: 5m
-  timeout: 5m
+  timeout: 30m
   chart:
     spec:
       chart: kyverno

--- a/kustomize/telemetry/base/filebeat/helm-release.yaml
+++ b/kustomize/telemetry/base/filebeat/helm-release.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: system-telemetry
 spec:
   interval: 5m
+  timeout: 10m
   chart:
     spec:
       chart: filebeat

--- a/kustomize/telemetry/base/filebeat/helm-repository.yaml
+++ b/kustomize/telemetry/base/filebeat/helm-repository.yaml
@@ -4,5 +4,5 @@ metadata:
   name: elastic-filebeat
   namespace: system-telemetry
 spec:
-  interval: 1h
+  interval: 10m
   url: https://helm.elastic.co

--- a/kustomize/telemetry/base/fluentbit/helm-release.yaml
+++ b/kustomize/telemetry/base/fluentbit/helm-release.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: system-telemetry
 spec:
   interval: 5m
-  timeout: 5m
+  timeout: 20m
   chart:
     spec:
       chart: fluent-operator

--- a/kustomize/telemetry/base/prometheus/helm-release.yaml
+++ b/kustomize/telemetry/base/prometheus/helm-release.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: system-telemetry
 spec:
   interval: 5m
-  timeout: 5m
+  timeout: 30m
   chart:
     spec:
       chart: kube-prometheus-stack

--- a/kustomize/telemetry/resources/metrics-server/helm-release.yaml
+++ b/kustomize/telemetry/resources/metrics-server/helm-release.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: system-telemetry
 spec:
   interval: 5m
-  timeout: 5m
+  timeout: 10m
   chart:
     spec:
       chart: metrics-server


### PR DESCRIPTION
Timing parameters including intervals and timeouts have been adjusted based on a set of `GUIDELINES.md`. These guidelines should set reasonable timing parameters based on the magnitude of the helm chart or kustomization being deployed. Fixes timeouts when pulling uncached images or on slower networks.

Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 98d663ea8523afedc641090d9e79a4a987cda1b7. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->