### PR TITLE
chore(observability): Vendor and patch grafana dashboards

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,12 +85,12 @@ jobs:
           # Regenerate vendored files from source.yaml definitions
           task dashboards
           
-          # Check if any files changed
-          if ! git diff --quiet; then
+          # Check if any files changed or new files created
+          if ! git diff --quiet || [ -n "$(git status --porcelain)" ]; then
             echo "::error::Vendored files are out of sync with source.yaml"
             echo ""
-            echo "Changed files:"
-            git diff --name-only
+            echo "Changed/untracked files:"
+            git status --short
             echo ""
             echo "Run 'task dashboards' locally and commit the changes."
             exit 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,6 +75,30 @@ jobs:
       - name: Run terraform fmt
         run: terraform fmt -check -recursive
 
+      - name: Install Task
+        uses: go-task/setup-task@0ab1b2a65bc55236a3bc64cde78f80e20e8885c2 # v1.0.0
+        with:
+          version: 3.x
+
+      - name: Validate vendored assets
+        run: |
+          # Regenerate vendored files from source.yaml definitions
+          task dashboards
+          
+          # Check if any files changed
+          if ! git diff --quiet; then
+            echo "::error::Vendored files are out of sync with source.yaml"
+            echo ""
+            echo "Changed files:"
+            git diff --name-only
+            echo ""
+            echo "Run 'task dashboards' locally and commit the changes."
+            exit 1
+          fi
+          
+          # Validate JSON and patch integrity
+          task dashboards:lint
+
       - name: Checkov GitHub Action
         uses: bridgecrewio/checkov-action@68260132005eaae0e6f84c7a73cc3b1532f678bf # v12.3058.0
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ contexts/**/.gcp/
 
 # macOS system files
 **/.DS_Store
