### PR TITLE
fix(cluster/aws-eks): Fix reference to roles that aren't yet created

### DIFF
--- a/terraform/cluster/aws-eks/main.tf
+++ b/terraform/cluster/aws-eks/main.tf
@@ -250,10 +250,7 @@ resource "aws_kms_key_policy" "ebs_encryption_key" {
         Sid    = "Allow Auto Scaling service-linked roles to create grants",
         Effect = "Allow",
         Principal = {
-          AWS = [
-            "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling",
-            "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/eks.amazonaws.com/AWSServiceRoleForAmazonEKSNodegroup"
-          ]
+          AWS = "*"
         },
         Action = [
           "kms:CreateGrant"
@@ -262,6 +259,16 @@ resource "aws_kms_key_policy" "ebs_encryption_key" {
         Condition = {
           StringEquals = {
             "kms:ViaService" = "ec2.${data.aws_region.current.region}.amazonaws.com"
+          },
+          StringLike = {
+            "aws:PrincipalArn" = [
+              "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/autoscaling.amazonaws.com/*",
+              "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/eks.amazonaws.com/*",
+              "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/eks-nodegroup.amazonaws.com/*"
+            ]
+          },
+          Bool = {
+            "kms:GrantIsForAWSResource" = "true"
           }
         }
       }


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines KMS grants for EBS encryption to prevent referencing not-yet-created service-linked roles.
> 
> - In `terraform/cluster/aws-eks/main.tf` `aws_kms_key_policy` (EBS), change `Principal.AWS` from explicit ARNs to `*` and restrict with `Condition`:
>   - Keep `StringEquals` on `kms:ViaService` for EC2 in-region
>   - Add `StringLike` to match `aws:PrincipalArn` for `autoscaling`, `eks`, and `eks-nodegroup` service-linked roles
>   - Add `Bool` `kms:GrantIsForAWSResource = true`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f85ab3d0c07196b10789942ca9cab42a7a435e61. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->