### PR TITLE
feat(observability): Parse logs and display on quickwit dashboards

### DIFF
--- a/contexts/_template/facets/addon-observability.yaml
+++ b/contexts/_template/facets/addon-observability.yaml
@@ -38,7 +38,7 @@ kustomize:
   path: observability
   when: addons?.observability?.logs_driver == 'stdout'
   dependsOn:
-    - telemetry-base
+    - telemetry-resources
   components:
     - fluentd
     - fluentd/filters/otel
@@ -50,7 +50,7 @@ kustomize:
   when: addons?.observability?.logs_driver == 'quickwit'
   dependsOn:
     - csi
-    - telemetry-base
+    - telemetry-resources
   components:
     - fluentd
     - fluentd/filters/otel

--- a/contexts/_template/facets/base.yaml
+++ b/contexts/_template/facets/base.yaml
@@ -70,6 +70,16 @@ kustomize:
     - fluentbit/containerd
     - fluentbit/fluentd
     - fluentbit/kubernetes
+    - fluentbit/parser/klog
+    - fluentbit/parser/coredns
+    - fluentbit/parser/json-structured
+    - fluentbit/parser/zerolog
+    - fluentbit/parser/logfmt
+    - fluentbit/parser/rust-tracing
+    - fluentbit/parser/nginx-access
+    - fluentbit/parser/grpc
+    - fluentbit/parser/fallback
+    - fluentbit/parser/service-name
     - fluentbit/systemd
   timeout: 10m
   interval: 5m

--- a/kustomize/observability/fluentd/filters/otel/clusterfilter.yaml
+++ b/kustomize/observability/fluentd/filters/otel/clusterfilter.yaml
@@ -9,14 +9,23 @@ spec:
     - recordTransformer:
         enableRuby: true
         renewRecord: false
-        removeKeys: "logtag,time,log,kubernetes"
+        removeKeys: "logtag,time,log,kubernetes,attr_http_request_method,attr_http_response_status_code,attr_url_path,attr_client_address,attr_http_request_duration,attr_server_address,attr_network_protocol_name,attr_network_peer_address"
         records:
           - key: timestamp_nanos
             value: |
               $${Time.parse(record["time"]).to_i * 1_000_000_000 + Time.parse(record["time"]).nsec}
+          - key: service_name
+            value: |
+              $${record["service_name"] || record.dig("kubernetes", "container_name") || ""}
+          - key: severity_text
+            value: |
+              $${record["severity_text"] || ""}
           - key: body
             value: |
-              $${{"message" => record["log"]}}
+              $${{"message" => (record["body"] || record["log"])}}
+          - key: attributes
+            value: |
+              $${attrs = {}; record.each { |k, v| attrs[k.sub("attr_", "").gsub("_", ".")] = v if k.start_with?("attr_") && v }; attrs.empty? ? nil : attrs}
           - key: resource_attributes
             value: |
-              $${{"pod_name" => record["kubernetes"]["pod_name"], "namespace_name" => record["kubernetes"]["namespace_name"], "container_name" => record["kubernetes"]["container_name"], "container_image_id" => record["kubernetes"]["docker_id"], "container_image" => record["kubernetes"]["container_image"]}}
+              $${{"k8s.namespace.name" => record.dig("kubernetes", "namespace_name"), "k8s.pod.name" => record.dig("kubernetes", "pod_name"), "k8s.container.name" => record.dig("kubernetes", "container_name"), "container.image.name" => record.dig("kubernetes", "container_image"), "container.image.id" => record.dig("kubernetes", "docker_id")}}

--- a/kustomize/observability/grafana/dashboards/quickwit/kustomization.yaml
+++ b/kustomize/observability/grafana/dashboards/quickwit/kustomization.yaml
@@ -22,7 +22,7 @@ configMapGenerator:
         grafana_dashboard: "1"
       annotations:
         grafana_folder: "Observability"
-  - name: grafana-dashboards-logs
+  - name: grafana-dashboards-quickwit-logs
     namespace: system-observability
     files:
       - logs.json

--- a/kustomize/observability/grafana/dashboards/quickwit/kustomization.yaml
+++ b/kustomize/observability/grafana/dashboards/quickwit/kustomization.yaml
@@ -1,7 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
-# Quickwit dashboards - vendored with patches
+# Quickwit dashboards
+# Infrastructure: indexers, searchers, metastore, ingesters (vendored)
+# Logs: logs.json (custom OTEL logs viewer)
+#
 # Run: task dashboards
 # See: source.yaml for provenance
 
@@ -19,3 +22,14 @@ configMapGenerator:
         grafana_dashboard: "1"
       annotations:
         grafana_folder: "Observability"
+  - name: grafana-dashboards-logs
+    namespace: system-observability
+    files:
+      - logs.json
+      - logs-stats.json
+    options:
+      disableNameSuffixHash: true
+      labels:
+        grafana_dashboard: "1"
+      annotations:
+        grafana_folder: "Logs"

