### PR TITLE
chore(k8s): Resolve k8s deprecations

### DIFF
--- a/contexts/_template/facets/base.yaml
+++ b/contexts/_template/facets/base.yaml
@@ -79,6 +79,7 @@ kustomize:
     - fluentbit/parser/nginx-access
     - fluentbit/parser/grpc
     - fluentbit/parser/fallback
+    - fluentbit/parser/upstream-warnings
     - fluentbit/parser/service-name
     - fluentbit/systemd
   timeout: 10m

--- a/kustomize/GUIDELINES.md
+++ b/kustomize/GUIDELINES.md
@@ -59,7 +59,7 @@ spec:
 Set `interval: 10m` in all `kustomize/*/helm-repository.yaml` files:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 spec:
   interval: 10m

--- a/kustomize/csi/openebs/helm-repository.yaml
+++ b/kustomize/csi/openebs/helm-repository.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: openebs

--- a/kustomize/database/cloudnativepg/helm-repository.yaml
+++ b/kustomize/database/cloudnativepg/helm-repository.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: cloudnativepg

--- a/kustomize/dns/coredns/helm-repository.yaml
+++ b/kustomize/dns/coredns/helm-repository.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: coredns

--- a/kustomize/dns/external-dns/helm-repository.yaml
+++ b/kustomize/dns/external-dns/helm-repository.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: external-dns

--- a/kustomize/ingress/nginx/helm-repository.yaml
+++ b/kustomize/ingress/nginx/helm-repository.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: ingress-nginx

--- a/kustomize/lb/base/metallb/helm-repository.yaml
+++ b/kustomize/lb/base/metallb/helm-repository.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: metallb

--- a/kustomize/lb/resources/kube-vip/helm-repository.yaml
+++ b/kustomize/lb/resources/kube-vip/helm-repository.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: kube-vip

--- a/kustomize/object-store/base/minio/git-repository.yaml
+++ b/kustomize/object-store/base/minio/git-repository.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
   name: minio

--- a/kustomize/object-store/base/minio/helm-repository.yaml
+++ b/kustomize/object-store/base/minio/helm-repository.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: minio

--- a/kustomize/observability/elasticsearch/helm-repository.yaml
+++ b/kustomize/observability/elasticsearch/helm-repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: elastic-elasticsearch

--- a/kustomize/observability/grafana/helm-repository.yaml
+++ b/kustomize/observability/grafana/helm-repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: grafana

--- a/kustomize/observability/kibana/helm-repository.yaml
+++ b/kustomize/observability/kibana/helm-repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: elastic-kibana

--- a/kustomize/observability/quickwit/helm-repository.yaml
+++ b/kustomize/observability/quickwit/helm-repository.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: quickwit

--- a/kustomize/pki/base/cert-manager/helm-repository.yaml
+++ b/kustomize/pki/base/cert-manager/helm-repository.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: jetstack

--- a/kustomize/policy/base/kyverno/helm-repository.yaml
+++ b/kustomize/policy/base/kyverno/helm-repository.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: kyverno

--- a/kustomize/telemetry/base/filebeat/helm-repository.yaml
+++ b/kustomize/telemetry/base/filebeat/helm-repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: elastic-filebeat

--- a/kustomize/telemetry/base/fluentbit/helm-repository.yaml
+++ b/kustomize/telemetry/base/fluentbit/helm-repository.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: fluent

--- a/kustomize/telemetry/base/prometheus/helm-repository.yaml
+++ b/kustomize/telemetry/base/prometheus/helm-repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: prometheus-community

--- a/kustomize/telemetry/resources/fluentbit/parser/kustomization.yaml
+++ b/kustomize/telemetry/resources/fluentbit/parser/kustomization.yaml
@@ -16,6 +16,7 @@ kind: Component
 #   - fluentbit/parser/nginx-access
 #   - fluentbit/parser/grpc
 #   - fluentbit/parser/fallback
+#   - fluentbit/parser/upstream-warnings
 #   - fluentbit/parser/service-name
 #
 # Format-specific parsers extract structured OTEL fields from known log formats.
@@ -35,4 +36,5 @@ components:
   - nginx-access
   - grpc
   - fallback
+  - upstream-warnings
   - service-name

--- a/kustomize/telemetry/resources/fluentbit/parser/upstream-warnings/fluentbit-clusterfilter.yaml
+++ b/kustomize/telemetry/resources/fluentbit/parser/upstream-warnings/fluentbit-clusterfilter.yaml
@@ -1,0 +1,18 @@
+apiVersion: fluentbit.fluent.io/v1alpha2
+kind: ClusterFilter
+metadata:
+  labels:
+    fluentbit.fluent.io/component: logging
+    fluentbit.fluent.io/enabled: "true"
+  name: upstream-warnings
+spec:
+  # Run after service-name filter (ordinal 100) since we match on service_name
+  ordinal: 105
+  match: kube.*
+  filters:
+  - lua:
+      call: suppress_upstream_warnings
+      script:
+        key: upstream-warnings.lua
+        name: fluent-bit-upstream-warnings-config
+      timeAsTable: true