+
+# IDE user config
+.cursor/
+.vscode/*.local.*

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -3,121 +3,13 @@ version: '3'
 tasks:
   dashboards:
     desc: Download and patch vendored assets from source.yaml files
-    silent: true
     cmds:
-      - cmd: |
-          # Find all source.yaml files in the repo
-          find . -name 'source.yaml' -type f | while read source_file; do
-            vendor_dir="$(dirname "$source_file")/"
-            
-            echo "Processing ${vendor_dir#./}..."
-            
-            # Parse upstream base URL
-            base_url=$(grep '^[[:space:]]*url:' "$source_file" | head -1 | awk '{print $2}')
-            [ -n "$base_url" ] && echo "  Upstream: $base_url"
-            
-            # Parse files and process each (export base_url for subshell)
-            export base_url vendor_dir
-            awk 'BEGIN { OFS="|" }
-              /^[[:space:]]+-[[:space:]]+name:/ { 
-                if (name) print name, (url ? url : "-"), (patch ? patch : "-")
-                name=$NF; url=""; patch=""
-              }
-              /^[[:space:]]+url:/ { url=$2 }
-              /^[[:space:]]+patch:/ { patch=$2 }
-              END { if (name) print name, (url ? url : "-"), (patch ? patch : "-") }
-            ' "$source_file" | while IFS='|' read file url patch; do
-              [ "$url" = "-" ] && url=""
-              [ "$patch" = "-" ] && patch=""
-              [ -z "$file" ] && continue
-              output="${vendor_dir}${file}"
-              
-              # Use explicit URL or construct from base
-              if [ -n "$url" ]; then
-                fetch_url="$url"
-              elif [ -n "$base_url" ]; then
-                fetch_url="${base_url}/${file}"
-              else
-                echo "  ERROR: No URL for $file"
-                continue
-              fi
-              
-              echo "  Fetching $file..."
-              upstream=$(curl -sL "$fetch_url")
-              
-              if [ -n "$patch" ] && [ -f "${vendor_dir}${patch}" ]; then
-                echo "  Applying ${patch}..."
-                echo "$upstream" | jq --argjson ops "$(cat "${vendor_dir}${patch}")" '
-                  reduce $ops[] as $op (.;
-                    ($op.path | split("/") | .[1:] | map(if test("^[0-9]+$") then tonumber else . end)) as $path |
-                    if $op.op == "replace" then setpath($path; $op.value)
-                    elif $op.op == "add" then setpath($path; $op.value)
-                    elif $op.op == "remove" then delpaths([$path])
-                    else .
-                    end
-                  )
-                ' > "$output"
-              else
-                echo "$upstream" > "$output"
-              fi
-              
-              # Escape Grafana variables to prevent Flux substitution
-              # $${var} becomes ${var} after Flux processing
-              sed -i '' 's/\${\([^}]*\)}/$\${\1}/g' "$output" 2>/dev/null || \
-              sed -i 's/\${\([^}]*\)}/$\${\1}/g' "$output"
-            done
-          done
-          echo "Done."
+      - scripts/vendor-dashboards.sh
 
   dashboards:lint:
     desc: Validate vendored JSON files and patch integrity
-    silent: true
     cmds:
-      - cmd: |
-          ERROR_FILE=$(mktemp)
-          echo 0 > "$ERROR_FILE"
-          
-          # Find all source.yaml files in the repo
-          find . -name 'source.yaml' -type f | while read source_file; do
-            vendor_dir="$(dirname "$source_file")/"
-            
-            echo "Validating ${vendor_dir#./}..."
-            
-            # Check all JSON files are valid
-            for json_file in "$vendor_dir"*.json; do
-              [ -f "$json_file" ] || continue
-              filename=$(basename "$json_file")
-              jq_err=$(jq . "$json_file" 2>&1 >/dev/null)
-              if [ -n "$jq_err" ]; then
-                echo "  ERROR: Invalid JSON in $filename"
-                echo $(( $(cat "$ERROR_FILE") + 1 )) > "$ERROR_FILE"
-              else
-                echo "  ✓ $filename: valid JSON"
-              fi
-            done
-            
-            # Check all patch files are valid JSON arrays
-            for patch_file in "$vendor_dir"patches/*.patch.json; do
-              [ -f "$patch_file" ] || continue
-              filename=$(basename "$patch_file")
-              if ! jq -e 'type == "array"' "$patch_file" >/dev/null 2>&1; then
-                echo "  ERROR: Patch must be JSON array: $filename"
-                echo $(( $(cat "$ERROR_FILE") + 1 )) > "$ERROR_FILE"
-              else
-                ops=$(jq 'length' "$patch_file")
-                echo "  ✓ $filename: $ops operations"
-              fi
-            done
-          done
-          
-          ERRORS=$(cat "$ERROR_FILE")
-          rm -f "$ERROR_FILE"
-          
-          if [ "$ERRORS" -gt 0 ]; then
-            echo "Validation failed with $ERRORS errors"
-            exit 1
-          fi
-          echo "All dashboards validated successfully"
+      - scripts/lint-dashboards.sh
 
   scan:
     desc: Scan for security vulnerabilities

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -74,7 +74,8 @@ tasks:
     silent: true
     cmds:
       - cmd: |
-          ERRORS=0
+          ERROR_FILE=$(mktemp)
+          echo 0 > "$ERROR_FILE"
           
           # Find all source.yaml files in the repo
           find . -name 'source.yaml' -type f | while read source_file; do
@@ -86,9 +87,10 @@ tasks:
             for json_file in "$vendor_dir"*.json; do
               [ -f "$json_file" ] || continue
               filename=$(basename "$json_file")
-              if ! jq empty "$json_file" 2>/dev/null; then
+              jq_err=$(jq . "$json_file" 2>&1 >/dev/null)
+              if [ -n "$jq_err" ]; then
                 echo "  ERROR: Invalid JSON in $filename"
-                ERRORS=$((ERRORS + 1))
+                echo $(( $(cat "$ERROR_FILE") + 1 )) > "$ERROR_FILE"
               else
                 echo "  ✓ $filename: valid JSON"
               fi
@@ -100,7 +102,7 @@ tasks:
               filename=$(basename "$patch_file")
               if ! jq -e 'type == "array"' "$patch_file" >/dev/null 2>&1; then
                 echo "  ERROR: Patch must be JSON array: $filename"
-                ERRORS=$((ERRORS + 1))
+                echo $(( $(cat "$ERROR_FILE") + 1 )) > "$ERROR_FILE"
               else
                 ops=$(jq 'length' "$patch_file")
                 echo "  ✓ $filename: $ops operations"
@@ -108,7 +110,10 @@ tasks:
             done
           done
           
-          if [ $ERRORS -gt 0 ]; then
+          ERRORS=$(cat "$ERROR_FILE")
+          rm -f "$ERROR_FILE"
+          
+          if [ "$ERRORS" -gt 0 ]; then
             echo "Validation failed with $ERRORS errors"
             exit 1
           fi

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,6 +1,119 @@
 version: '3'
 
 tasks:
+  dashboards:
+    desc: Download and patch vendored assets from source.yaml files
+    silent: true
+    cmds:
+      - cmd: |
+          # Find all source.yaml files in the repo
+          find . -name 'source.yaml' -type f | while read source_file; do
+            vendor_dir="$(dirname "$source_file")/"
+            
+            echo "Processing ${vendor_dir#./}..."
+            
+            # Parse upstream base URL
+            base_url=$(grep '^[[:space:]]*url:' "$source_file" | head -1 | awk '{print $2}')
+            [ -n "$base_url" ] && echo "  Upstream: $base_url"
+            
+            # Parse files and process each (export base_url for subshell)
+            export base_url vendor_dir
+            awk 'BEGIN { OFS="|" }
+              /^[[:space:]]+-[[:space:]]+name:/ { 
+                if (name) print name, (url ? url : "-"), (patch ? patch : "-")
+                name=$NF; url=""; patch=""
+              }
+              /^[[:space:]]+url:/ { url=$2 }
+              /^[[:space:]]+patch:/ { patch=$2 }
+              END { if (name) print name, (url ? url : "-"), (patch ? patch : "-") }
+            ' "$source_file" | while IFS='|' read file url patch; do
+              [ "$url" = "-" ] && url=""
+              [ "$patch" = "-" ] && patch=""
+              [ -z "$file" ] && continue
+              output="${vendor_dir}${file}"
+              
+              # Use explicit URL or construct from base
+              if [ -n "$url" ]; then
+                fetch_url="$url"
+              elif [ -n "$base_url" ]; then
+                fetch_url="${base_url}/${file}"
+              else
+                echo "  ERROR: No URL for $file"
+                continue
+              fi
+              
+              echo "  Fetching $file..."
+              upstream=$(curl -sL "$fetch_url")
+              
+              if [ -n "$patch" ] && [ -f "${vendor_dir}${patch}" ]; then
+                echo "  Applying ${patch}..."
+                echo "$upstream" | jq --argjson ops "$(cat "${vendor_dir}${patch}")" '
+                  reduce $ops[] as $op (.;
+                    ($op.path | split("/") | .[1:] | map(if test("^[0-9]+$") then tonumber else . end)) as $path |
+                    if $op.op == "replace" then setpath($path; $op.value)
+                    elif $op.op == "add" then setpath($path; $op.value)
+                    elif $op.op == "remove" then delpaths([$path])
+                    else .
+                    end
+                  )
+                ' > "$output"
+              else
+                echo "$upstream" > "$output"
+              fi
+              
+              # Escape Grafana variables to prevent Flux substitution
+              # $${var} becomes ${var} after Flux processing
+              sed -i '' 's/\${\([^}]*\)}/$\${\1}/g' "$output" 2>/dev/null || \
+              sed -i 's/\${\([^}]*\)}/$\${\1}/g' "$output"
+            done
+          done
+          echo "Done."
+
+  dashboards:lint:
+    desc: Validate vendored JSON files and patch integrity
+    silent: true
+    cmds:
+      - cmd: |
+          ERRORS=0
+          
+          # Find all source.yaml files in the repo
+          find . -name 'source.yaml' -type f | while read source_file; do
+            vendor_dir="$(dirname "$source_file")/"
+            
+            echo "Validating ${vendor_dir#./}..."
+            
+            # Check all JSON files are valid
+            for json_file in "$vendor_dir"*.json; do
+              [ -f "$json_file" ] || continue
+              filename=$(basename "$json_file")
+              if ! jq empty "$json_file" 2>/dev/null; then
+                echo "  ERROR: Invalid JSON in $filename"
+                ERRORS=$((ERRORS + 1))
+              else
+                echo "  ✓ $filename: valid JSON"
+              fi
+            done
+            
+            # Check all patch files are valid JSON arrays
+            for patch_file in "$vendor_dir"patches/*.patch.json; do
+              [ -f "$patch_file" ] || continue
+              filename=$(basename "$patch_file")
+              if ! jq -e 'type == "array"' "$patch_file" >/dev/null 2>&1; then
+                echo "  ERROR: Patch must be JSON array: $filename"
+                ERRORS=$((ERRORS + 1))
+              else
+                ops=$(jq 'length' "$patch_file")
+                echo "  ✓ $filename: $ops operations"
+              fi
+            done
+          done
+          
+          if [ $ERRORS -gt 0 ]; then
+            echo "Validation failed with $ERRORS errors"
+            exit 1
+          fi
+          echo "All dashboards validated successfully"
+
   scan:
     desc: Scan for security vulnerabilities
     silent: true

--- a/kustomize/observability/grafana/dashboards/.gitignore
+++ b/kustomize/observability/grafana/dashboards/.gitignore
@@ -1,0 +1,2 @@
+# Upstream files are fetched at build time from source.yaml
+*/upstream/