--- a/kustomize/observability/grafana/dashboards/quickwit/logs-stats.json
+++ b/kustomize/observability/grafana/dashboards/quickwit/logs-stats.json
@@ -1,0 +1,857 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_QUICKWIT_LOGS",
+      "label": "Quickwit Logs",
+      "description": "Quickwit logs datasource",
+      "type": "datasource",
+      "pluginId": "quickwit-quickwit-datasource",
+      "pluginName": "Quickwit"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "quickwit-quickwit-datasource",
+      "name": "Quickwit",
+      "version": "0.4.0"
+    },
+    {
+      "type": "panel",
+      "id": "barchart",
+      "name": "Bar chart",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Log statistics and breakdown from Quickwit",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Overview",
+      "tooltip": "",
+      "type": "link",
+      "url": "/d/logs-overview-quickwit/logs-overview"
+    }
+  ],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "quickwit-quickwit-datasource",
+        "uid": "quickwit-logs"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 1,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.8,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "hidden",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "orientation": "horizontal",
+        "showValue": "auto",
+        "stacking": "none",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "quickwit-quickwit-datasource",
+            "uid": "quickwit-logs"
+          },
+          "metrics": [
+            {
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "bucketAggs": [
+            {
+              "id": "2",
+              "type": "terms",
+              "field": "service_name",
+              "settings": {
+                "order": "desc",
+                "size": "10",
+                "orderBy": "_count"
+              }
+            }
+          ],
+          "query": "*",
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 Services",
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "quickwit-quickwit-datasource",
+        "uid": "quickwit-logs"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 2,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.8,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "hidden",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "orientation": "horizontal",
+        "showValue": "auto",
+        "stacking": "none",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "quickwit-quickwit-datasource",
+            "uid": "quickwit-logs"
+          },
+          "metrics": [
+            {
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "bucketAggs": [
+            {
+              "id": "2",
+              "type": "terms",
+              "field": "resource_attributes.k8s.namespace.name",
+              "settings": {
+                "order": "desc",
+                "size": "10",
+                "orderBy": "_count"
+              }
+            }
+          ],
+          "query": "*",
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 Namespaces",
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "quickwit-quickwit-datasource",
+        "uid": "quickwit-logs"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "red",
+            "mode": "fixed"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 3,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.8,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "hidden",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "orientation": "horizontal",
+        "showValue": "auto",
+        "stacking": "none",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "quickwit-quickwit-datasource",
+            "uid": "quickwit-logs"
+          },
+          "metrics": [
+            {
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "bucketAggs": [
+            {
+              "id": "2",
+              "type": "terms",
+              "field": "service_name",
+              "settings": {
+                "order": "desc",
+                "size": "10",
+                "orderBy": "_count"
+              }
+            }
+          ],
+          "query": "severity_text:ERROR OR severity_text:FATAL",
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 Erroring Services",
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "quickwit-quickwit-datasource",
+        "uid": "quickwit-logs"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "orange",
+            "mode": "fixed"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 4,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.8,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "hidden",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "orientation": "horizontal",
+        "showValue": "auto",
+        "stacking": "none",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "quickwit-quickwit-datasource",
+            "uid": "quickwit-logs"
+          },
+          "metrics": [
+            {
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "bucketAggs": [
+            {
+              "id": "2",
+              "type": "terms",
+              "field": "service_name",
+              "settings": {
+                "order": "desc",
+                "size": "10",
+                "orderBy": "_count"
+              }
+            }
+          ],
+          "query": "severity_text:WARN",
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 Warning Services",
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "quickwit-quickwit-datasource",
+        "uid": "quickwit-logs"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "red",
+            "mode": "fixed"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": ["sum", "mean"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "quickwit-quickwit-datasource",
+            "uid": "quickwit-logs"
+          },
+          "metrics": [
+            {
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "bucketAggs": [
+            {
+              "id": "2",
+              "type": "date_histogram",
+              "field": "timestamp_nanos",
+              "settings": {
+                "interval": "auto"
+              }
+            }
+          ],
+          "query": "severity_text:ERROR OR severity_text:FATAL",
+          "refId": "A"
+        }
+      ],
+      "title": "Errors Over Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "quickwit-quickwit-datasource",
+        "uid": "quickwit-logs"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "orange",
+            "mode": "fixed"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": ["sum", "mean"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "quickwit-quickwit-datasource",
+            "uid": "quickwit-logs"
+          },
+          "metrics": [
+            {
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "bucketAggs": [
+            {
+              "id": "2",
+              "type": "date_histogram",
+              "field": "timestamp_nanos",
+              "settings": {
+                "interval": "auto"
+              }
+            }
+          ],
+          "query": "severity_text:WARN",
+          "refId": "A"
+        }
+      ],
+      "title": "Warnings Over Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "quickwit-quickwit-datasource",
+        "uid": "quickwit-logs"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": ["sum"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Total",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "quickwit-quickwit-datasource",
+            "uid": "quickwit-logs"
+          },
+          "metrics": [
+            {
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "bucketAggs": [
+            {
+              "id": "2",
+              "type": "terms",
+              "field": "service_name",
+              "settings": {
+                "order": "desc",
+                "size": "10",
+                "orderBy": "_count"
+              }
+            },
+            {
+              "id": "3",
+              "type": "date_histogram",
+              "field": "timestamp_nanos",
+              "settings": {
+                "interval": "auto"
+              }
+            }
+          ],
+          "query": "*",
+          "refId": "A"
+        }
+      ],
+      "title": "Log Volume by Service",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["logs", "quickwit", "stats"],
+  "templating": {
+    "list": [
+      {
+        "datasource": {
+          "type": "quickwit-quickwit-datasource",
+          "uid": "quickwit-logs"
+        },
+        "filters": [],
+        "hide": 0,
+        "label": "",
+        "name": "Filters",
+        "skipUrlSync": false,
+        "type": "adhoc"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Logs / Stats",
+  "uid": "logs-stats-quickwit",
+  "version": 1,
+  "weekStart": ""
+}

--- a/kustomize/observability/grafana/dashboards/quickwit/logs.json
+++ b/kustomize/observability/grafana/dashboards/quickwit/logs.json
@@ -1,0 +1,338 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_QUICKWIT_LOGS",
+      "label": "Quickwit Logs",
+      "description": "Quickwit logs datasource",
+      "type": "datasource",
+      "pluginId": "quickwit-quickwit-datasource",
+      "pluginName": "Quickwit"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "quickwit-quickwit-datasource",
+      "name": "Quickwit",
+      "version": "0.4.0"
+    },
+    {
+      "type": "panel",
+      "id": "logs",
+      "name": "Logs",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "barchart",
+      "name": "Bar chart",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Unified logs overview from Quickwit (otel-logs-v0_7)",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Stats",
+      "tooltip": "",
+      "type": "link",
+      "url": "/d/logs-stats-quickwit/logs-stats"
+    }
+  ],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "quickwit-quickwit-datasource",
+        "uid": "quickwit-logs"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ERROR"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "WARN"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "INFO"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "DEBUG"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": ["sum"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "quickwit-quickwit-datasource",
+            "uid": "quickwit-logs"
+          },
+          "metrics": [
+            {
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "bucketAggs": [
+            {
+              "id": "2",
+              "type": "terms",
+              "field": "severity_text",
+              "settings": {
+                "order": "desc",
+                "size": "10",
+                "orderBy": "_count"
+              }
+            },
+            {
+              "id": "3",
+              "type": "date_histogram",
+              "field": "timestamp_nanos",
+              "settings": {
+                "interval": "auto"
+              }
+            }
+          ],
+          "query": "*",
+          "refId": "A"
+        }
+      ],
+      "title": "Log Volume by Severity",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "quickwit-quickwit-datasource",
+        "uid": "quickwit-logs"
+      },
+      "gridPos": {
+        "h": 16,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "id": 6,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": true,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true,
+        "displayedFields": ["severity_text", "service_name", "resource_attributes.k8s.namespace.name", "body.message"]
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "quickwit-quickwit-datasource",
+            "uid": "quickwit-logs"
+          },
+          "metrics": [
+            {
+              "id": "1",
+              "type": "logs"
+            }
+          ],
+          "bucketAggs": [],
+          "query": "*",
+          "refId": "A"
+        }
+      ],
+      "title": "Logs",
+      "type": "logs"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["logs", "quickwit"],
+  "templating": {
+    "list": [
+      {
+        "datasource": {
+          "type": "quickwit-quickwit-datasource",
+          "uid": "quickwit-logs"
+        },
+        "filters": [],
+        "hide": 0,
+        "label": "",
+        "name": "Filters",
+        "skipUrlSync": false,
+        "type": "adhoc"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Logs / Overview",
+  "uid": "logs-overview-quickwit",
+  "version": 1,
+  "weekStart": ""
+}

--- a/kustomize/observability/grafana/quickwit/patches/helm-release.yaml
+++ b/kustomize/observability/grafana/quickwit/patches/helm-release.yaml
@@ -8,7 +8,97 @@ spec:
     - name: quickwit
       namespace: system-observability
   values:
-    plugins:
-      - quickwit-quickwit-datasource
-    # Dashboards are deployed via ConfigMap from vendored files
-    # See: kustomize/observability/grafana/dashboards/quickwit/
+    # Quickwit plugin installed via init container (not yet in Grafana catalog)
+    extraInitContainers:
+      - name: install-quickwit-plugin
+        # renovate: datasource=docker depName=alpine
+        image: alpine:3.21.5@sha256:5405e8f36ce1878720f71217d664aa3dea32e5e5df11acbf07fc78ef5661465b
+        env:
+          - name: PLUGIN_NAME
+            value: quickwit-quickwit-datasource
+          # renovate: datasource=github-releases depName=quickwit-oss/quickwit-datasource
+          - name: PLUGIN_VERSION
+            value: "0.5.0"
+          # SHA256 of quickwit-quickwit-datasource-0.5.0.zip - update when version changes
+          - name: PLUGIN_SHA256
+            value: c9a8f640c13cefce60ad458c4e4d5fe50b7c6851440d36a3f99fae6f55181b6c
+        args:
+          - $(PLUGIN_NAME)
+          - $(PLUGIN_VERSION)
+          - $(PLUGIN_SHA256)
+        command:
+          - /bin/sh
+          - -c
+          - |
+            set -eu
+            PLUGIN_NAME="$$0"
+            PLUGIN_VERSION="$$1"
+            PLUGIN_SHA256="$$2"
+            
+            # Install unzip if not present
+            if ! command -v unzip >/dev/null 2>&1; then
+              echo "Installing unzip..."
+              apk add --no-cache unzip
+            fi
+            PLUGIN_URL="https://github.com/quickwit-oss/quickwit-datasource/releases/download/v$${PLUGIN_VERSION}/$${PLUGIN_NAME}-$${PLUGIN_VERSION}.zip"
+            DEST_DIR="/plugins/$${PLUGIN_NAME}"
+            MAX_RETRIES=5
+
+            # Skip if already installed
+            if [ -d "$${DEST_DIR}" ]; then
+              echo "Plugin already installed, skipping"
+              exit 0
+            fi
+
+            # Download with retry and exponential backoff
+            attempt=1
+            delay=2
+            while [ $$attempt -le $$MAX_RETRIES ]; do
+              echo "Downloading $${PLUGIN_NAME} v$${PLUGIN_VERSION} (attempt $${attempt}/$${MAX_RETRIES})..."
+              if wget -q -O /tmp/plugin.zip "$${PLUGIN_URL}"; then
+                break
+              fi
+              if [ $$attempt -eq $$MAX_RETRIES ]; then
+                echo "ERROR: Download failed after $$MAX_RETRIES attempts"
+                exit 1
+              fi
+              echo "Download failed, retrying in $${delay}s..."
+              sleep $$delay
+              delay=$$((delay * 2))
+              attempt=$$((attempt + 1))
+            done
+
+            # Verify checksum
+            echo "Verifying SHA256 checksum..."
+            ACTUAL_SHA256=$$(sha256sum /tmp/plugin.zip | cut -d' ' -f1)
+            if [ "$${ACTUAL_SHA256}" != "$${PLUGIN_SHA256}" ]; then
+              echo "ERROR: Checksum mismatch!"
+              echo "Expected: $${PLUGIN_SHA256}"
+              echo "Actual:   $${ACTUAL_SHA256}"
+              exit 1
+            fi
+            echo "Checksum verified"
+
+            # Extract plugin
+            echo "Extracting plugin..."
+            unzip -q /tmp/plugin.zip -d /plugins
+            rm /tmp/plugin.zip
+            echo "Plugin installed successfully"
+        volumeMounts:
+          - name: plugins
+            mountPath: /plugins
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          runAsNonRoot: true
+          runAsUser: 472
+          runAsGroup: 472
+          capabilities:
+            drop:
+              - ALL
+    extraVolumeMounts:
+      - name: plugins
+        mountPath: /var/lib/grafana/plugins
+    extraVolumes:
+      - name: plugins
+        emptyDir: {}

--- a/kustomize/observability/grafana/quickwit/patches/patch.json
+++ b/kustomize/observability/grafana/quickwit/patches/patch.json
@@ -8,7 +8,9 @@
       "type": "quickwit-quickwit-datasource",
       "url": "http://quickwit-searcher.system-observability.svc.cluster.local:7280/api/v1",
       "jsonData": {
-        "index": "otel-logs-v0_7"
+        "index": "otel-logs-v0_7",
+        "logLevelField": "severity_text",
+        "logMessageField": "body.message"
       }
     }
   }

