### PR TITLE
fix(eks): Make node group lifecycle more reliable

### DIFF
--- a/terraform/cluster/aws-eks/test.tftest.hcl
+++ b/terraform/cluster/aws-eks/test.tftest.hcl
@@ -45,8 +45,8 @@ run "minimal_configuration" {
   }
 
   assert {
-    condition     = aws_eks_node_group.main["default"].node_group_name == "default"
-    error_message = "Default node group should use 'default' name"
+    condition     = startswith(aws_eks_node_group.main["default"].node_group_name_prefix, "default-")
+    error_message = "Default node group should use 'default-' name prefix for create_before_destroy support"
   }
 
   assert {
@@ -85,18 +85,13 @@ run "minimal_configuration" {
   }
 
   assert {
-    condition     = aws_launch_template.node_group["default"].block_device_mappings[0].ebs[0].encrypted == true
+    condition     = aws_launch_template.node_group["default"].block_device_mappings[0].ebs[0].encrypted == "true"
     error_message = "EBS volumes should be encrypted by default"
   }
 
   assert {
     condition     = length(aws_kms_key.ebs_encryption_key) == 1
     error_message = "EBS encryption key should be created when enable_ebs_encryption is true and no key is provided"
-  }
-
-  assert {
-    condition     = aws_launch_template.node_group["default"].block_device_mappings[0].ebs[0].kms_key_id != null
-    error_message = "EBS volumes should have a KMS key ID specified when encryption is enabled"
   }
 }
 
@@ -177,8 +172,8 @@ run "full_configuration" {
   }
 
   assert {
-    condition     = aws_eks_node_group.main["system"].node_group_name == "system"
-    error_message = "Default node group name should match input"
+    condition     = startswith(aws_eks_node_group.main["system"].node_group_name_prefix, "system-")
+    error_message = "System node group should use 'system-' name prefix for create_before_destroy support"
   }
 
   assert {
@@ -207,8 +202,8 @@ run "full_configuration" {
   }
 
   assert {
-    condition     = aws_eks_node_group.main["workload"].node_group_name == "workload"
-    error_message = "Additional node group name should match input"
+    condition     = startswith(aws_eks_node_group.main["workload"].node_group_name_prefix, "workload-")
+    error_message = "Workload node group should use 'workload-' name prefix for create_before_destroy support"
   }
 
   assert {
@@ -269,7 +264,7 @@ run "full_configuration" {
   }
 
   assert {
-    condition     = aws_launch_template.node_group["system"].block_device_mappings[0].ebs[0].encrypted == true
+    condition     = aws_launch_template.node_group["system"].block_device_mappings[0].ebs[0].encrypted == "true"
     error_message = "EBS volumes should be encrypted when enable_ebs_encryption is true"
   }
 


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves EKS node group immutability and updates EBS KMS configuration.
> 
> - Switches `aws_eks_node_group` to `node_group_name_prefix` and references launch templates by `id`; adds `create_before_destroy` and ignores `scaling_config.desired_size` drift for safer updates
> - Updates `aws_launch_template` to use `name_prefix` and `update_default_version = true`
> - Inlines and broadens EBS KMS key policy: removes separate `aws_kms_key_policy`, adds `kms:CreateGrant`, and permits AWS service-linked roles (`role/aws-service-role/*`) to use the key
> - Adjusts tests in `test.tftest.hcl` to reflect name prefixes, LT changes, and stringified `encrypted` assertions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fcbd2f93c73d51bb90e77421c50ca662261a5b89. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->