### PR TITLE
feat(gitops): Support flux concurrency settings

### DIFF
--- a/contexts/_template/facets/local-dev.yaml
+++ b/contexts/_template/facets/local-dev.yaml
@@ -13,6 +13,7 @@ terraform:
     git_username: ${git.livereload.username}
     git_password: ${git.livereload.password}
     webhook_token: abcdef123456
+    concurrency: ${max(2, min(floor((cluster.controlplanes.cpu ?? 4) / 2), floor((cluster.controlplanes.memory ?? 4) / 2), 10))}
 
 kustomize:
 - name: pki-resources

--- a/contexts/_template/facets/provider-aws.yaml
+++ b/contexts/_template/facets/provider-aws.yaml
@@ -25,6 +25,8 @@ terraform:
   path: gitops/flux
   dependsOn:
     - cluster
+  inputs:
+    concurrency: 5
   destroy: false
 
 kustomize:

--- a/contexts/_template/facets/provider-azure.yaml
+++ b/contexts/_template/facets/provider-azure.yaml
@@ -20,6 +20,8 @@ terraform:
   destroy: false
   dependsOn:
     - cluster
+  inputs:
+    concurrency: 5
 
 kustomize:
 

--- a/contexts/_template/facets/provider-generic.yaml
+++ b/contexts/_template/facets/provider-generic.yaml
@@ -22,6 +22,8 @@ terraform:
   path: gitops/flux
   dependsOn:
     - cluster
+  inputs:
+    concurrency: ${max(2, min(floor((cluster.controlplanes.cpu ?? 4) / 2), floor((cluster.controlplanes.memory ?? 4) / 2), 10))}
   destroy: false
 
 kustomize:

--- a/contexts/_template/facets/provider-incus.yaml
+++ b/contexts/_template/facets/provider-incus.yaml
@@ -66,6 +66,8 @@ terraform:
   path: gitops/flux
   dependsOn:
   - cluster
+  inputs:
+    concurrency: ${max(2, min(floor((cluster.controlplanes.cpu ?? 4) / 2), floor((cluster.controlplanes.memory ?? 4) / 2), 10))}
   destroy: false
 
 kustomize:

--- a/terraform/gitops/flux/variables.tf
+++ b/terraform/gitops/flux/variables.tf
@@ -74,3 +74,9 @@ variable "webhook_token" {
   sensitive   = true
   default     = ""
 }
+
+variable "concurrency" {
+  description = "Number of concurrent reconciliations per Flux controller"
+  type        = number
+  default     = 2
+}


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces configurable concurrency for Flux controllers and propagates it across environments.
> 
> - Adds `variable "concurrency"` to `terraform/gitops/flux` and computes `local.requeue_interval` based on it
> - Updates Helm values to pass `--concurrent` and `--requeue-dependency` to `kustomizeController`, `helmController` (uses `max(2, var.concurrency - 1)`), and `sourceController`
> - Wires `inputs.concurrency` in facets: `local-dev` and `provider-{generic,incus}` compute from control plane CPU/memory; `provider-{aws,azure}` set to `5`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55bb28906a70d079a88eb4439a3d4a217b602947. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->