--- a/kustomize/observability/quickwit/helm-release.yaml
+++ b/kustomize/observability/quickwit/helm-release.yaml
@@ -20,5 +20,10 @@ spec:
     image:
       # renovate: datasource=docker depName=quickwit/quickwit package=quickwit/quickwit
       tag: v0.8.2@sha256:363ff56ce45614e46eba1c308e420f56a9f2fd8ab5788cbca0ec6b68a2e0ef92
+    environment:
+      # Disable ANSI color codes in log output
+      NO_COLOR: "1"
+      # Reduce log verbosity - warn for internal modules, info for main operations
+      RUST_LOG: "info,quickwit_search::leaf=warn,quickwit_search::root=warn,quickwit_indexing::actors=warn,tantivy=warn,hyper=warn,h2=warn,tower=warn"
     searcher:
       replicaCount: 1

--- a/kustomize/policy/base/kyverno/helm-release.yaml
+++ b/kustomize/policy/base/kyverno/helm-release.yaml
@@ -19,3 +19,24 @@ spec:
     image:
       # renovate: datasource=docker depName=ghcr.io/kyverno/kyverno package=ghcr.io/kyverno/kyverno
       tag: v3.6.0@sha256:89a052af62c612d0e05d2596f03edba77d7d904c4478b387a5dc6305821fe0a1
+    # Disable ANSI color codes in logs
+    admissionController:
+      container:
+        extraEnvVars:
+        - name: NO_COLOR
+          value: "1"
+    backgroundController:
+      container:
+        extraEnvVars:
+        - name: NO_COLOR
+          value: "1"
+    cleanupController:
+      container:
+        extraEnvVars:
+        - name: NO_COLOR
+          value: "1"
+    reportsController:
+      container:
+        extraEnvVars:
+        - name: NO_COLOR
+          value: "1"

--- a/kustomize/telemetry/resources/fluentbit/parser/coredns/coredns.lua
+++ b/kustomize/telemetry/resources/fluentbit/parser/coredns/coredns.lua
@@ -1,0 +1,68 @@
+-- CoreDNS log parser
+-- Formats:
+--   [INFO] plugin/kubernetes: message
+--   [WARNING] plugin/health: Local health request failed
+--   [INFO] 10.244.0.56:49016 - 44622 "A IN example.com. udp 44 false 1232" NXDOMAIN qr,rd,ra 33 0.321674073s
+
+-- OTEL severity number mapping
+local SEVERITY_MAP = {
+  INFO    = { text = "INFO",  number = 9 },
+  WARNING = { text = "WARN",  number = 13 },
+  ERROR   = { text = "ERROR", number = 17 },
+  DEBUG   = { text = "DEBUG", number = 5 },
+  FATAL   = { text = "FATAL", number = 21 }
+}
+
+function parse_coredns(tag, timestamp, record)
+  local log = record["log"]
+  if not log then return 0, timestamp, record end
+
+  -- Skip if already parsed (severity already set)
+  if record["severity_text"] and record["severity_text"] ~= "" then
+    return 0, timestamp, record
+  end
+
+  -- Match CoreDNS format: [LEVEL] message
+  local level, msg = log:match("^%[([A-Z]+)%]%s*(.*)$")
+
+  if not level then
+    return 0, timestamp, record
+  end
+
+  -- Validate this is a known CoreDNS severity
+  local sev = SEVERITY_MAP[level]
+  if not sev then
+    return 0, timestamp, record
+  end
+
+  record["severity_text"] = sev.text
+  record["severity_number"] = sev.number
+
+  -- Parse plugin name if present
+  local plugin, plugin_msg = msg:match("^plugin/([^:]+):%s*(.*)$")
+  if plugin then
+    -- No body.* extraction - schema doesn't support dynamic fields
+    record["body"] = plugin_msg
+  else
+    -- Check for DNS query log format
+    -- 10.244.0.56:49016 - 44622 "A IN example.com. udp 44 false 1232" NXDOMAIN qr,rd,ra 33 0.321s
+    local client_ip, client_port, query_id, query, rcode, duration = msg:match(
+      "^([%d%.]+):(%d+)%s+%-%s+(%d+)%s+\"([^\"]+)\"%s+(%S+)%s+%S+%s+%S+%s+([%d%.]+%a*)$"
+    )
+
+    if client_ip then
+      record["body"] = query
+      -- No body.* extraction - schema doesn't support dynamic fields
+
+      -- Parse query details: "A IN example.com. udp 44 false 1232"
+      local qtype, qclass, qname = query:match("^(%S+)%s+(%S+)%s+(%S+)")
+      if qtype then
+        -- No body.* extraction - schema doesn't support dynamic fields
+      end
+    else
+      record["body"] = msg
+    end
+  end
+
+  return 1, timestamp, record
+end

--- a/kustomize/telemetry/resources/fluentbit/parser/coredns/fluentbit-clusterfilter.yaml
+++ b/kustomize/telemetry/resources/fluentbit/parser/coredns/fluentbit-clusterfilter.yaml
@@ -1,0 +1,17 @@
+apiVersion: fluentbit.fluent.io/v1alpha2
+kind: ClusterFilter
+metadata:
+  labels:
+    fluentbit.fluent.io/component: logging
+    fluentbit.fluent.io/enabled: "true"
+  name: coredns
+spec:
+  ordinal: 10
+  match: kube.*
+  filters:
+  - lua:
+      call: parse_coredns
+      script:
+        key: coredns.lua
+        name: fluent-bit-coredns-config
+      timeAsTable: true

--- a/kustomize/telemetry/resources/fluentbit/parser/coredns/kustomization.yaml
+++ b/kustomize/telemetry/resources/fluentbit/parser/coredns/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# CoreDNS log parser
+# Matches: coredns pods in kube-system
+# Format: [INFO] plugin/kubernetes: message
+#         [INFO] 10.244.0.56:49016 - 44622 "A IN example.com..." NXDOMAIN ...
+
+resources:
+  - fluentbit-clusterfilter.yaml
+
+configMapGenerator:
+  - name: fluent-bit-coredns-config
+    namespace: system-telemetry
+    files:
+      - coredns.lua
+    options:
+      disableNameSuffixHash: true

--- a/kustomize/telemetry/resources/fluentbit/parser/fallback/fallback.lua
+++ b/kustomize/telemetry/resources/fluentbit/parser/fallback/fallback.lua
@@ -1,0 +1,81 @@
+-- Fallback parser for logs not matched by specific format parsers
+-- Handles: klog format (outside kube-system), bracketed format, default severity
+-- Does NOT parse: JSON, logfmt, rust-tracing (handled by dedicated parsers)
+
+-- OTEL severity number mapping
+local SEVERITY_MAP = {
+  TRACE = { text = "TRACE", number = 1 },
+  DEBUG = { text = "DEBUG", number = 5 },
+  INFO  = { text = "INFO",  number = 9 },
+  WARN  = { text = "WARN",  number = 13 },
+  ERROR = { text = "ERROR", number = 17 },
+  FATAL = { text = "FATAL", number = 21 }
+}
+
+local LEVEL_ALIASES = {
+  warning = "WARN",
+  warn = "WARN",
+  critical = "FATAL",
+  panic = "FATAL"
+}
+
+-- klog severity mapping (I=Info, W=Warning, E=Error, F=Fatal)
+local KLOG_SEVERITY = {
+  I = { text = "INFO",  number = 9 },
+  W = { text = "WARN",  number = 13 },
+  E = { text = "ERROR", number = 17 },
+  F = { text = "FATAL", number = 21 }
+}
+
+function parse_fallback(tag, timestamp, record)
+  local log = record["log"]
+  if not log then return 0, timestamp, record end
+
+  -- Skip if already parsed (severity already set by another parser)
+  if record["severity_text"] and record["severity_text"] ~= "" then
+    return 0, timestamp, record
+  end
+
+  -- Skip JSON logs - let json-structured handle them
+  if log:match("^%s*{") then
+    return 0, timestamp, record
+  end
+
+  -- Try klog format: I0123, W0123, E0123, F0123 at start of line
+  -- Format: [IWEF]MMDD HH:MM:SS.NNNNNN  PID file:line] message
+  local klog_level = log:match('^([IWEF])%d%d%d%d%s')
+  if klog_level then
+    local sev = KLOG_SEVERITY[klog_level]
+    if sev then
+      record["severity_text"] = sev.text
+      record["severity_number"] = sev.number
+      -- Extract message after "] "
+      local msg = log:match('%]%s*(.+)$')
+      record["body"] = msg or log
+      return 1, timestamp, record
+    end
+  end
+
+  -- Set body to full log if not already set
+  if not record["body"] then
+    record["body"] = log
+  end
+
+  -- Try bracketed format: [ info], [error], [ warn] (Fluent Bit format)
+  local bracketed = log:match('%[%s*([a-zA-Z]+)%]')
+  if bracketed then
+    local level = bracketed:upper()
+    level = LEVEL_ALIASES[bracketed:lower()] or level
+    local sev = SEVERITY_MAP[level]
+    if sev then
+      record["severity_text"] = sev.text
+      record["severity_number"] = sev.number
+      return 1, timestamp, record
+    end
+  end
+
+  -- No severity detected - default to INFO (most unstructured logs are informational)
+  record["severity_text"] = "INFO"
+  record["severity_number"] = 9
+  return 1, timestamp, record
+end

