### PR TITLE
chore(backend): Relocate backend.tfvars to context folder

### DIFF
--- a/terraform/backend/azurerm/main.tf
+++ b/terraform/backend/azurerm/main.tf
@@ -124,7 +124,7 @@ resource "local_file" "backend_config" {
     storage_account_name = azurerm_storage_account.this.name
     container_name       = azurerm_storage_container.this.name
   })
-  filename = "${var.context_path}/terraform/backend.tfvars"
+  filename = "${var.context_path}/backend.tfvars"
 }
 
 # User-assigned identity for CMK

--- a/terraform/backend/s3/main.tf
+++ b/terraform/backend/s3/main.tf
@@ -294,5 +294,5 @@ resource "local_file" "backend_config" {
     dynamodb_table = var.enable_dynamodb ? "terraform-state-locks-${var.context_id}" : ""
     kms_key_id     = var.enable_kms && var.kms_key_alias == "" ? aws_kms_key.terraform_state[0].arn : ""
   })
-  filename = "${var.context_path}/terraform/backend.tf"
+  filename = "${var.context_path}/backend.tfvars"
 }


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes where and how backend config files are written.
> 
> - AzureRM: changes `local_file.backend_config` output from `context_path/terraform/backend.tfvars` to `context_path/backend.tfvars`
> - S3: changes `local_file.backend_config` output from `context_path/terraform/backend.tf` to `context_path/backend.tfvars`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 587eb1e69fa386af2d5ea05919bc843beaf2e8f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->