### PR TITLE
feat(provider/talos): Make controlplane schedulable

### DIFF
--- a/contexts/_template/configs/talos-generic.jsonnet
+++ b/contexts/_template/configs/talos-generic.jsonnet
@@ -10,6 +10,7 @@ local provider = hlp.getString(context, "provider", "");
 local cluster = hlp.getObject(context, "cluster", {});
 local controlplaneNodes = hlp.getObject(context, "cluster.controlplanes.nodes", {});
 local workerNodes = hlp.getObject(context, "cluster.workers.nodes", {});
+local controlplaneSchedulable = hlp.getBool(context, "cluster.controlplanes.schedulable", false);
 
 // Get first controlplane node safely
 local nodeList = std.objectValues(controlplaneNodes);
@@ -100,7 +101,7 @@ local commonConfig = {
     extraManifests: [
       "https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml"
     ]
-  },
+  } + (if controlplaneSchedulable then { allowSchedulingOnControlPlanes: true } else {}),
   machine: machineConfig
 };
 

--- a/contexts/_template/facets/provider-generic.yaml
+++ b/contexts/_template/facets/provider-generic.yaml
@@ -14,7 +14,7 @@ terraform:
     cluster_endpoint: ${cluster.endpoint ?? ("https://" + split(values(cluster.controlplanes.nodes)[0].endpoint, ":")[0] + ":6443")}
     cluster_name: talos
     controlplanes: ${values(cluster.controlplanes.nodes)}
-    workers: ${values(cluster.workers.nodes)}
+    workers: "${cluster.workers?.nodes != null && (cluster.workers?.count ?? 0) > 0 ? values(cluster.workers.nodes) : []}"
     common_config_patches: ${jsonnet("../configs/talos-generic.jsonnet").common_config_patches}
     worker_config_patches: ${jsonnet("../configs/talos-generic.jsonnet").worker_config_patches}
     controlplane_config_patches: ${jsonnet("../configs/talos-generic.jsonnet").controlplane_config_patches}

--- a/contexts/_template/facets/provider-generic.yaml
+++ b/contexts/_template/facets/provider-generic.yaml
@@ -14,7 +14,7 @@ terraform:
     cluster_endpoint: ${cluster.endpoint ?? ("https://" + split(values(cluster.controlplanes.nodes)[0].endpoint, ":")[0] + ":6443")}
     cluster_name: talos
     controlplanes: ${values(cluster.controlplanes.nodes)}
-    workers: "${cluster.workers?.nodes != null && (cluster.workers?.count ?? 0) > 0 ? values(cluster.workers.nodes) : []}"
+    workers: "${(cluster.workers?.count ?? 0) > 0 ? values(cluster.workers.nodes) : []}"
     common_config_patches: ${jsonnet("../configs/talos-generic.jsonnet").common_config_patches}
     worker_config_patches: ${jsonnet("../configs/talos-generic.jsonnet").worker_config_patches}
     controlplane_config_patches: ${jsonnet("../configs/talos-generic.jsonnet").controlplane_config_patches}

--- a/contexts/_template/facets/provider-incus.yaml
+++ b/contexts/_template/facets/provider-incus.yaml
@@ -34,7 +34,7 @@ terraform:
           raw.qemu: -boot order=c,menu=off
       - name: worker
         role: worker
-        count: ${cluster.workers.count ?? 2}
+        count: ${cluster.workers.count ?? 0}
         ipv4: ${cidrhost(network.cidr_block, 20)}
         image: windsor:talos/v1.12.0/arm64
         type: virtual-machine

--- a/contexts/_template/schema.yaml
+++ b/contexts/_template/schema.yaml
@@ -149,6 +149,10 @@ properties:
             items:
               type: string
             description: Additional volume mounts for control planes
+          schedulable:
+            type: boolean
+            default: false
+            description: Allow scheduling workloads on control plane nodes (useful for single-node clusters or resource-constrained environments)
         additionalProperties: false
       workers:
         type: object
@@ -299,6 +303,13 @@ properties:
           remote:
             type: string
             description: Incus remote name (e.g., "colima-windsor-local" for Colima, "local" for direct Incus)
+          storage_pool:
+            type: string
+            description: Name of the storage pool to use for VM root disks. Defaults to 'local' for Colima (dir-backed), 'default' otherwise
+          storage_driver:
+            type: string
+            enum: [dir, zfs, btrfs, lvm, ceph]
+            description: Storage driver for pool creation. Only set if you want Terraform to create the pool. Omit to use existing pool. "dir" recommended for nested virtualization
         additionalProperties: false
     additionalProperties: false
 

--- a/contexts/_template/schema.yaml
+++ b/contexts/_template/schema.yaml
@@ -160,7 +160,7 @@ properties:
           count:
             type: integer
             minimum: 0
-            default: 2
+            default: 0
             description: Number of worker nodes
           instance_type:
             type: string


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces optional control-plane scheduling and zero-worker cluster support across templates and schema.
> 
> - Adds `cluster.controlplanes.schedulable` flag to schema and propagates to Talos via `allowSchedulingOnControlPlanes` in `talos-generic.jsonnet`
> - Supports zero-worker clusters: sets `workers.count` default to `0`, conditionally passes empty `workers` to `cluster/talos` (generic facet), and sets Incus worker instance `count` default to `0`
> - Extends Incus provider config with `storage_pool` and `storage_driver` fields in schema
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a0c1c42ae9c3b59ddd705465f405b1c8e186421. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->