--- a/kustomize/telemetry/resources/fluentbit/parser/fallback/fluentbit-clusterfilter.yaml
+++ b/kustomize/telemetry/resources/fluentbit/parser/fallback/fluentbit-clusterfilter.yaml
@@ -1,0 +1,18 @@
+apiVersion: fluentbit.fluent.io/v1alpha2
+kind: ClusterFilter
+metadata:
+  labels:
+    fluentbit.fluent.io/component: logging
+    fluentbit.fluent.io/enabled: "true"
+  name: fallback
+spec:
+  # Run last - defaults severity for unrecognized formats
+  ordinal: 90
+  match: kube.*
+  filters:
+  - lua:
+      call: parse_fallback
+      script:
+        key: fallback.lua
+        name: fluent-bit-fallback-config
+      timeAsTable: true

--- a/kustomize/telemetry/resources/fluentbit/parser/fallback/kustomization.yaml
+++ b/kustomize/telemetry/resources/fluentbit/parser/fallback/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# Fallback parser for unrecognized log formats
+# Runs after all specific parsers, catches anything not yet parsed
+# Sets default OTEL fields for unstructured logs
+
+resources:
+  - fluentbit-clusterfilter.yaml
+
+configMapGenerator:
+  - name: fluent-bit-fallback-config
+    namespace: system-telemetry
+    files:
+      - fallback.lua
+    options:
+      disableNameSuffixHash: true

--- a/kustomize/telemetry/resources/fluentbit/parser/grpc/fluentbit-clusterfilter.yaml
+++ b/kustomize/telemetry/resources/fluentbit/parser/grpc/fluentbit-clusterfilter.yaml
@@ -1,0 +1,18 @@
+apiVersion: fluentbit.fluent.io/v1alpha2
+kind: ClusterFilter
+metadata:
+  labels:
+    fluentbit.fluent.io/component: logging
+    fluentbit.fluent.io/enabled: "true"
+  name: grpc
+spec:
+  # Runs after format parsers to clean gRPC prefixes from body
+  ordinal: 60
+  match: kube.*
+  filters:
+  - lua:
+      call: parse_grpc
+      script:
+        key: grpc.lua
+        name: fluent-bit-grpc-config
+      timeAsTable: true

