### PR TITLE
fix(provider/incus): Incus storage optimizations and updates

### DIFF
--- a/contexts/_template/facets/provider-incus.yaml
+++ b/contexts/_template/facets/provider-incus.yaml
@@ -15,12 +15,14 @@ terraform:
     network_name: "${vm?.driver == 'colima' ? 'incusbr0' : ''}"
     create_network: "${vm?.driver != 'colima'}"
     network_cidr: ${network.cidr_block}
+    storage_pool: "${providers?.incus?.storage_pool ?? (vm?.driver == 'colima' ? 'local' : 'default')}"
+    storage_driver: "${providers?.incus?.storage_driver ?? (vm?.driver == 'colima' ? 'dir' : null)}"
     instances:
       - name: controlplane
         role: controlplane
         count: ${cluster.controlplanes.count ?? 1}
         ipv4: ${cidrhost(network.cidr_block, 10)}
-        image: windsor:talos/v1.12.0/arm64
+        image: windsor:talos/v1.12.1/arm64
         type: virtual-machine
         description: Talos control plane node
         root_disk_size: ${string(cluster.controlplanes.root_disk_size ?? 30) + "GB"}
@@ -36,17 +38,17 @@ terraform:
         role: worker
         count: ${cluster.workers.count ?? 0}
         ipv4: ${cidrhost(network.cidr_block, 20)}
-        image: windsor:talos/v1.12.0/arm64
+        image: windsor:talos/v1.12.1/arm64
         type: virtual-machine
         description: Talos worker node
-        root_disk_size: ${string(cluster.workers.root_disk_size ?? 50) + "GB"}
+        root_disk_size: ${string(cluster.workers?.root_disk_size ?? 50) + "GB"}
         limits:
-          cpu: ${string(cluster.workers.cpu ?? 4)}
-          memory: ${string(cluster.workers.memory ?? 4) + "GB"}
-        disks: ${cluster.workers.disks ?? []}
+          cpu: ${string(cluster.workers?.cpu ?? 4)}
+          memory: ${string(cluster.workers?.memory ?? 4) + "GB"}
+        disks: ${cluster.workers?.disks ?? []}
         config:
-          user.hostname: ${values(cluster.workers.nodes)[0].hostname ?? "worker-1"}
-          environment.TALOSSKU: ${string(cluster.workers.cpu ?? 4) + "CPU-" + string(cluster.workers.memory ?? 4) + "GB"}
+          user.hostname: "${cluster.workers?.nodes != null ? (values(cluster.workers.nodes)[0].hostname ?? 'worker-1') : 'worker-1'}"
+          environment.TALOSSKU: "${string(cluster.workers?.cpu ?? 4) + 'CPU-' + string(cluster.workers?.memory ?? 4) + 'GB'}"
           raw.qemu: -boot order=c,menu=off
 
 - name: cluster
@@ -58,7 +60,7 @@ terraform:
     cluster_endpoint: ${cluster.endpoint ?? ("https://" + split(terraform_output("compute", "controlplanes")[0].endpoint, ":")[0] + ":6443")}
     cluster_name: talos
     controlplanes: ${terraform_output("compute", "controlplanes") ?? values(cluster.controlplanes.nodes)}
-    workers: ${terraform_output("compute", "workers") ?? values(cluster.workers.nodes)}
+    workers: "${terraform_output('compute', 'workers') ?? (cluster.workers?.nodes != null ? values(cluster.workers.nodes) : [])}"
     common_config_patches: ${jsonnet("../configs/talos-generic.jsonnet").common_config_patches}
     worker_config_patches: ${jsonnet("../configs/talos-generic.jsonnet").worker_config_patches}
     controlplane_config_patches: ${jsonnet("../configs/talos-generic.jsonnet").controlplane_config_patches}
@@ -81,9 +83,7 @@ kustomize:
   - openebs
   - openebs/dynamic-localpv
   substitutions:
-    local_volume_path: ${split(cluster.workers.volumes[0] ?? "/var/local", ":")[1] ?? split(cluster.workers.volumes[0] ?? "/var/local", ":")[0]}
-  cleanup:
-    - pvcs
+    local_volume_path: "${cluster.controlplanes?.schedulable == true ? split(cluster.controlplanes?.volumes[0] ?? '/var/local', ':')[len(split(cluster.controlplanes?.volumes[0] ?? '/var/local', ':')) - 1] : split(cluster.workers?.volumes[0] ?? '/var/local', ':')[len(split(cluster.workers?.volumes[0] ?? '/var/local', ':')) - 1]}"
   timeout: 20m
   interval: 5m
 

