### PR TITLE
fix(compute/incus): Fix null ipv6 error

### DIFF
--- a/terraform/compute/incus/modules/instance/main.tf
+++ b/terraform/compute/incus/modules/instance/main.tf
@@ -22,7 +22,7 @@ locals {
   # - IPv6: wait if static IPv6 is set, or if wait_for_ipv6 is explicitly true (DHCP case, default false)
   # - This allows fine-grained control: IPv4-only, IPv6-only, or both
   wait_for_ipv4 = var.ipv4 != null || var.wait_for_ipv4
-  wait_for_ipv6 = var.ipv6 != null || (var.wait_for_ipv6 != null && var.wait_for_ipv6)
+  wait_for_ipv6 = var.ipv6 != null || coalesce(var.wait_for_ipv6, false)
 
   # Build device map for this instance, including network devices
   instance_devices = merge(


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes IPv6 wait condition in `terraform/compute/incus/modules/instance/main.tf`.
> 
> - Replaces `var.wait_for_ipv6 != null && var.wait_for_ipv6` with `coalesce(var.wait_for_ipv6, false)` in `local.wait_for_ipv6`, defaulting to false when unset
> - Prevents null handling errors and only waits for IPv6 when explicitly requested or when a static IPv6 is provided
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c90bbd3fe45385994e0bc72653fe57d6fed149c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->