--- a/kustomize/telemetry/resources/fluentbit/parser/grpc/grpc.lua
+++ b/kustomize/telemetry/resources/fluentbit/parser/grpc/grpc.lua
@@ -1,0 +1,51 @@
+-- gRPC-Go log parser
+-- Parses grpc-go logging format embedded in klog or other log formats
+-- Format: [LEVEL] [component] [Channel #N SubChannel #M]grpc: message
+-- OR:     error [core] [Channel #N]grpc: message
+-- Example: [core] [Channel #2512 SubChannel #2513]grpc: addrConn.createTransport failed...
+
+local SEVERITY_MAP = {
+  error = { text = "ERROR", number = 17 },
+  warn  = { text = "WARN",  number = 13 },
+  warning = { text = "WARN", number = 13 },
+  info  = { text = "INFO",  number = 9 },
+  debug = { text = "DEBUG", number = 5 }
+}
+
+function parse_grpc(tag, timestamp, record)
+  local log = record["log"]
+  local body = record["body"] or log
+  if not body then return 0, timestamp, record end
+
+  -- Check if this looks like a grpc log (contains "grpc:" or starts with [core], [transport], etc.)
+  if not body:match("grpc:") and not body:match("%[core%]") and not body:match("%[transport%]") then
+    return 0, timestamp, record
+  end
+
+  -- Try to extract severity from "error [core]" or "error[core]" pattern at start
+  -- Also handle body starting with severity (no prior extraction)
+  local level, rest = body:match("^%s*(%l+)%s*(%[.+)$")
+  if level and SEVERITY_MAP[level] then
+    local sev = SEVERITY_MAP[level]
+    if not record["severity_text"] or record["severity_text"] == "" or record["severity_text"] == "INFO" then
+      record["severity_text"] = sev.text
+      record["severity_number"] = sev.number
+    end
+    body = rest
+  end
+
+  -- Extract the actual message after "grpc:" (clean up grpc prefixes)
+  local grpc_msg = body:match("grpc:%s*(.+)$")
+  if grpc_msg then
+    record["body"] = grpc_msg
+  else
+    -- Fallback: strip leading brackets and component markers
+    local cleaned = body:gsub("^%[[^%]]*%]%s*", "") -- Remove first [...]
+    cleaned = cleaned:gsub("^%[[^%]]*%]%s*", "")    -- Remove second [...] if present
+    if cleaned ~= body then
+      record["body"] = cleaned
+    end
+  end
+
+  return 1, timestamp, record
+end

--- a/kustomize/telemetry/resources/fluentbit/parser/grpc/kustomization.yaml
+++ b/kustomize/telemetry/resources/fluentbit/parser/grpc/kustomization.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# gRPC-Go log parser
+# Matches: any kubernetes pod log containing grpc messages
+# Format: [core] [Channel #N SubChannel #M]grpc: message
+#
+# Runs after klog/fallback have extracted body from raw log.
+# Parses grpc-specific structure from body and extracts:
+#   - attributes.rpc.system: "grpc"
+#   - attributes.rpc.grpc.component: core, transport, balancer, etc.
+#   - attributes.rpc.grpc.channel_id: channel number
+#   - attributes.rpc.grpc.subchannel_id: subchannel number
+#   - attributes.rpc.grpc.target: target address
+#   - body: cleaned message without grpc prefixes
+
+resources:
+  - fluentbit-clusterfilter.yaml
+
+configMapGenerator:
+  - name: fluent-bit-grpc-config
+    namespace: system-telemetry
+    files:
+      - grpc.lua
+    options:
+      disableNameSuffixHash: true

--- a/kustomize/telemetry/resources/fluentbit/parser/json-structured/fluentbit-clusterfilter.yaml
+++ b/kustomize/telemetry/resources/fluentbit/parser/json-structured/fluentbit-clusterfilter.yaml
@@ -1,0 +1,17 @@
+apiVersion: fluentbit.fluent.io/v1alpha2
+kind: ClusterFilter
+metadata:
+  labels:
+    fluentbit.fluent.io/component: logging
+    fluentbit.fluent.io/enabled: "true"
+  name: json-structured
+spec:
+  ordinal: 30
+  match: kube.*
+  filters:
+  - lua:
+      call: parse_json_structured
+      script:
+        key: json-structured.lua
+        name: fluent-bit-json-structured-config
+      timeAsTable: true

--- a/kustomize/telemetry/resources/fluentbit/parser/json-structured/json-structured.lua
+++ b/kustomize/telemetry/resources/fluentbit/parser/json-structured/json-structured.lua
@@ -1,0 +1,145 @@
+-- JSON structured log parser
+-- Handles common JSON log formats: zap, logrus, zerolog, slog
+-- Uses cjson for full JSON parsing, extracts all fields generically
+--
+-- OTEL mapping:
+--   body        = message content (msg, message, error, err)
+--   body.*      = all other JSON fields (generic extraction)
+--   severity_*  = from level/severity/lvl field
+--   attributes  = OTEL semantic attributes (code.filepath, etc.)
+
+-- Try to load cjson (available in Fluent Bit's LuaJIT)
+local cjson_ok, cjson = pcall(require, "cjson.safe")
+
+-- OTEL severity number mapping
+local SEVERITY_MAP = {
+  trace   = { text = "TRACE", number = 1 },
+  debug   = { text = "DEBUG", number = 5 },
+  info    = { text = "INFO",  number = 9 },
+  warn    = { text = "WARN",  number = 13 },
+  warning = { text = "WARN",  number = 13 },
+  error   = { text = "ERROR", number = 17 },
+  fatal   = { text = "FATAL", number = 21 },
+  panic   = { text = "FATAL", number = 21 },
+  dpanic  = { text = "FATAL", number = 21 },
+  critical = { text = "FATAL", number = 21 }
+}
+
+-- Fields that map to severity
+local LEVEL_FIELDS = { level = true, severity = true, lvl = true, loglevel = true }
+
+-- Fields that map to body (message content)
+local MESSAGE_FIELDS = { msg = true, message = true }
+
+-- Fields to skip (metadata, timestamps)
+local SKIP_FIELDS = {
+  ts = true, time = true, timestamp = true, ["@timestamp"] = true,
+  level = true, severity = true, lvl = true, loglevel = true,
+  msg = true, message = true
+}
+
+-- No separate attribute extraction - all fields go to body.*
+-- The Quickwit OTEL schema requires attributes to be a proper object,
+-- which is complex to construct in Fluentd. All extracted fields go to body.
+local ATTRIBUTE_MAP = {}
+
+-- Fallback regex extraction (when cjson unavailable)
+local function extract_json_field(json, field)
+  local pattern = '"' .. field .. '"%s*:%s*"([^"]*)"'
+  return json:match(pattern)
+end
+
+function parse_json_structured(tag, timestamp, record)
+  local log = record["log"]
+  if not log then return 0, timestamp, record end
+
+  -- Skip if already parsed
+  if record["severity_text"] and record["severity_text"] ~= "" then
+    return 0, timestamp, record
+  end
+
+  -- Check if this looks like JSON
+  if not log:match("^%s*{") then
+    return 0, timestamp, record
+  end
+
+  -- Try cjson parsing
+  local data = nil
+  if cjson_ok then
+    data = cjson.decode(log)
+  end
+
+  if data then
+    -- Full JSON parsing with cjson
+    local level = nil
+    local msg = nil
+
+    -- First pass: extract level and message
+    for k, v in pairs(data) do
+      if type(v) == "string" then
+        if LEVEL_FIELDS[k] or LEVEL_FIELDS[k:lower()] then
+          level = v
+        elseif MESSAGE_FIELDS[k] or MESSAGE_FIELDS[k:lower()] then
+          msg = v
+        end
+      end
+    end
+
+    -- Must have a level to parse as structured
+    if not level then
+      return 0, timestamp, record
+    end
+
+    -- Map severity
+    local sev = SEVERITY_MAP[level:lower()]
+    if sev then
+      record["severity_text"] = sev.text
+      record["severity_number"] = sev.number
+    else
+      record["severity_text"] = level:upper()
+      record["severity_number"] = 9
+    end
+
+    -- Set body
+    record["body"] = msg or log
+
+    -- Second pass: extract all other fields
+    for k, v in pairs(data) do
+      if not SKIP_FIELDS[k] and not SKIP_FIELDS[k:lower()] then
+        -- Check if this maps to an OTEL attribute
+        local attr_fn = ATTRIBUTE_MAP[k]
+        if attr_fn and type(v) == "string" then
+          attr_fn(v, record)
+        end
+
+        -- Skip body.* extraction for now - schema doesn't support dynamic fields
+      end
+    end
+  else
+    -- Fallback: regex extraction for common fields
+    local level = extract_json_field(log, "level") or
+                  extract_json_field(log, "severity") or
+                  extract_json_field(log, "lvl")
+    if not level then
+      return 0, timestamp, record
+    end
+
+    local msg = extract_json_field(log, "msg") or
+                extract_json_field(log, "message")
+
+    local sev = SEVERITY_MAP[level:lower()]
+    if sev then
+      record["severity_text"] = sev.text
+      record["severity_number"] = sev.number
+    else
+      record["severity_text"] = level:upper()
+      record["severity_number"] = 9
+    end
+
+    record["body"] = msg or log
+
+    -- No body.* extraction - schema doesn't support dynamic fields
+  end
+
+  return 1, timestamp, record
+end

--- a/kustomize/telemetry/resources/fluentbit/parser/json-structured/kustomization.yaml
+++ b/kustomize/telemetry/resources/fluentbit/parser/json-structured/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# JSON structured log parser
+# Matches: Flux controllers, operators, and modern cloud-native apps
+# Format: {"level":"info","ts":"...","msg":"...","key":"value"}
+
+resources:
+  - fluentbit-clusterfilter.yaml
+
+configMapGenerator:
+  - name: fluent-bit-json-structured-config
+    namespace: system-telemetry
+    files:
+      - json-structured.lua
+    options:
+      disableNameSuffixHash: true

--- a/kustomize/telemetry/resources/fluentbit/parser/klog/fluentbit-clusterfilter.yaml
+++ b/kustomize/telemetry/resources/fluentbit/parser/klog/fluentbit-clusterfilter.yaml
@@ -1,0 +1,17 @@
+apiVersion: fluentbit.fluent.io/v1alpha2
+kind: ClusterFilter
+metadata:
+  labels:
+    fluentbit.fluent.io/component: logging
+    fluentbit.fluent.io/enabled: "true"
+  name: klog
+spec:
+  ordinal: 20
+  match: kube.*
+  filters:
+  - lua:
+      call: parse_klog
+      script:
+        key: klog.lua
+        name: fluent-bit-klog-config
+      timeAsTable: true

--- a/kustomize/telemetry/resources/fluentbit/parser/klog/klog.lua
+++ b/kustomize/telemetry/resources/fluentbit/parser/klog/klog.lua
@@ -1,0 +1,58 @@
+-- klog parser for Kubernetes components
+-- Format: <severity><MMDD> <HH:MM:SS.microseconds> <pid> <file>:<line>] <message>
+-- Examples:
+--   I0123 19:30:55.954002       1 shared_informer.go:356] "Caches are synced"
+--   W0123 19:40:33.804067       1 logging.go:55] [core] grpc: message...
+--   E0123 19:30:31.251850       1 reflector.go:158] "Unhandled Error" err="..."
+
+-- OTEL severity number mapping (https://opentelemetry.io/docs/specs/otel/logs/data-model/#severity-fields)
+local SEVERITY_MAP = {
+  I = { text = "INFO",  number = 9 },
+  W = { text = "WARN",  number = 13 },
+  E = { text = "ERROR", number = 17 },
+  D = { text = "DEBUG", number = 5 },
+  F = { text = "FATAL", number = 21 }
+}
+
+function parse_klog(tag, timestamp, record)
+  local log = record["log"]
+  if not log then return 0, timestamp, record end
+
+  -- Skip if already parsed (severity already set)
+  if record["severity_text"] and record["severity_text"] ~= "" then
+    return 0, timestamp, record
+  end
+
+  -- Match klog format: <sev><MMDD> <time> <pid> <file>:<line>] <msg>
+  -- Pattern: single char + 4 digits + space + time
+  local sev_char = log:sub(1, 1)
+  local mmdd = log:sub(2, 5)
+
+  -- Validate this is klog format
+  if not SEVERITY_MAP[sev_char] or not mmdd:match("^%d%d%d%d$") then
+    return 0, timestamp, record
+  end
+
+  -- Extract components
+  local time_str, pid, file, line, msg = log:match(
+    "^.%d%d%d%d%s+(%d%d:%d%d:%d%d%.%d+)%s+(%d+)%s+([^:]+):(%d+)%]%s*(.*)$"
+  )
+
+  if not msg then
+    -- Fallback: just extract severity and treat rest as message
+    msg = log:sub(22) -- Skip "X0123 HH:MM:SS.xxxxxx "
+    if msg:match("^%s*%d+%s+") then
+      msg = msg:match("^%s*%d+%s+(.*)$") or msg
+    end
+  end
+
+  -- Set OTEL fields
+  local sev = SEVERITY_MAP[sev_char]
+  record["severity_text"] = sev.text
+  record["severity_number"] = sev.number
+  record["body"] = msg or log
+
+  -- No body.* extraction - schema doesn't support dynamic fields
+
+  return 1, timestamp, record
+end

--- a/kustomize/telemetry/resources/fluentbit/parser/klog/kustomization.yaml
+++ b/kustomize/telemetry/resources/fluentbit/parser/klog/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# klog parser for Kubernetes system components
+# Matches: kube-apiserver, kube-controller-manager, kube-scheduler, kube-proxy, etc.
+# Format: I0123 19:30:55.954002 1 file.go:356] message
+
+resources:
+  - fluentbit-clusterfilter.yaml
+
+configMapGenerator:
+  - name: fluent-bit-klog-config
+    namespace: system-telemetry
+    files:
+      - klog.lua
+    options:
+      disableNameSuffixHash: true

--- a/kustomize/telemetry/resources/fluentbit/parser/kustomization.yaml
+++ b/kustomize/telemetry/resources/fluentbit/parser/kustomization.yaml
@@ -1,0 +1,38 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# Fluent Bit log parsers
+#
+# NOTE: Facets should reference individual parsers, not this bundle.
+# This file exists for local testing: `kubectl kustomize .../parser`
+#
+# Example facet components:
+#   - fluentbit/parser/klog
+#   - fluentbit/parser/coredns
+#   - fluentbit/parser/json-structured
+#   - fluentbit/parser/zerolog
+#   - fluentbit/parser/logfmt
+#   - fluentbit/parser/rust-tracing
+#   - fluentbit/parser/nginx-access
+#   - fluentbit/parser/grpc
+#   - fluentbit/parser/fallback
+#   - fluentbit/parser/service-name
+#
+# Format-specific parsers extract structured OTEL fields from known log formats.
+# Each parser sets:
+#   - body: The log message content
+#   - severity_text: String severity (INFO, WARN, ERROR, etc.)
+#   - severity_number: OTEL numeric severity (1-24)
+#   - attributes.*: Format-specific structured fields
+
+components:
+  - coredns
+  - klog
+  - json-structured
+  - zerolog
+  - logfmt
+  - rust-tracing
+  - nginx-access
+  - grpc
+  - fallback
+  - service-name