--- a/contexts/_template/facets/provider-incus.yaml
+++ b/contexts/_template/facets/provider-incus.yaml
@@ -14,7 +14,9 @@ terraform:
     network_name: "${vm?.driver == 'colima' ? 'incusbr0' : ''}"
     create_network: "${vm?.driver != 'colima'}"
     network_cidr: ${network.cidr_block}
-    storage_pools: "${vm?.driver == 'colima' ? {local: {driver: 'dir'}} : {}}"
+    storage_pools:
+      local:
+        driver: "${vm?.driver == 'colima' ? 'dir' : null}"
     instances:
       - name: controlplane
         role: controlplane

--- a/contexts/_template/facets/provider-incus.yaml
+++ b/contexts/_template/facets/provider-incus.yaml
@@ -11,12 +11,10 @@ terraform:
 - name: compute
   path: compute/incus
   inputs:
-    remote: ${providers?.incus?.remote ?? ""}
     network_name: "${vm?.driver == 'colima' ? 'incusbr0' : ''}"
     create_network: "${vm?.driver != 'colima'}"
     network_cidr: ${network.cidr_block}
-    storage_pool: "${providers?.incus?.storage_pool ?? (vm?.driver == 'colima' ? 'local' : 'default')}"
-    storage_driver: "${providers?.incus?.storage_driver ?? (vm?.driver == 'colima' ? 'dir' : null)}"
+    storage_pools: "${vm?.driver == 'colima' ? {local: {driver: 'dir'}} : {}}"
     instances:
       - name: controlplane
         role: controlplane
@@ -25,6 +23,7 @@ terraform:
         image: windsor:talos/v1.12.1/arm64
         type: virtual-machine
         description: Talos control plane node
+        storage_pool: "${vm?.driver == 'colima' ? 'local' : 'default'}"
         root_disk_size: ${string(cluster.controlplanes.root_disk_size ?? 30) + "GB"}
         limits:
           cpu: ${string(cluster.controlplanes.cpu ?? 2)}
@@ -41,6 +40,7 @@ terraform:
         image: windsor:talos/v1.12.1/arm64
         type: virtual-machine
         description: Talos worker node
+        storage_pool: "${vm?.driver == 'colima' ? 'local' : 'default'}"
         root_disk_size: ${string(cluster.workers?.root_disk_size ?? 50) + "GB"}
         limits:
           cpu: ${string(cluster.workers?.cpu ?? 4)}

--- a/contexts/_template/schema.yaml
+++ b/contexts/_template/schema.yaml
@@ -293,26 +293,6 @@ properties:
         description: Container/VM runtime
     additionalProperties: false
 
-  # Provider-specific configuration
-  providers:
-    type: object
-    properties:
-      incus:
-        type: object
-        properties:
-          remote:
-            type: string
-            description: Incus remote name (e.g., "colima-windsor-local" for Colima, "local" for direct Incus)
-          storage_pool:
-            type: string
-            description: Name of the storage pool to use for VM root disks. Defaults to 'local' for Colima (dir-backed), 'default' otherwise
-          storage_driver:
-            type: string
-            enum: [dir, zfs, btrfs, lvm, ceph]
-            description: Storage driver for pool creation. Only set if you want Terraform to create the pool. Omit to use existing pool. "dir" recommended for nested virtualization
-        additionalProperties: false
-    additionalProperties: false
-
   # Optional addons
   addons:
     type: object

--- a/terraform/compute/incus/main.tf
+++ b/terraform/compute/incus/main.tf
@@ -173,6 +173,8 @@ resource "incus_storage_volume" "disks" {
   }
 
   project = var.project
+
+  depends_on = [incus_storage_pool.main]
 }
 
 # =============================================================================