--- a/scripts/lint-dashboards.sh
+++ b/scripts/lint-dashboards.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Validate vendored JSON files and patch integrity
+# Usage: scripts/lint-dashboards.sh
+
+set -euo pipefail
+
+ERROR_FILE=$(mktemp)
+echo 0 > "$ERROR_FILE"
+trap 'rm -f "$ERROR_FILE"' EXIT
+
+# Find all source.yaml files in the repo
+find . -name 'source.yaml' -type f | while read source_file; do
+  vendor_dir="$(dirname "$source_file")/"
+  
+  echo "Validating ${vendor_dir#./}..."
+  
+  # Check all JSON files are valid
+  for json_file in "$vendor_dir"*.json; do
+    [ -f "$json_file" ] || continue
+    filename=$(basename "$json_file")
+    jq_err=$(jq . "$json_file" 2>&1 >/dev/null)
+    if [ -n "$jq_err" ]; then
+      echo "  ERROR: Invalid JSON in $filename"
+      echo $(( $(cat "$ERROR_FILE") + 1 )) > "$ERROR_FILE"
+    else
+      echo "  ✓ $filename: valid JSON"
+    fi
+  done
+  
+  # Check all patch files are valid JSON arrays
+  for patch_file in "$vendor_dir"patches/*.patch.json; do
+    [ -f "$patch_file" ] || continue
+    filename=$(basename "$patch_file")
+    if ! jq -e 'type == "array"' "$patch_file" >/dev/null 2>&1; then
+      echo "  ERROR: Patch must be JSON array: $filename"
+      echo $(( $(cat "$ERROR_FILE") + 1 )) > "$ERROR_FILE"
+    else
+      ops=$(jq 'length' "$patch_file")
+      echo "  ✓ $filename: $ops operations"
+    fi
+  done
+done
+
+ERRORS=$(cat "$ERROR_FILE")
+
+if [ "$ERRORS" -gt 0 ]; then
+  echo "Validation failed with $ERRORS errors"
+  exit 1
+fi
+
+echo "All dashboards validated successfully"

--- a/scripts/vendor-dashboards.sh
+++ b/scripts/vendor-dashboards.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Vendor dashboards from upstream sources defined in source.yaml files
+# Usage: scripts/vendor-dashboards.sh
+
+set -euo pipefail
+
+# Find all source.yaml files in the repo
+find . -name 'source.yaml' -type f | while read source_file; do
+  vendor_dir="$(dirname "$source_file")/"
+  
+  echo "Processing ${vendor_dir#./}..."
+  
+  # Parse upstream base URL
+  base_url=$(grep '^[[:space:]]*url:' "$source_file" | head -1 | awk '{print $2}')
+  [ -n "$base_url" ] && echo "  Upstream: $base_url"
+  
+  # Parse files and process each (export base_url for subshell)
+  export base_url vendor_dir
+  awk 'BEGIN { OFS="|" }
+    /^[[:space:]]+-[[:space:]]+name:/ { 
+      if (name) print name, (url ? url : "-"), (patch ? patch : "-")
+      name=$NF; url=""; patch=""
+    }
+    /^[[:space:]]+url:/ { url=$2 }
+    /^[[:space:]]+patch:/ { patch=$2 }
+    END { if (name) print name, (url ? url : "-"), (patch ? patch : "-") }
+  ' "$source_file" | while IFS='|' read file url patch; do
+    [ "$url" = "-" ] && url=""
+    [ "$patch" = "-" ] && patch=""
+    [ -z "$file" ] && continue
+    output="${vendor_dir}${file}"
+    
+    # Use explicit URL or construct from base
+    if [ -n "$url" ]; then
+      fetch_url="$url"
+    elif [ -n "$base_url" ]; then
+      fetch_url="${base_url}/${file}"
+    else
+      echo "  ERROR: No URL for $file"
+      continue
+    fi
+    
+    echo "  Fetching $file..."
+    upstream=$(curl -sL "$fetch_url")
+    
+    if [ -n "$patch" ] && [ -f "${vendor_dir}${patch}" ]; then
+      echo "  Applying ${patch}..."
+      echo "$upstream" | jq --argjson ops "$(cat "${vendor_dir}${patch}")" '
+        reduce $ops[] as $op (.;
+          ($op.path | split("/") | .[1:] | map(if test("^[0-9]+$") then tonumber else . end)) as $path |
+          if $op.op == "replace" then setpath($path; $op.value)
+          elif $op.op == "add" then setpath($path; $op.value)
+          elif $op.op == "remove" then delpaths([$path])
+          else .
+          end
+        )
+      ' > "$output"
+    else
+      echo "$upstream" > "$output"
+    fi
+    
+    # Escape Grafana variables to prevent Flux substitution
+    # $${var} becomes ${var} after Flux processing
+    sed -i '' 's/\${\([^}]*\)}/$\${\1}/g' "$output" 2>/dev/null || \
+    sed -i 's/\${\([^}]*\)}/$\${\1}/g' "$output"
+  done
+done
+
+echo "Done."

--- a/scripts/vendor-dashboards.sh
+++ b/scripts/vendor-dashboards.sh
@@ -55,7 +55,7 @@ find . -name 'source.yaml' -type f | while read -r source_file; do
           if $op.op == "replace" then setpath($path; $op.value)
           elif $op.op == "add" then setpath($path; $op.value)
           elif $op.op == "remove" then delpaths([$path])
-          else .
+          else error("Unsupported patch operation: \($op.op) at path \($op.path)")
           end
         )
       ' > "$output"


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Automates vendoring and validation of Grafana dashboards and integrates it into CI.
> 
> - Adds `scripts/vendor-dashboards.sh` to fetch dashboards from `source.yaml`, apply JSON patches via `jq`, and escape Grafana variables
> - Adds `scripts/lint-dashboards.sh` to validate JSON files, patch array structure, and referenced patch paths
> - Extends `Taskfile.yaml` with `dashboards` and `dashboards:lint` tasks
> - Updates CI workflow to install `go-task`, regenerate dashboards, detect drift, and run linting before security scans
> - Adds `.gitignore` rules for IDE configs and vendored `*/upstream/` directories
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f1784bd47f5e866e6f82a63e4cc8f661df31c64. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->