--- a/kustomize/telemetry/resources/fluentbit/parser/logfmt/fluentbit-clusterfilter.yaml
+++ b/kustomize/telemetry/resources/fluentbit/parser/logfmt/fluentbit-clusterfilter.yaml
@@ -1,0 +1,17 @@
+apiVersion: fluentbit.fluent.io/v1alpha2
+kind: ClusterFilter
+metadata:
+  labels:
+    fluentbit.fluent.io/component: logging
+    fluentbit.fluent.io/enabled: "true"
+  name: logfmt
+spec:
+  ordinal: 40
+  match: kube.*
+  filters:
+  - lua:
+      call: parse_logfmt
+      script:
+        key: logfmt.lua
+        name: fluent-bit-logfmt-config
+      timeAsTable: true

--- a/kustomize/telemetry/resources/fluentbit/parser/logfmt/kustomization.yaml
+++ b/kustomize/telemetry/resources/fluentbit/parser/logfmt/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# Logfmt log parser
+# Matches: Go services using key=value logging (client-go, controller-runtime)
+# Format: ts=... level=info caller=... msg="message"
+#
+# Extracts:
+#   - severity_text/number: from level= field
+#   - body: from msg= field
+
+resources:
+  - fluentbit-clusterfilter.yaml
+
+configMapGenerator:
+  - name: fluent-bit-logfmt-config
+    namespace: system-telemetry
+    files:
+      - logfmt.lua
+    options:
+      disableNameSuffixHash: true

--- a/kustomize/telemetry/resources/fluentbit/parser/logfmt/logfmt.lua
+++ b/kustomize/telemetry/resources/fluentbit/parser/logfmt/logfmt.lua
@@ -1,0 +1,70 @@
+-- Logfmt log parser
+-- Format: key=value key2="value with spaces" key3=value3
+-- Examples:
+--   ts=2026-01-23T21:04:56.097Z level=info caller=/go/pkg/mod/... msg="Warning: v1 Endpoints..."
+--   level=error time=2026-01-23T21:00:00Z msg="connection failed" err="timeout"
+--
+-- Common in: Go services (client-go, controller-runtime, etc.)
+
+-- OTEL severity number mapping
+local SEVERITY_MAP = {
+  TRACE = { text = "TRACE", number = 1 },
+  DEBUG = { text = "DEBUG", number = 5 },
+  INFO  = { text = "INFO",  number = 9 },
+  WARN  = { text = "WARN",  number = 13 },
+  ERROR = { text = "ERROR", number = 17 },
+  FATAL = { text = "FATAL", number = 21 }
+}
+
+local LEVEL_ALIASES = {
+  warning = "WARN",
+  warn = "WARN",
+  critical = "FATAL",
+  panic = "FATAL"
+}
+
+function parse_logfmt(tag, timestamp, record)
+  local log = record["log"]
+  if not log then return 0, timestamp, record end
+
+  -- Skip if already parsed
+  if record["severity_text"] and record["severity_text"] ~= "" then
+    return 0, timestamp, record
+  end
+
+  -- Skip JSON logs
+  if log:match("^%s*{") then
+    return 0, timestamp, record
+  end
+
+  -- Match logfmt: level= or level:
+  local level = log:match('level[=:]%s*"?([a-zA-Z]+)"?')
+  if not level then
+    return 0, timestamp, record
+  end
+
+  -- Normalize level
+  local normalized = level:upper()
+  normalized = LEVEL_ALIASES[level:lower()] or normalized
+
+  local sev = SEVERITY_MAP[normalized]
+  if not sev then
+    return 0, timestamp, record
+  end
+
+  record["severity_text"] = sev.text
+  record["severity_number"] = sev.number
+
+  -- Extract msg= value for body (handles quoted and unquoted)
+  local msg = log:match('msg="([^"]+)"') or
+              log:match("msg='([^']+)'") or
+              log:match('msg=([^%s]+)')
+
+  if msg then
+    record["body"] = msg
+  else
+    record["body"] = log
+  end
+
+  return 1, timestamp, record
+end

--- a/kustomize/telemetry/resources/fluentbit/parser/nginx-access/fluentbit-clusterfilter.yaml
+++ b/kustomize/telemetry/resources/fluentbit/parser/nginx-access/fluentbit-clusterfilter.yaml
@@ -1,0 +1,17 @@
+apiVersion: fluentbit.fluent.io/v1alpha2
+kind: ClusterFilter
+metadata:
+  labels:
+    fluentbit.fluent.io/component: logging
+    fluentbit.fluent.io/enabled: "true"
+  name: nginx-access
+spec:
+  ordinal: 50
+  match: kube.*
+  filters:
+  - lua:
+      call: parse_nginx_access
+      script:
+        key: nginx-access.lua
+        name: fluent-bit-nginx-access-config
+      timeAsTable: true

--- a/kustomize/telemetry/resources/fluentbit/parser/nginx-access/kustomization.yaml
+++ b/kustomize/telemetry/resources/fluentbit/parser/nginx-access/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# nginx-ingress access log parser
+# Matches: nginx-ingress controller pods
+# Format: Combined log format with ingress extensions
+#
+# Extracts:
+#   - severity_text: based on HTTP status (5xx=ERROR, 4xx=WARN, else INFO)
+#   - body: "METHOD /path STATUS TIME → upstream (upstream_status)"
+#
+# OTEL HTTP semantic conventions applied for filtering/querying
+
+resources:
+  - fluentbit-clusterfilter.yaml
+
+configMapGenerator:
+  - name: fluent-bit-nginx-access-config
+    namespace: system-telemetry
+    files:
+      - nginx-access.lua
+    options:
+      disableNameSuffixHash: true

--- a/kustomize/telemetry/resources/fluentbit/parser/nginx-access/nginx-access.lua
+++ b/kustomize/telemetry/resources/fluentbit/parser/nginx-access/nginx-access.lua
@@ -1,0 +1,117 @@
+-- nginx-ingress access log parser
+-- Handles both HTTP and Stream (TCP/UDP) log formats
+--
+-- HTTP Format: $remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent
+--              "$http_referer" "$http_user_agent" $request_length $request_time
+--              [$proxy_upstream_name] [$proxy_alternative_upstream_name]
+--              $upstream_addr $upstream_response_length $upstream_response_time $upstream_status $req_id
+--
+-- Stream Format: [$remote_addr] [$time_local] $protocol $status $bytes_sent $bytes_received $session_time
+--
+-- HTTP Example:
+-- 10.244.0.1 - - [23/Jan/2026:21:47:21 +0000] "POST /api/ds/query HTTP/2.0" 200 6129 "https://..." "Mozilla/5.0" 500 0.094 [system-observability-grafana-80] [] 10.244.0.98:3000 6142 0.094 200 abc123
+--
+-- Stream Example:
+-- [10.244.0.1] [23/Jan/2026:22:39:25 +0000] UDP 200 58 30 0.004
+--
+-- Extracts OTEL semantic conventions
+
+-- Severity based on HTTP status code
+local function status_to_severity(status)
+  local code = tonumber(status)
+  if not code then return "INFO", 9 end
+
+  if code >= 500 then
+    return "ERROR", 17
+  elseif code >= 400 then
+    return "WARN", 13
+  else
+    return "INFO", 9
+  end
+end
+
+function parse_nginx_access(tag, timestamp, record)
+  local log = record["log"]
+  if not log then return 0, timestamp, record end
+
+  -- Skip if already parsed
+  if record["severity_text"] and record["severity_text"] ~= "" then
+    return 0, timestamp, record
+  end
+
+  -- Try Stream format first: [IP] [timestamp] PROTO STATUS bytes_sent bytes_recv duration
+  local stream_ip, stream_proto, stream_status, bytes_sent, bytes_recv, session_time =
+    log:match('^%[([%d%.]+)%]%s+%[[^%]]+%]%s+([A-Z]+)%s+(%d+)%s+(%d+)%s+(%d+)%s+([%d%.]+)')
+
+  if stream_proto then
+    local sev_text, sev_num = status_to_severity(stream_status)
+    record["severity_text"] = sev_text
+    record["severity_number"] = sev_num
+
+    -- OTEL network semantic attributes
+    record["attr_network_protocol_name"] = stream_proto:lower()
+    record["attr_network_peer_address"] = stream_ip
+    record["attr_http_response_status_code"] = tonumber(stream_status)
+    record["attr_http_request_duration"] = tonumber(session_time)
+
+    -- Build concise body: PROTO STATUS bytes duration
+    record["body"] = string.format("%s %s %s/%sB %.3fs",
+      stream_proto, stream_status, bytes_sent, bytes_recv, tonumber(session_time))
+
+    return 1, timestamp, record
+  end
+
+  -- Match nginx combined log format with ingress extensions
+  -- Pattern: IP - - [timestamp] "METHOD PATH PROTO" STATUS BYTES ...
+  local client_ip, method, path, proto, status, bytes, request_time =
+    log:match('^([%d%.]+)%s+%-%s+%-%s+%[[^%]]+%]%s+"([A-Z]+)%s+([^%s]+)%s+([^"]+)"%s+(%d+)%s+(%d+)%s+"[^"]*"%s+"[^"]*"%s+%d+%s+([%d%.]+)')
+
+  if not method then
+    -- Try simpler pattern without all extensions
+    client_ip, method, path, proto, status, bytes =
+      log:match('^([%d%.]+)%s+%-%s+%-%s+%[[^%]]+%]%s+"([A-Z]+)%s+([^%s]+)%s+([^"]+)"%s+(%d+)%s+(%d+)')
+  end
+
+  if not method then
+    return 0, timestamp, record
+  end
+
+  -- Set severity based on status code
+  local sev_text, sev_num = status_to_severity(status)
+  record["severity_text"] = sev_text
+  record["severity_number"] = sev_num
+
+  -- Extract upstream info if present
+  local upstream_name = log:match('%[([^%]]+)%]%s+%[')
+  local upstream_status = log:match('%s+(%d+)%s+[a-f0-9]+$')
+
+  -- Strip query params from path for cleaner display
+  local clean_path = path:match('^([^?]+)') or path
+
+  -- OTEL HTTP semantic attributes (prefixed for Fluentd to merge)
+  record["attr_http_request_method"] = method
+  record["attr_http_response_status_code"] = tonumber(status)
+  record["attr_url_path"] = clean_path
+  record["attr_client_address"] = client_ip
+  if request_time then
+    record["attr_http_request_duration"] = tonumber(request_time)
+  end
+  if upstream_name and upstream_name ~= "" then
+    record["attr_server_address"] = upstream_name
+  end
+
+  -- Build concise body: METHOD PATH STATUS TIME
+  local body_parts = { method, clean_path, status }
+  if request_time then
+    table.insert(body_parts, string.format("%.3fs", tonumber(request_time)))
+  end
+  if upstream_name and upstream_name ~= "" then
+    table.insert(body_parts, "→ " .. upstream_name)
+  end
+  if upstream_status and upstream_status ~= status then
+    table.insert(body_parts, "(" .. upstream_status .. ")")
+  end
+  record["body"] = table.concat(body_parts, " ")
+
+  return 1, timestamp, record
+end