--- a/terraform/compute/incus/main.tf
+++ b/terraform/compute/incus/main.tf
@@ -100,7 +100,7 @@ resource "incus_image" "local" {
 # Create storage pools from configuration
 # The "default" pool is assumed to exist and need not be defined
 resource "incus_storage_pool" "pools" {
-  for_each = var.storage_pools
+  for_each = { for name, pool in var.storage_pools : name => pool if pool.driver != null }
 
   name   = each.key
   driver = each.value.driver
@@ -395,9 +395,10 @@ locals {
 
   # Collect all storage pool references from instances (root disk) and disks (type field)
   # The "default" pool is always valid (assumed to exist)
+  # Only pools with non-null drivers are valid (null driver = conditional skip)
   valid_pool_names = merge(
     { "default" = true },
-    { for name, _ in var.storage_pools : name => true }
+    { for name, pool in var.storage_pools : name => true if pool.driver != null }
   )
 
   # Find invalid pool references in instance storage_pool fields

--- a/terraform/compute/incus/modules/instance/main.tf
+++ b/terraform/compute/incus/modules/instance/main.tf
@@ -80,7 +80,7 @@ locals {
         properties = merge(
           {
             path = "/"
-            pool = "default"
+            pool = var.storage_pool
           },
           # VM-specific root disk properties
           var.type == "virtual-machine" ? {

--- a/terraform/compute/incus/modules/instance/variables.tf
+++ b/terraform/compute/incus/modules/instance/variables.tf
@@ -167,6 +167,12 @@ variable "root_disk_size" {
   default     = "10GB"
 }
 
+variable "storage_pool" {
+  description = "Storage pool to use for the root disk. Default: 'default'."
+  type        = string
+  default     = "default"
+}
+
 variable "qemu_args" {
   description = "QEMU command-line arguments for virtual machines (default: boot from disk, disable menu). Set to empty string to disable."
   type        = string

--- a/terraform/compute/incus/variables.tf
+++ b/terraform/compute/incus/variables.tf
@@ -138,9 +138,9 @@ variable "remote" {
 }
 
 variable "storage_pools" {
-  description = "Map of storage pools to create. Key is pool name, value contains driver, optional source, and config. Instances reference pools via storage_pool field, disks via type field. The 'default' pool is assumed to exist and need not be defined."
+  description = "Map of storage pools to create. Key is pool name, value contains driver, optional source, and config. Pools with null driver are skipped (allows conditional pool creation). The 'default' pool is assumed to exist."
   type = map(object({
-    driver = string                    # Storage driver: dir, zfs, btrfs, lvm, ceph
+    driver = optional(string)          # Storage driver: dir, zfs, btrfs, lvm, ceph. Null = skip pool creation.
     source = optional(string)          # Source device/path for the pool (driver-specific)
     size   = optional(string)          # Pool size (for loop-file backed pools)
     config = optional(map(string), {}) # Driver-specific configuration options
@@ -148,8 +148,8 @@ variable "storage_pools" {
   default = {}
   validation {
     condition = alltrue([
-      for name, pool in var.storage_pools : contains(["dir", "zfs", "btrfs", "lvm", "ceph"], pool.driver)
+      for name, pool in var.storage_pools : pool.driver == null || contains(["dir", "zfs", "btrfs", "lvm", "ceph"], pool.driver)
     ])
-    error_message = "All storage pool drivers must be one of: dir, zfs, btrfs, lvm, ceph"
+    error_message = "Storage pool drivers must be one of: dir, zfs, btrfs, lvm, ceph (or null to skip)"
   }
 }

--- a/terraform/compute/incus/variables.tf
+++ b/terraform/compute/incus/variables.tf
@@ -134,3 +134,19 @@ variable "remote" {
   type        = string
   default     = null
 }
+
+variable "storage_pool" {
+  description = "Name of the storage pool to use for instance root disks"
+  type        = string
+  default     = "default"
+}
+
+variable "storage_driver" {
+  description = "Storage driver to use when creating the pool. Set to null to use an existing pool. Valid drivers: dir, zfs, btrfs, lvm, ceph"
+  type        = string
+  default     = null
+  validation {
+    condition     = var.storage_driver == null || contains(["dir", "zfs", "btrfs", "lvm", "ceph"], var.storage_driver)
+    error_message = "Storage driver must be one of: dir, zfs, btrfs, lvm, ceph (or null to skip pool creation)"
+  }
+}


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces explicit storage management and validation across the Incus Terraform modules and updates blueprint templates.
> 
> - Add `storage_pools` input and create `incus_storage_pool` resources; pass per-instance `storage_pool` to module so root disk uses the selected pool; ensure volumes depend on pools
> - New preconditions validate instance/disk pool references; retain existing IP conflict/overflow checks; update module `depends_on`
> - Enhance disk handling: map generic `disks` to Incus pools/sizes and create `incus_storage_volume` as needed
> - Update `contexts/_template/facets/provider-incus.yaml`: add `storage_pools.local`, set instance `storage_pool`, null-safe worker fields, refine CSI `local_volume_path`, and bump Talos images to `v1.12.1`
> - Remove provider-specific `providers` block from `schema.yaml`
> - Extend `test.tftest.hcl` to cover storage pools (creation, drivers), invalid configurations, and undefined pool references
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2bd4a35d646a75fc77eb5c57ea7f51922bf0f2eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->