--- a/kustomize/telemetry/resources/fluentbit/parser/upstream-warnings/kustomization.yaml
+++ b/kustomize/telemetry/resources/fluentbit/parser/upstream-warnings/kustomization.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# Upstream warning suppressor
+# Downgrades known third-party deprecation warnings to TRACE severity
+#
+# These are warnings from upstream components (OpenEBS, etc.) that use
+# deprecated Kubernetes APIs. We can't fix the upstream code, but we can
+# reduce log noise by downgrading these known-harmless warnings.
+#
+# To add new patterns: edit upstream-warnings.lua SUPPRESS_PATTERNS table
+
+resources:
+  - fluentbit-clusterfilter.yaml
+
+configMapGenerator:
+  - name: fluent-bit-upstream-warnings-config
+    namespace: system-telemetry
+    files:
+      - upstream-warnings.lua
+    options:
+      disableNameSuffixHash: true

--- a/kustomize/telemetry/resources/fluentbit/parser/upstream-warnings/upstream-warnings.lua
+++ b/kustomize/telemetry/resources/fluentbit/parser/upstream-warnings/upstream-warnings.lua
@@ -1,0 +1,66 @@
+-- Upstream deprecation warning suppressor
+-- Downgrades known upstream warnings to TRACE severity
+--
+-- These warnings come from third-party components using deprecated Kubernetes APIs.
+-- We can't fix the upstream code, but we can reduce log noise by downgrading
+-- these known-harmless warnings to TRACE level.
+--
+-- Tracked issues:
+--   - OpenEBS LocalPV: Uses v1 Endpoints instead of EndpointSlices
+--     No upstream fix available as of v4.4.0
+--     https://github.com/openebs/dynamic-localpv-provisioner
+
+-- Service-specific suppressions: { service_pattern = { message_patterns } }
+-- Only suppresses if BOTH service name matches AND message matches
+local SUPPRESS_RULES = {
+  -- OpenEBS LocalPV uses deprecated v1 Endpoints API
+  -- No upstream fix available as of v4.4.0
+  ["openebs"] = {
+    "v1 Endpoints is deprecated",
+  },
+}
+
+function suppress_upstream_warnings(tag, timestamp, record)
+  -- Only process WARN level logs
+  local sev = record["severity_text"]
+  if sev ~= "WARN" then
+    return 0, timestamp, record
+  end
+
+  -- Get service name for targeted suppression
+  local service = record["service_name"]
+  if not service or type(service) ~= "string" then
+    return 0, timestamp, record
+  end
+
+  -- Get content to match against (check both body and log)
+  local body = record["body"]
+  local log = record["log"]
+  
+  -- body might be a string or nil at this stage
+  local content = ""
+  if type(body) == "string" then
+    content = body
+  elseif type(log) == "string" then
+    content = log
+  else
+    return 0, timestamp, record
+  end
+
+  -- Check if service matches any suppression rule
+  for service_pattern, message_patterns in pairs(SUPPRESS_RULES) do
+    if service:find(service_pattern, 1, true) then
+      -- Service matches, now check message patterns
+      for _, msg_pattern in ipairs(message_patterns) do
+        if content:find(msg_pattern, 1, true) then
+          -- Downgrade to TRACE (preserves log but hides from warning views)
+          record["severity_text"] = "TRACE"
+          record["severity_number"] = 1
+          return 1, timestamp, record
+        end
+      end
+    end
+  end
+
+  return 0, timestamp, record
+end

--- a/kustomize/telemetry/resources/metrics-server/helm-repository.yaml
+++ b/kustomize/telemetry/resources/metrics-server/helm-repository.yaml
@@ -1,5 +1,5 @@
 
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: metrics-server

--- a/kustomize/telemetry/resources/prometheus/flux/helm-repository.yaml
+++ b/kustomize/telemetry/resources/prometheus/flux/helm-repository.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: fluxcd-community


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Scope**
> 
> - Migrates all `HelmRepository`/`GitRepository` manifests from `source.toolkit.fluxcd.io/v1beta2` to `v1` across kustomize modules; updates docs snippet accordingly.
> - Adds Fluent Bit "upstream-warnings" Lua filter to downgrade known third‑party deprecation warnings (e.g., OpenEBS) to `TRACE` and wires it into parser components and `base` facet (ClusterFilter + ConfigMap).
> 
> **Notes**
> 
> - Parser bundle and facet now include `fluentbit/parser/upstream-warnings`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52ffc42c8f647bb2ac5e750168000eedecbaa288. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->