--- a/kustomize/telemetry/resources/fluentbit/parser/rust-tracing/fluentbit-clusterfilter.yaml
+++ b/kustomize/telemetry/resources/fluentbit/parser/rust-tracing/fluentbit-clusterfilter.yaml
@@ -1,0 +1,17 @@
+apiVersion: fluentbit.fluent.io/v1alpha2
+kind: ClusterFilter
+metadata:
+  labels:
+    fluentbit.fluent.io/component: logging
+    fluentbit.fluent.io/enabled: "true"
+  name: rust-tracing
+spec:
+  ordinal: 55
+  match: kube.*
+  filters:
+  - lua:
+      call: parse_rust_tracing
+      script:
+        key: rust-tracing.lua
+        name: fluent-bit-rust-tracing-config
+      timeAsTable: true

--- a/kustomize/telemetry/resources/fluentbit/parser/rust-tracing/kustomization.yaml
+++ b/kustomize/telemetry/resources/fluentbit/parser/rust-tracing/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# Rust tracing log parser
+# Matches: Rust services using tracing crate (Quickwit, etc.)
+# Format: TIMESTAMP  LEVEL module::path: message
+#
+# Extracts:
+#   - severity_text/number: from LEVEL (TRACE, DEBUG, INFO, WARN, ERROR)
+#   - body: message content after module path
+
+resources:
+  - fluentbit-clusterfilter.yaml
+
+configMapGenerator:
+  - name: fluent-bit-rust-tracing-config
+    namespace: system-telemetry
+    files:
+      - rust-tracing.lua
+    options:
+      disableNameSuffixHash: true

