### PR TITLE
feat(observability): Add support for setting global log levels

### DIFF
--- a/contexts/_template/facets/addon-observability.yaml
+++ b/contexts/_template/facets/addon-observability.yaml
@@ -33,7 +33,16 @@ kustomize:
     date_interval_hour: "${time_format == '12h' ? 'MMM DD hh:mm a' : 'MM/DD HH:mm'}"
     date_interval_day: "${time_format == '12h' ? 'MMM DD' : 'MM/DD'}"
 
-# FluentD outputs
+# FluentBit → FluentD forwarding
+- name: telemetry-resources
+  path: telemetry/resources
+  when: addons?.observability?.logs_driver in ['stdout', 'quickwit']
+  dependsOn:
+    - telemetry-base
+  components:
+    - fluentbit/fluentd
+
+# FluentD stdout output
 - name: observability
   path: observability
   when: addons?.observability?.logs_driver == 'stdout'
@@ -60,6 +69,15 @@ kustomize:
     - quickwit/prometheus
     - grafana/quickwit
     - grafana/dashboards/logs/quickwit
+
+# Log level filtering for FluentD (default: info)
+- name: observability
+  path: observability
+  when: addons?.observability?.logs_driver in ['stdout', 'quickwit'] && log_level != 'trace'
+  dependsOn:
+    - telemetry-resources
+  components:
+    - fluentd/filters/log-level/${log_level ?? 'info'}
 
 # Elasticsearch + Kibana
 - name: observability

--- a/contexts/_template/facets/base.yaml
+++ b/contexts/_template/facets/base.yaml
@@ -68,19 +68,9 @@ kustomize:
     - prometheus/flux
     - fluentbit
     - fluentbit/containerd
-    - fluentbit/fluentd
     - fluentbit/kubernetes
-    - fluentbit/parser/klog
-    - fluentbit/parser/coredns
-    - fluentbit/parser/json-structured
-    - fluentbit/parser/zerolog
-    - fluentbit/parser/logfmt
-    - fluentbit/parser/rust-tracing
-    - fluentbit/parser/nginx-access
-    - fluentbit/parser/grpc
-    - fluentbit/parser/fallback
-    - fluentbit/parser/upstream-warnings
-    - fluentbit/parser/service-name
+    - fluentbit/parser
     - fluentbit/systemd
   timeout: 10m
   interval: 5m
+

--- a/contexts/_template/schema.yaml
+++ b/contexts/_template/schema.yaml
@@ -31,6 +31,18 @@ properties:
     default: 24h
     description: Time format for Grafana dashboards (12h or 24h)
 
+  # Log level
+  log_level:
+    type: string
+    enum:
+      - trace
+      - debug
+      - info
+      - warn
+      - error
+    default: info
+    description: Minimum log level to retain (logs below this level are dropped)
+
   # Core infrastructure provider (determines basic stack)
   provider:
     type: string

--- a/kustomize/observability/fluentd/filters/log-level/debug/clusterfilter.yaml
+++ b/kustomize/observability/fluentd/filters/log-level/debug/clusterfilter.yaml
@@ -7,6 +7,6 @@ metadata:
 spec:
   filters:
     - grep:
-        regexp:
+        exclude:
           - key: severity_text
-            pattern: "^(DEBUG|INFO|WARN|ERROR|FATAL)$"
+            pattern: "^(TRACE)$"

--- a/kustomize/observability/fluentd/filters/log-level/debug/clusterfilter.yaml
+++ b/kustomize/observability/fluentd/filters/log-level/debug/clusterfilter.yaml
@@ -1,0 +1,12 @@
+apiVersion: fluentd.fluent.io/v1alpha1
+kind: ClusterFilter
+metadata:
+  name: log-level
+  labels:
+    filter.fluentd.fluent.io/enabled: "true"
+spec:
+  filters:
+    - grep:
+        regexp:
+          - key: severity_text
+            pattern: "^(DEBUG|INFO|WARN|ERROR|FATAL)$"

--- a/kustomize/observability/fluentd/filters/log-level/debug/kustomization.yaml
+++ b/kustomize/observability/fluentd/filters/log-level/debug/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# Log level filter: DEBUG
+#
+# Drops only TRACE level logs.
+# Use this for development/debugging.
+
+resources:
+  - clusterfilter.yaml

--- a/kustomize/observability/fluentd/filters/log-level/error/clusterfilter.yaml
+++ b/kustomize/observability/fluentd/filters/log-level/error/clusterfilter.yaml
@@ -7,6 +7,6 @@ metadata:
 spec:
   filters:
     - grep:
-        regexp:
+        exclude:
           - key: severity_text
-            pattern: "^(ERROR|FATAL)$"
+            pattern: "^(TRACE|DEBUG|INFO|WARN)$"