--- a/kustomize/telemetry/resources/fluentbit/parser/rust-tracing/rust-tracing.lua
+++ b/kustomize/telemetry/resources/fluentbit/parser/rust-tracing/rust-tracing.lua
@@ -1,0 +1,69 @@
+-- Rust tracing log parser
+-- Format: TIMESTAMP  LEVEL module::path: message key=value key2=value2
+-- Examples:
+--   2026-01-23T21:40:14.382Z  INFO quickwit_janitor::actors::garbage_collector: Janitor deleted...
+--   2026-01-23T21:15:28.810Z  WARN quickwit_search::root: search failed...
+--
+-- Common in: Quickwit, other Rust services using tracing crate
+
+-- OTEL severity number mapping
+local SEVERITY_MAP = {
+  TRACE = { text = "TRACE", number = 1 },
+  DEBUG = { text = "DEBUG", number = 5 },
+  INFO  = { text = "INFO",  number = 9 },
+  WARN  = { text = "WARN",  number = 13 },
+  ERROR = { text = "ERROR", number = 17 }
+}
+
+-- Strip ANSI escape codes from string
+local function strip_ansi(s)
+  -- Pattern matches: ESC [ ... m (SGR sequences)
+  return s:gsub('\027%[[%d;]*m', '')
+end
+
+function parse_rust_tracing(tag, timestamp, record)
+  local log = record["log"]
+  if not log then return 0, timestamp, record end
+
+  -- Skip if already parsed
+  if record["severity_text"] and record["severity_text"] ~= "" then
+    return 0, timestamp, record
+  end
+
+  -- Strip ANSI color codes if present
+  log = strip_ansi(log)
+
+  -- Match Rust tracing format: TIMESTAMP  LEVEL module::path: message
+  -- The level is typically uppercase, surrounded by whitespace
+  local level = log:match('%s+(TRACE)%s+') or
+                log:match('%s+(DEBUG)%s+') or
+                log:match('%s+(INFO)%s+') or
+                log:match('%s+(WARN)%s+') or
+                log:match('%s+(ERROR)%s+')
+
+  if not level then
+    return 0, timestamp, record
+  end
+
+  local sev = SEVERITY_MAP[level]
+  if not sev then
+    return 0, timestamp, record
+  end
+
+  record["severity_text"] = sev.text
+  record["severity_number"] = sev.number
+
+  -- Extract message: everything after "module::path: " 
+  -- Use greedy match to find last ": " (colon-space) pattern after level
+  -- This handles nested module paths like quickwit_search::actors::collector
+  local msg = log:match(level .. '%s+.+:%s(.+)$')
+
+  if msg then
+    record["body"] = msg
+  else
+    -- Use stripped log as body
+    record["body"] = log
+  end
+
+  return 1, timestamp, record
+end

--- a/kustomize/telemetry/resources/fluentbit/parser/rust-tracing/rust-tracing.lua
+++ b/kustomize/telemetry/resources/fluentbit/parser/rust-tracing/rust-tracing.lua
@@ -53,10 +53,11 @@ function parse_rust_tracing(tag, timestamp, record)
   record["severity_text"] = sev.text
   record["severity_number"] = sev.number
 
-  -- Extract message: everything after "module::path: " 
-  -- Use greedy match to find last ": " (colon-space) pattern after level
-  -- This handles nested module paths like quickwit_search::actors::collector
-  local msg = log:match(level .. '%s+.+:%s(.+)$')
+  -- Extract message: everything after "module::path: "
+  -- Module paths contain only alphanumerics, underscores, and :: separators
+  -- Using [%w_:]+ stops at first ": " (single colon-space) after module path
+  -- This preserves ": " sequences within the actual message
+  local msg = log:match(level .. '%s+[%w_:]+:%s(.+)$')
 
   if msg then
     record["body"] = msg

--- a/kustomize/telemetry/resources/fluentbit/parser/service-name/fluentbit-clusterfilter.yaml
+++ b/kustomize/telemetry/resources/fluentbit/parser/service-name/fluentbit-clusterfilter.yaml
@@ -1,0 +1,18 @@
+apiVersion: fluentbit.fluent.io/v1alpha2
+kind: ClusterFilter
+metadata:
+  labels:
+    fluentbit.fluent.io/component: logging
+    fluentbit.fluent.io/enabled: "true"
+  name: service-name
+spec:
+  # Runs last - after all parsing complete
+  ordinal: 100
+  match: kube.*
+  filters:
+  - lua:
+      call: extract_service_name
+      script:
+        key: service-name.lua
+        name: fluent-bit-service-name-config
+      timeAsTable: true

--- a/kustomize/telemetry/resources/fluentbit/parser/service-name/kustomization.yaml
+++ b/kustomize/telemetry/resources/fluentbit/parser/service-name/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - fluentbit-clusterfilter.yaml
+configMapGenerator:
+  - name: fluent-bit-service-name-config
+    namespace: system-telemetry
+    files:
+      - service-name.lua
+    options:
+      disableNameSuffixHash: true

--- a/kustomize/telemetry/resources/fluentbit/parser/service-name/service-name.lua
+++ b/kustomize/telemetry/resources/fluentbit/parser/service-name/service-name.lua
@@ -1,0 +1,23 @@
+function extract_service_name(tag, timestamp, record)
+  local k = record["kubernetes"]
+  if not k then return 0, timestamp, record end
+
+  -- Extract service name from pod_name by stripping replicaset/pod suffix
+  -- e.g., "source-controller-7d9859db54-s24pw" -> "source-controller"
+  local pod = k["pod_name"]
+  if pod then
+    -- Strip replicaset hash and pod suffix (deployment pattern: name-hash-hash)
+    local service = pod:match("^(.+)%-[a-z0-9]+%-[a-z0-9]+$")
+    -- StatefulSet pattern: name-0, name-1
+    if not service then
+      service = pod:match("^(.+)%-[0-9]+$")
+    end
+    -- DaemonSet/Job pattern: name-hash
+    if not service then
+      service = pod:match("^(.+)%-[a-z0-9]+$")
+    end
+    record["service_name"] = service or pod
+  end
+
+  return 1, timestamp, record
+end

--- a/kustomize/telemetry/resources/fluentbit/parser/zerolog/fluentbit-clusterfilter.yaml
+++ b/kustomize/telemetry/resources/fluentbit/parser/zerolog/fluentbit-clusterfilter.yaml
@@ -1,0 +1,17 @@
+apiVersion: fluentbit.fluent.io/v1alpha2
+kind: ClusterFilter
+metadata:
+  labels:
+    fluentbit.fluent.io/component: logging
+    fluentbit.fluent.io/enabled: "true"
+  name: zerolog
+spec:
+  ordinal: 35
+  match: kube.*
+  filters:
+  - lua:
+      call: parse_zerolog
+      script:
+        key: zerolog.lua
+        name: fluent-bit-zerolog-config
+      timeAsTable: true

--- a/kustomize/telemetry/resources/fluentbit/parser/zerolog/kustomization.yaml
+++ b/kustomize/telemetry/resources/fluentbit/parser/zerolog/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# Zerolog parser (Go logging library)
+# Format: TIMESTAMP LEVEL caller > message key=value
+# Level codes: TRC, DBG, INF, WRN, ERR, FTL, PNC
+#
+# Extracts:
+#   - severity_text: mapped from zerolog codes (TRC->TRACE, INF->INFO, etc.)
+#   - body: message content after ">" separator
+#
+# Common in: Kyverno, and other Go services using zerolog
+
+resources:
+  - fluentbit-clusterfilter.yaml
+
+configMapGenerator:
+  - name: fluent-bit-zerolog-config
+    namespace: system-telemetry
+    files:
+      - zerolog.lua
+    options:
+      disableNameSuffixHash: true

--- a/kustomize/telemetry/resources/fluentbit/parser/zerolog/zerolog.lua
+++ b/kustomize/telemetry/resources/fluentbit/parser/zerolog/zerolog.lua
@@ -1,9 +1,9 @@
 -- Zerolog log parser (Go logging library)
 -- Format: TIMESTAMP LEVEL caller/path.go:line > message key=value key2=value2
 -- Examples:
---   2026-01-23T22:21:37Z TRC github.com/kyverno/.../validation.go:123 > validation passed action=validate
+--   2026-01-23T22:21:37.123Z TRC github.com/kyverno/.../validation.go:123 > validation passed action=validate
 --   2026-01-23T22:21:37Z INF pkg/engine/validate.go:45 > policy applied policy=require-labels
---   2026-01-23T22:21:37Z ERR pkg/webhooks/server.go:89 > webhook failed error="timeout"
+--   2026-01-23T22:21:37.456789Z ERR pkg/webhooks/server.go:89 > webhook failed error="timeout"
 --
 -- Common in: Kyverno, and other Go services using zerolog
 
@@ -38,8 +38,8 @@ function parse_zerolog(tag, timestamp, record)
   log = strip_ansi(log)
 
   -- Match zerolog format: TIMESTAMP LEVEL caller > message
-  -- Pattern: timestamp followed by 3-letter level code
-  local level = log:match('^%d%d%d%d%-%d%d%-%d%dT[%d:]+Z%s+(%u%u%u)%s+')
+  -- Pattern: timestamp followed by 3-letter level code (supports fractional seconds)
+  local level = log:match('^%d%d%d%d%-%d%d%-%d%dT[%d:.]+Z%s+(%u%u%u)%s+')
 
   if not level then
     return 0, timestamp, record

--- a/kustomize/telemetry/resources/fluentbit/parser/zerolog/zerolog.lua
+++ b/kustomize/telemetry/resources/fluentbit/parser/zerolog/zerolog.lua
@@ -1,0 +1,71 @@
+-- Zerolog log parser (Go logging library)
+-- Format: TIMESTAMP LEVEL caller/path.go:line > message key=value key2=value2
+-- Examples:
+--   2026-01-23T22:21:37Z TRC github.com/kyverno/.../validation.go:123 > validation passed action=validate
+--   2026-01-23T22:21:37Z INF pkg/engine/validate.go:45 > policy applied policy=require-labels
+--   2026-01-23T22:21:37Z ERR pkg/webhooks/server.go:89 > webhook failed error="timeout"
+--
+-- Common in: Kyverno, and other Go services using zerolog
+
+-- Strip ANSI escape codes (color codes like [32m, [0m, etc.)
+local function strip_ansi(str)
+  if not str then return str end
+  -- Match ESC[ followed by any params and ending with a letter
+  return str:gsub('\027%[[%d;]*[A-Za-z]', '')
+end
+
+-- OTEL severity mapping for zerolog short codes
+local SEVERITY_MAP = {
+  TRC = { text = "TRACE", number = 1 },
+  DBG = { text = "DEBUG", number = 5 },
+  INF = { text = "INFO",  number = 9 },
+  WRN = { text = "WARN",  number = 13 },
+  ERR = { text = "ERROR", number = 17 },
+  FTL = { text = "FATAL", number = 21 },
+  PNC = { text = "FATAL", number = 21 }  -- panic
+}
+
+function parse_zerolog(tag, timestamp, record)
+  local log = record["log"]
+  if not log then return 0, timestamp, record end
+
+  -- Skip if already parsed
+  if record["severity_text"] and record["severity_text"] ~= "" then
+    return 0, timestamp, record
+  end
+
+  -- Strip ANSI escape codes before parsing
+  log = strip_ansi(log)
+
+  -- Match zerolog format: TIMESTAMP LEVEL caller > message
+  -- Pattern: timestamp followed by 3-letter level code
+  local level = log:match('^%d%d%d%d%-%d%d%-%d%dT[%d:]+Z%s+(%u%u%u)%s+')
+
+  if not level then
+    return 0, timestamp, record
+  end
+
+  local sev = SEVERITY_MAP[level]
+  if not sev then
+    return 0, timestamp, record
+  end
+
+  record["severity_text"] = sev.text
+  record["severity_number"] = sev.number
+
+  -- Extract message: everything after " > " up to first key=value or end
+  local msg = log:match('%s>%s+([^=]+)%s+%w+[=:]') or
+              log:match('%s>%s+(.+)$')
+
+  if msg then
+    -- Trim trailing whitespace
+    msg = msg:gsub('%s+$', '')
+    record["body"] = msg
+  else
+    -- Fallback: just the level and everything after caller
+    local after_caller = log:match('%s>%s+(.+)$')
+    record["body"] = after_caller or log
+  end
+
+  return 1, timestamp, record
+end


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds end-to-end Kubernetes log parsing and visualization powered by Quickwit and Grafana.
> 
> - New Fluent Bit Lua parsers (`klog`, `coredns`, `json-structured`, `zerolog`, `logfmt`, `rust-tracing`, `nginx-access`, `grpc`, `fallback`, `service-name`) with `ClusterFilter`s to normalize logs into OTEL fields (`severity_*`, `body`, `attributes.*`)
> - Updates Fluentd OTEL filter to build `timestamp_nanos`, derive `service_name`, preserve `severity_text`, map `body`, and aggregate `attr_*` into `attributes`; standardizes `resource_attributes` keys
> - Adds Grafana Quickwit dashboards (`logs.json`, `logs-stats.json`) and wires `grafana/quickwit` component; configures datasource with `logLevelField` and `logMessageField`
> - Patches Grafana HelmRelease to install the Quickwit datasource plugin via init container and mounts plugin volume
> - Quickwit HelmRelease: sets `NO_COLOR` and tuned `RUST_LOG`; Kyverno HelmRelease: sets `NO_COLOR` for all controllers
> - Facet wiring: includes parser components in `telemetry-resources` and ensures observability facets depend on `telemetry-resources`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c8c8d18cb860fb4cb3a9fbbe446e4352b83bf76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->