--- a/kustomize/observability/fluentd/filters/log-level/error/clusterfilter.yaml
+++ b/kustomize/observability/fluentd/filters/log-level/error/clusterfilter.yaml
@@ -1,0 +1,12 @@
+apiVersion: fluentd.fluent.io/v1alpha1
+kind: ClusterFilter
+metadata:
+  name: log-level
+  labels:
+    filter.fluentd.fluent.io/enabled: "true"
+spec:
+  filters:
+    - grep:
+        regexp:
+          - key: severity_text
+            pattern: "^(ERROR|FATAL)$"

--- a/kustomize/observability/fluentd/filters/log-level/error/kustomization.yaml
+++ b/kustomize/observability/fluentd/filters/log-level/error/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# Log level filter: ERROR
+#
+# Drops logs with severity below ERROR (TRACE, DEBUG, INFO, WARN).
+# Use this for minimal logging.
+
+resources:
+  - clusterfilter.yaml

--- a/kustomize/observability/fluentd/filters/log-level/info/clusterfilter.yaml
+++ b/kustomize/observability/fluentd/filters/log-level/info/clusterfilter.yaml
@@ -1,0 +1,12 @@
+apiVersion: fluentd.fluent.io/v1alpha1
+kind: ClusterFilter
+metadata:
+  name: log-level
+  labels:
+    filter.fluentd.fluent.io/enabled: "true"
+spec:
+  filters:
+    - grep:
+        regexp:
+          - key: severity_text
+            pattern: "^(INFO|WARN|ERROR|FATAL)$"

--- a/kustomize/observability/fluentd/filters/log-level/info/clusterfilter.yaml
+++ b/kustomize/observability/fluentd/filters/log-level/info/clusterfilter.yaml
@@ -7,6 +7,6 @@ metadata:
 spec:
   filters:
     - grep:
-        regexp:
+        exclude:
           - key: severity_text
-            pattern: "^(INFO|WARN|ERROR|FATAL)$"
+            pattern: "^(TRACE|DEBUG)$"

--- a/kustomize/observability/fluentd/filters/log-level/info/kustomization.yaml
+++ b/kustomize/observability/fluentd/filters/log-level/info/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# Log level filter: INFO
+#
+# Drops logs with severity below INFO (TRACE, DEBUG).
+# This is the default log level for production environments.
+
+resources:
+  - clusterfilter.yaml

--- a/kustomize/observability/fluentd/filters/log-level/warn/clusterfilter.yaml
+++ b/kustomize/observability/fluentd/filters/log-level/warn/clusterfilter.yaml
@@ -1,0 +1,12 @@
+apiVersion: fluentd.fluent.io/v1alpha1
+kind: ClusterFilter
+metadata:
+  name: log-level
+  labels:
+    filter.fluentd.fluent.io/enabled: "true"
+spec:
+  filters:
+    - grep:
+        regexp:
+          - key: severity_text
+            pattern: "^(WARN|ERROR|FATAL)$"

--- a/kustomize/observability/fluentd/filters/log-level/warn/clusterfilter.yaml
+++ b/kustomize/observability/fluentd/filters/log-level/warn/clusterfilter.yaml
@@ -7,6 +7,6 @@ metadata:
 spec:
   filters:
     - grep:
-        regexp:
+        exclude:
           - key: severity_text
-            pattern: "^(WARN|ERROR|FATAL)$"
+            pattern: "^(TRACE|DEBUG|INFO)$"

--- a/kustomize/observability/fluentd/filters/log-level/warn/kustomization.yaml
+++ b/kustomize/observability/fluentd/filters/log-level/warn/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# Log level filter: WARN
+#
+# Drops logs with severity below WARN (TRACE, DEBUG, INFO).
+# Use this for high-volume production environments.
+
+resources:
+  - clusterfilter.yaml


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds configurable log-level filtering to the logging pipeline and streamlines telemetry wiring.
> 
> - Introduces `log_level` in `schema.yaml` (trace/debug/info/warn/error; default `info`) to control minimum retained severity
> - Implements FluentD `ClusterFilter` components for `debug`, `info`, `warn`, `error`; applied when logs_driver is `stdout` or `quickwit` via `fluentd/filters/log-level/${log_level}` (skipped for `trace`)
> - Refactors telemetry: separates FluentBit→FluentD forwarding into a dedicated `telemetry-resources` step for `stdout`/`quickwit`; consolidates Fluent Bit parsers to `fluentbit/parser` in `base.yaml`
> - Minor observability facet wiring updates for `stdout` and `quickwit` paths (no change to Elasticsearch path)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa1b825333f1dad1464739396b5b42bca7b908e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->