### PR TITLE
chore(template): Add template tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,8 +111,8 @@ jobs:
         with:
           sarif_file: results.sarif
 
-  terraform-tests:
-    name: Terraform Tests
+  tests:
+    name: Tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -124,12 +124,18 @@ jobs:
           # renovate: datasource=github-releases depName=terraform package=hashicorp/terraform
           terraform_version: 1.14.3
 
+      - name: Install Windsor CLI
+        uses: windsorcli/action@a829ee3c5d9826fd0b31d5e730edcd515644d866 # v0.5.1
+        with:
+          ref: main
+          context: local
+
       - name: Install Task
         uses: go-task/setup-task@0ab1b2a65bc55236a3bc64cde78f80e20e8885c2 # v1.0.0
         with:
           version: 3.x
 
-      - name: Run Terraform Tests
+      - name: Run Tests
         run: task test
 
   integration:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -18,6 +18,13 @@ tasks:
       - cmd: source .venv/bin/activate && checkov -d {{.CLI_ARGS | default "terraform/"}} 2>/dev/null
 
   test:
+    desc: Run all tests (Terraform and Blueprint)
+    silent: true
+    cmds:
+      - task: test:terraform
+      - task: test:blueprint
+
+  test:terraform:
     desc: Run Terraform tests (all or specific module)
     silent: true
     cmds:
@@ -66,6 +73,12 @@ tasks:
             echo "Module path '$MODULE' does not exist."
             exit 1
           fi
+
+  test:blueprint:
+    desc: Run Windsor blueprint tests
+    silent: true
+    cmds:
+      - windsor test
 
   fmt:
     desc: Check Terraform formatting

--- a/contexts/_template/facets/addon-database.yaml
+++ b/contexts/_template/facets/addon-database.yaml
@@ -4,14 +4,14 @@ metadata:
   name: database
   description: PostgreSQL database service with CloudNativePG
 
-when: addons?.database?.postgres?.enabled == true || dev == true
+when: addons.database.postgres.enabled == true || dev == true
 
 kustomize:
 
 # CloudNativePG operator base
 - name: database
   path: database
-  when: addons?.database?.postgres?.driver == 'cloudnativepg' || dev == true
+  when: addons.database.postgres.driver == 'cloudnativepg' || dev == true
   timeout: 15m
   interval: 10m
   dependsOn:
@@ -23,13 +23,13 @@ kustomize:
 # High availability configuration
 - name: database
   path: database
-  when: addons?.database?.postgres?.driver == 'cloudnativepg' && ha == true
+  when: addons.database.postgres.driver == 'cloudnativepg' && ha == true
   components:
     - cloudnativepg/ha
 
 # CloudNativePG Grafana dashboard
 - name: observability
   path: observability
-  when: (addons?.database?.postgres?.driver == 'cloudnativepg' && addons?.observability?.enabled == true) || dev == true
+  when: (addons.database.postgres.driver == 'cloudnativepg' && addons.observability.enabled == true) || dev == true
   components:
     - grafana/dashboards/cloudnativepg

--- a/contexts/_template/facets/addon-object-store.yaml
+++ b/contexts/_template/facets/addon-object-store.yaml
@@ -4,14 +4,14 @@ metadata:
   name: object-store
   description: Object storage service with multiple drivers
 
-when: addons?.object_store?.enabled == true
+when: addons.object_store.enabled == true
 
 kustomize:
 
   # MinIO object storage base
   - name: object-store-base
     path: object-store/base
-    when: addons?.object_store?.driver == 'minio'
+    when: addons.object_store.driver == 'minio'
     timeout: 10m
     interval: 5m
     dependsOn:

--- a/contexts/_template/facets/addon-observability.yaml
+++ b/contexts/_template/facets/addon-observability.yaml
@@ -4,20 +4,17 @@ metadata:
   name: observability
   description: Observability stack with multiple log storage drivers
 
-when: addons?.observability?.enabled == true || dev == true
+when: addons.observability.enabled == true || dev == true
 
 kustomize:
 
-# Dashboards
+# Dashboards (base - no ingress dependency)
 - name: observability
   path: observability
   timeout: 15m
   interval: 10m
-  dependsOn:
-    - ingress
   components:
     - grafana
-    - grafana/ingress
     - grafana/prometheus
     - grafana/dashboards/node
     - grafana/dashboards/kubernetes
@@ -25,7 +22,7 @@ kustomize:
     - grafana/dashboards/cert-manager
     - grafana/dashboards/nginx
   substitutions:
-    external_domain: "${dns?.domain}"
+    external_domain: "${dns.domain}"
     timezone: "${timezone}"
     date_full: "${time_format == '12h' ? 'MMM DD, YYYY @ hh:mm:ss a' : 'YYYY-MM-DD HH:mm:ss'}"
     date_interval_second: "${time_format == '12h' ? 'hh:mm:ss a' : 'HH:mm:ss'}"
@@ -33,10 +30,19 @@ kustomize:
     date_interval_hour: "${time_format == '12h' ? 'MMM DD hh:mm a' : 'MM/DD HH:mm'}"
     date_interval_day: "${time_format == '12h' ? 'MMM DD' : 'MM/DD'}"
 
+# Grafana ingress (only when ingress is enabled)
+- name: observability
+  path: observability
+  when: ingress.enabled == true
+  dependsOn:
+    - ingress
+  components:
+    - grafana/ingress
+
 # FluentBit → FluentD forwarding
 - name: telemetry-resources
   path: telemetry/resources
-  when: addons?.observability?.logs_driver in ['stdout', 'quickwit']
+  when: addons.observability.logs_driver in ['stdout', 'quickwit']
   dependsOn:
     - telemetry-base
   components:
@@ -45,7 +51,7 @@ kustomize:
 # FluentD stdout output
 - name: observability
   path: observability
-  when: addons?.observability?.logs_driver == 'stdout'
+  when: addons.observability.logs_driver == 'stdout'
   dependsOn:
     - telemetry-resources
   components:
@@ -56,7 +62,7 @@ kustomize:
 # Quickwit log storage
 - name: observability
   path: observability
-  when: addons?.observability?.logs_driver == 'quickwit'
+  when: addons.observability.logs_driver == 'quickwit'
   dependsOn:
     - csi
     - telemetry-resources
@@ -73,7 +79,7 @@ kustomize:
 # Log level filtering for FluentD (default: info)
 - name: observability
   path: observability
-  when: addons?.observability?.logs_driver in ['stdout', 'quickwit'] && log_level != 'trace'
+  when: addons.observability.logs_driver in ['stdout', 'quickwit'] && log_level != 'trace'
   dependsOn:
     - telemetry-resources
   components:
@@ -82,7 +88,7 @@ kustomize:
 # Elasticsearch + Kibana
 - name: observability
   path: observability
-  when: addons?.observability?.logs_driver == 'elasticsearch'
+  when: addons.observability.logs_driver == 'elasticsearch'
   dependsOn:
     - csi
     - ingress
@@ -91,12 +97,12 @@ kustomize:
     - kibana
     - kibana/ingress
   substitutions:
-    external_domain: ${dns?.domain}
+    external_domain: ${dns.domain}
 
 # Elasticsearch telemetry
 - name: telemetry-base
   path: telemetry/base
-  when: addons?.observability?.logs_driver == 'elasticsearch'
+  when: addons.observability.logs_driver == 'elasticsearch'
   timeout: 30m
   interval: 10m
   strategy: replace
@@ -107,7 +113,7 @@ kustomize:
 
 - name: telemetry-resources
   path: telemetry/resources
-  when: addons?.observability?.logs_driver == 'elasticsearch'
+  when: addons.observability.logs_driver == 'elasticsearch'
   timeout: 10m
   interval: 5m
   strategy: replace

--- a/contexts/_template/facets/addon-observability.yaml
+++ b/contexts/_template/facets/addon-observability.yaml
@@ -22,8 +22,8 @@ kustomize:
     - grafana/dashboards/cert-manager
     - grafana/dashboards/nginx
   substitutions:
-    external_domain: "${dns.domain}"
-    timezone: "${timezone}"
+    external_domain: ${dns.domain}
+    timezone: ${timezone}
     date_full: "${time_format == '12h' ? 'MMM DD, YYYY @ hh:mm:ss a' : 'YYYY-MM-DD HH:mm:ss'}"
     date_interval_second: "${time_format == '12h' ? 'hh:mm:ss a' : 'HH:mm:ss'}"
     date_interval_minute: "${time_format == '12h' ? 'hh:mm a' : 'HH:mm'}"

--- a/contexts/_template/facets/addon-private-ca.yaml
+++ b/contexts/_template/facets/addon-private-ca.yaml
@@ -4,7 +4,7 @@ metadata:
   name: private-ca
   description: Private Certificate Authority with trust-manager integration
 
-when: addons?.private_ca?.enabled == true || dev == true
+when: addons.private_ca.enabled == true || dev == true
 
 kustomize:
 

--- a/contexts/_template/facets/addon-private-dns.yaml
+++ b/contexts/_template/facets/addon-private-dns.yaml
@@ -4,7 +4,7 @@ metadata:
   name: private-dns
   description: Self-hosted CoreDNS for private DNS zones
 
-when: addons?.private_dns?.enabled == true || dev == true
+when: addons.private_dns.enabled == true || dev == true
 
 kustomize:
 
@@ -22,17 +22,17 @@ kustomize:
     - external-dns/coredns
     - external-dns/ingress
   substitutions:
-    external_domain: ${dns?.domain}
+    external_domain: ${dns.domain}
 
 - name: dns
   path: dns
-  when: vm?.driver == 'docker-desktop'
+  when: vm.driver == 'docker-desktop'
   components:
     - external-dns/localhost
 
 - name: ingress
   path: ingress
-  when: ingress?.enabled == true && ingress?.driver == 'nginx'
+  when: ingress.enabled == true && ingress.driver == 'nginx'
   dependsOn:
     - pki-base
   components:

--- a/contexts/_template/facets/local-dev.yaml
+++ b/contexts/_template/facets/local-dev.yaml
@@ -10,8 +10,8 @@ terraform:
 - name: gitops
   path: gitops/flux
   inputs:
-    git_username: ${git.livereload.username}
-    git_password: ${git.livereload.password}
+    git_username: ${git.livereload.username ?? ""}
+    git_password: ${git.livereload.password ?? ""}
     webhook_token: abcdef123456
     concurrency: ${max(2, min(floor((cluster.controlplanes.cpu ?? 4) / 2), floor((cluster.controlplanes.memory ?? 4) / 2), 10))}
 

--- a/contexts/_template/facets/local-dev.yaml
+++ b/contexts/_template/facets/local-dev.yaml
@@ -29,12 +29,12 @@ kustomize:
   components:
   - grafana/dev
   substitutions:
-    admin_password: ${addons?.observability?.admin_password ?? "grafana"}
+    admin_password: ${addons.observability.admin_password ?? "grafana"}
 
 # Ingress
 - name: ingress
   path: ingress
-  when: ingress?.enabled == true && ingress?.driver == 'nginx' && vm?.driver == 'docker-desktop'
+  when: ingress.enabled == true && ingress.driver == 'nginx' && vm.driver == 'docker-desktop'
   dependsOn:
   - pki-base
   components:

--- a/contexts/_template/facets/provider-aws.yaml
+++ b/contexts/_template/facets/provider-aws.yaml
@@ -11,7 +11,7 @@ terraform:
   path: network/aws-vpc
   inputs:
     cidr_block: ${network.cidr_block}
-    domain_name: ${dns?.domain ?? ""}
+    domain_name: ${dns.domain ?? ""}
 - name: cluster
   path: cluster/aws-eks
   dependsOn:
@@ -34,7 +34,7 @@ kustomize:
 # Ingress
 - name: ingress
   path: ingress
-  when: ingress?.enabled == true && ingress?.driver == 'nginx'
+  when: ingress.enabled == true && ingress.driver == 'nginx'
   dependsOn:
     - pki-base
   components:
@@ -54,4 +54,4 @@ kustomize:
   timeout: 5m
   interval: 5m
   substitutions:
-    single_storage_type: ${cluster.storage?.single_storage_type ?? "gp3"}
+    single_storage_type: ${cluster.storage.single_storage_type ?? "gp3"}

--- a/contexts/_template/facets/provider-azure.yaml
+++ b/contexts/_template/facets/provider-azure.yaml
@@ -28,7 +28,7 @@ kustomize:
 # Ingress
 - name: ingress
   path: ingress
-  when: ingress?.enabled == true && ingress?.driver == 'nginx'
+  when: ingress.enabled == true && ingress.driver == 'nginx'
   dependsOn:
     - pki-base
   components:
@@ -49,7 +49,7 @@ kustomize:
   timeout: 5m
   interval: 5m
   substitutions:
-    single_storage_type: ${cluster.storage?.single_storage_type ?? "StandardSSD_LRS"}
+    single_storage_type: ${cluster.storage.single_storage_type ?? "StandardSSD_LRS"}
 
 # Telemetry - exclude metrics-server as AKS provides it natively
 - name: telemetry-resources

--- a/contexts/_template/facets/provider-generic.yaml
+++ b/contexts/_template/facets/provider-generic.yaml
@@ -14,7 +14,7 @@ terraform:
     cluster_endpoint: ${cluster.endpoint ?? ("https://" + split(values(cluster.controlplanes.nodes)[0].endpoint, ":")[0] + ":6443")}
     cluster_name: talos
     controlplanes: ${values(cluster.controlplanes.nodes)}
-    workers: "${(cluster.workers?.count ?? 0) > 0 ? values(cluster.workers.nodes) : []}"
+    workers: "${(cluster.workers.count ?? 0) > 0 ? values(cluster.workers.nodes) : []}"
     common_config_patches: ${jsonnet("../configs/talos-generic.jsonnet").common_config_patches}
     worker_config_patches: ${jsonnet("../configs/talos-generic.jsonnet").worker_config_patches}
     controlplane_config_patches: ${jsonnet("../configs/talos-generic.jsonnet").controlplane_config_patches}
@@ -44,7 +44,7 @@ kustomize:
 # Load Balancer
 - name: lb-base
   path: lb/base
-  when: vm?.driver != 'docker-desktop'
+  when: vm.driver != 'docker-desktop'
   dependsOn:
     - policy-resources
   components:
@@ -54,7 +54,7 @@ kustomize:
 
 - name: lb-resources
   path: lb/resources
-  when: vm?.driver != 'docker-desktop'
+  when: vm.driver != 'docker-desktop'
   dependsOn:
     - lb-base
   components:
@@ -68,7 +68,7 @@ kustomize:
 # Ingress
 - name: ingress
   path: ingress
-  when: vm?.driver != 'docker-desktop'
+  when: vm.driver != 'docker-desktop'
   dependsOn:
     - pki-base
   components:
@@ -81,7 +81,7 @@ kustomize:
 # Ingress
 - name: ingress
   path: ingress
-  when: ingress?.enabled == true && ingress?.driver == 'nginx'
+  when: ingress.enabled == true && ingress.driver == 'nginx'
   dependsOn:
     - pki-base
   components:

--- a/contexts/_template/facets/provider-incus.yaml
+++ b/contexts/_template/facets/provider-incus.yaml
@@ -11,12 +11,12 @@ terraform:
 - name: compute
   path: compute/incus
   inputs:
-    network_name: "${vm?.driver == 'colima' ? 'incusbr0' : ''}"
-    create_network: "${vm?.driver != 'colima'}"
+    network_name: "${vm.driver == 'colima' ? 'incusbr0' : ''}"
+    create_network: "${vm.driver != 'colima'}"
     network_cidr: ${network.cidr_block}
     storage_pools:
       local:
-        driver: "${vm?.driver == 'colima' ? 'dir' : null}"
+        driver: "${vm.driver == 'colima' ? 'dir' : null}"
     instances:
       - name: controlplane
         role: controlplane
@@ -25,7 +25,7 @@ terraform:
         image: windsor:talos/v1.12.1/arm64
         type: virtual-machine
         description: Talos control plane node
-        storage_pool: "${vm?.driver == 'colima' ? 'local' : 'default'}"
+        storage_pool: "${vm.driver == 'colima' ? 'local' : 'default'}"
         root_disk_size: ${string(cluster.controlplanes.root_disk_size ?? 30) + "GB"}
         limits:
           cpu: ${string(cluster.controlplanes.cpu ?? 2)}
@@ -42,15 +42,15 @@ terraform:
         image: windsor:talos/v1.12.1/arm64
         type: virtual-machine
         description: Talos worker node
-        storage_pool: "${vm?.driver == 'colima' ? 'local' : 'default'}"
-        root_disk_size: ${string(cluster.workers?.root_disk_size ?? 50) + "GB"}
+        storage_pool: "${vm.driver == 'colima' ? 'local' : 'default'}"
+        root_disk_size: ${string(cluster.workers.root_disk_size ?? 50) + "GB"}
         limits:
-          cpu: ${string(cluster.workers?.cpu ?? 4)}
-          memory: ${string(cluster.workers?.memory ?? 4) + "GB"}
-        disks: ${cluster.workers?.disks ?? []}
+          cpu: ${string(cluster.workers.cpu ?? 4)}
+          memory: ${string(cluster.workers.memory ?? 4) + "GB"}
+        disks: ${cluster.workers.disks ?? []}
         config:
-          user.hostname: "${cluster.workers?.nodes != null ? (values(cluster.workers.nodes)[0].hostname ?? 'worker-1') : 'worker-1'}"
-          environment.TALOSSKU: "${string(cluster.workers?.cpu ?? 4) + 'CPU-' + string(cluster.workers?.memory ?? 4) + 'GB'}"
+          user.hostname: "${cluster.workers.nodes != null ? (values(cluster.workers.nodes)[0].hostname ?? 'worker-1') : 'worker-1'}"
+          environment.TALOSSKU: "${string(cluster.workers.cpu ?? 4) + 'CPU-' + string(cluster.workers.memory ?? 4) + 'GB'}"
           raw.qemu: -boot order=c,menu=off
 
 - name: cluster
@@ -62,7 +62,7 @@ terraform:
     cluster_endpoint: ${cluster.endpoint ?? ("https://" + split(terraform_output("compute", "controlplanes")[0].endpoint, ":")[0] + ":6443")}
     cluster_name: talos
     controlplanes: ${terraform_output("compute", "controlplanes") ?? values(cluster.controlplanes.nodes)}
-    workers: "${terraform_output('compute', 'workers') ?? (cluster.workers?.nodes != null ? values(cluster.workers.nodes) : [])}"
+    workers: "${terraform_output('compute', 'workers') ?? (cluster.workers.nodes != null ? values(cluster.workers.nodes) : [])}"
     common_config_patches: ${jsonnet("../configs/talos-generic.jsonnet").common_config_patches}
     worker_config_patches: ${jsonnet("../configs/talos-generic.jsonnet").worker_config_patches}
     controlplane_config_patches: ${jsonnet("../configs/talos-generic.jsonnet").controlplane_config_patches}
@@ -85,7 +85,7 @@ kustomize:
   - openebs
   - openebs/dynamic-localpv
   substitutions:
-    local_volume_path: "${cluster.controlplanes?.schedulable == true ? split(cluster.controlplanes?.volumes[0] ?? '/var/local', ':')[len(split(cluster.controlplanes?.volumes[0] ?? '/var/local', ':')) - 1] : split(cluster.workers?.volumes[0] ?? '/var/local', ':')[len(split(cluster.workers?.volumes[0] ?? '/var/local', ':')) - 1]}"
+    local_volume_path: "${cluster.controlplanes.schedulable == true ? split(cluster.controlplanes.volumes[0] ?? '/var/local', ':')[len(split(cluster.controlplanes.volumes[0] ?? '/var/local', ':')) - 1] : split(cluster.workers.volumes[0] ?? '/var/local', ':')[len(split(cluster.workers.volumes[0] ?? '/var/local', ':')) - 1]}"
   timeout: 20m
   interval: 5m
 
@@ -126,7 +126,7 @@ kustomize:
 # Ingress
 - name: ingress
   path: ingress
-  when: ingress?.enabled == true
+  when: ingress.enabled == true
   dependsOn:
   - pki-base
   components:

--- a/contexts/_template/tests/addon-database.test.yaml
+++ b/contexts/_template/tests/addon-database.test.yaml
@@ -1,0 +1,129 @@
+# Note: All tests with provider: generic require cluster.controlplanes.nodes and network
+
+# Common configurations
+x-defaults:
+  network: &default-network
+    loadbalancer_driver: kube-vip
+    loadbalancer_mode: arp
+    loadbalancer_ips:
+      start: "10.5.1.10"
+      end: "10.5.1.100"
+
+  cluster: &default-cluster
+    controlplanes:
+      nodes:
+        controlplane-1:
+          endpoint: 10.5.0.10:50000
+          node: 10.5.0.10
+          hostname: controlplane-1
+    workers:
+      volumes:
+        - /var/local
+
+  ingress-disabled: &ingress-disabled
+    enabled: false
+    driver: nginx
+
+cases:
+  - name: creates database with cloudnativepg and prometheus when dev mode enabled
+    values:
+      provider: generic
+      dev: true
+      network: *default-network
+      cluster: *default-cluster
+    expect:
+      kustomize:
+        - name: database
+          path: database
+          dependsOn:
+            - csi
+          components:
+            - cloudnativepg
+            - cloudnativepg/prometheus
+          timeout: 15m
+          interval: 10m
+
+  - name: creates database when addon explicitly enabled
+    values:
+      provider: generic
+      network: *default-network
+      cluster: *default-cluster
+      addons:
+        database:
+          postgres:
+            enabled: true
+            driver: cloudnativepg
+    expect:
+      kustomize:
+        - name: database
+          path: database
+          dependsOn:
+            - csi
+          components:
+            - cloudnativepg
+            - cloudnativepg/prometheus
+
+  - name: excludes database when addon disabled
+    values:
+      provider: generic
+      ingress: *ingress-disabled
+      network: *default-network
+      cluster: *default-cluster
+      addons:
+        database:
+          postgres:
+            enabled: false
+    exclude:
+      kustomize:
+        - name: database
+
+  - name: adds HA component when ha enabled
+    values:
+      provider: generic
+      network: *default-network
+      cluster: *default-cluster
+      addons:
+        database:
+          postgres:
+            enabled: true
+            driver: cloudnativepg
+      ha: true
+    expect:
+      kustomize:
+        - name: database
+          components:
+            - cloudnativepg/ha
+
+  - name: creates database without HA when ha disabled
+    values:
+      provider: generic
+      ingress: *ingress-disabled
+      network: *default-network
+      cluster: *default-cluster
+      addons:
+        database:
+          postgres:
+            enabled: true
+            driver: cloudnativepg
+      ha: false
+    expect:
+      kustomize:
+        - name: database
+          components:
+            - cloudnativepg
+            - cloudnativepg/prometheus
+
+  - name: includes Grafana dashboard when observability enabled
+    values:
+      provider: generic
+      dev: true
+      network: *default-network
+      cluster: *default-cluster
+      addons:
+        observability:
+          enabled: true
+    expect:
+      kustomize:
+        - name: observability
+          components:
+            - grafana/dashboards/cloudnativepg

--- a/contexts/_template/tests/addon-database.test.yaml
+++ b/contexts/_template/tests/addon-database.test.yaml
@@ -1,4 +1,5 @@
-# Note: All tests with provider: generic require cluster.controlplanes.nodes and network
+# addon-database.yaml facet tests
+# Tests CloudNativePG database operator with HA and observability integration
 
 # Common configurations
 x-defaults:
@@ -25,7 +26,8 @@ x-defaults:
     driver: nginx
 
 cases:
-  - name: creates database with cloudnativepg and prometheus when dev mode enabled
+  # Minimal: Test default behavior with dev mode (implicit enablement)
+  - name: minimal config creates database with defaults via dev mode
     values:
       provider: generic
       dev: true
@@ -42,17 +44,25 @@ cases:
             - cloudnativepg/prometheus
           timeout: 15m
           interval: 10m
+        - name: observability
+          path: observability
+          components:
+            - grafana/dashboards/cloudnativepg
 
-  - name: creates database when addon explicitly enabled
+  # Full: Test all configurable options together
+  - name: full config creates database with HA and observability integration
     values:
       provider: generic
       network: *default-network
       cluster: *default-cluster
+      ha: true
       addons:
         database:
           postgres:
             enabled: true
             driver: cloudnativepg
+        observability:
+          enabled: true
     expect:
       kustomize:
         - name: database
@@ -62,7 +72,14 @@ cases:
           components:
             - cloudnativepg
             - cloudnativepg/prometheus
+            - cloudnativepg/ha
+          timeout: 15m
+          interval: 10m
+        - name: observability
+          components:
+            - grafana/dashboards/cloudnativepg
 
+  # Edge case: Explicit disable
   - name: excludes database when addon disabled
     values:
       provider: generic
@@ -77,53 +94,27 @@ cases:
       kustomize:
         - name: database
 
-  - name: adds HA component when ha enabled
-    values:
-      provider: generic
-      network: *default-network
-      cluster: *default-cluster
-      addons:
-        database:
-          postgres:
-            enabled: true
-            driver: cloudnativepg
-      ha: true
-    expect:
-      kustomize:
-        - name: database
-          components:
-            - cloudnativepg/ha
-
+  # Edge case: HA disabled explicitly - database created without HA component
   - name: creates database without HA when ha disabled
     values:
       provider: generic
       ingress: *ingress-disabled
       network: *default-network
       cluster: *default-cluster
+      ha: false
       addons:
         database:
           postgres:
             enabled: true
             driver: cloudnativepg
-      ha: false
     expect:
       kustomize:
         - name: database
+          path: database
+          dependsOn:
+            - csi
           components:
             - cloudnativepg
             - cloudnativepg/prometheus
-
-  - name: includes Grafana dashboard when observability enabled
-    values:
-      provider: generic
-      dev: true
-      network: *default-network
-      cluster: *default-cluster
-      addons:
-        observability:
-          enabled: true
-    expect:
-      kustomize:
-        - name: observability
-          components:
-            - grafana/dashboards/cloudnativepg
+          timeout: 15m
+          interval: 10m

--- a/contexts/_template/tests/addon-object-store.test.yaml
+++ b/contexts/_template/tests/addon-object-store.test.yaml
@@ -1,4 +1,5 @@
-# Note: All tests with provider: generic require cluster.controlplanes.nodes and network
+# addon-object-store.yaml facet tests
+# Tests MinIO object storage service
 
 # Common configurations
 x-defaults:
@@ -25,7 +26,8 @@ x-defaults:
     driver: nginx
 
 cases:
-  - name: creates Minio object store when enabled with ingress
+  # Full: Test MinIO with all dependencies (no dev mode implicit enablement)
+  - name: full config creates MinIO object store with ingress dependency
     values:
       provider: generic
       vm:
@@ -43,12 +45,15 @@ cases:
       kustomize:
         - name: object-store-base
           path: object-store/base
+          timeout: 10m
+          interval: 5m
           dependsOn:
             - csi
             - ingress
           components:
             - minio
 
+  # Edge case: Addon disabled
   - name: excludes object store when addon disabled
     values:
       provider: generic
@@ -61,7 +66,8 @@ cases:
       kustomize:
         - name: object-store-base
 
-  - name: fails when Minio enabled without ingress
+  # Edge case: MinIO without ingress fails
+  - name: fails when MinIO enabled without ingress
     values:
       provider: generic
       vm:

--- a/contexts/_template/tests/addon-object-store.test.yaml
+++ b/contexts/_template/tests/addon-object-store.test.yaml
@@ -1,0 +1,76 @@
+# Note: All tests with provider: generic require cluster.controlplanes.nodes and network
+
+# Common configurations
+x-defaults:
+  network: &default-network
+    loadbalancer_driver: kube-vip
+    loadbalancer_mode: arp
+    loadbalancer_ips:
+      start: "10.5.1.10"
+      end: "10.5.1.100"
+
+  cluster: &default-cluster
+    controlplanes:
+      nodes:
+        controlplane-1:
+          endpoint: 10.5.0.10:50000
+          node: 10.5.0.10
+          hostname: controlplane-1
+    workers:
+      volumes:
+        - /var/local
+
+  ingress-disabled: &ingress-disabled
+    enabled: false
+    driver: nginx
+
+cases:
+  - name: creates Minio object store when enabled with ingress
+    values:
+      provider: generic
+      vm:
+        driver: colima
+      ingress:
+        enabled: true
+        driver: nginx
+      network: *default-network
+      cluster: *default-cluster
+      addons:
+        object_store:
+          enabled: true
+          driver: minio
+    expect:
+      kustomize:
+        - name: object-store-base
+          path: object-store/base
+          dependsOn:
+            - csi
+            - ingress
+          components:
+            - minio
+
+  - name: excludes object store when addon disabled
+    values:
+      provider: generic
+      network: *default-network
+      cluster: *default-cluster
+      addons:
+        object_store:
+          enabled: false
+    exclude:
+      kustomize:
+        - name: object-store-base
+
+  - name: fails when Minio enabled without ingress
+    values:
+      provider: generic
+      vm:
+        driver: docker-desktop
+      ingress: *ingress-disabled
+      network: *default-network
+      cluster: *default-cluster
+      addons:
+        object_store:
+          enabled: true
+          driver: minio
+    expectError: true

--- a/contexts/_template/tests/addon-observability.test.yaml
+++ b/contexts/_template/tests/addon-observability.test.yaml
@@ -1,4 +1,5 @@
-# Note: All tests with provider: generic require cluster.controlplanes.nodes and network
+# addon-observability.yaml facet tests
+# Tests observability stack with multiple log drivers and time format options
 
 # Common configurations
 x-defaults:
@@ -25,17 +26,13 @@ x-defaults:
     driver: nginx
 
 cases:
-  - name: creates observability with Grafana dashboards and ingress in dev mode
+  # Minimal: Test default behavior with dev mode (implicit enablement, 24h default format)
+  - name: minimal config creates observability with defaults via dev mode
     values:
       provider: generic
       dev: true
       dns:
         domain: example.local
-      timezone: America/New_York
-      time_format: 12h
-      ingress:
-        enabled: true
-        driver: nginx
       network: *default-network
       cluster: *default-cluster
     expect:
@@ -54,60 +51,23 @@ cases:
             - grafana/dashboards/nginx
           substitutions:
             external_domain: example.local
-            timezone: America/New_York
-            date_full: "MMM DD, YYYY @ hh:mm:ss a"
-        - name: observability
-          dependsOn:
-            - ingress
-          components:
-            - grafana/ingress
-
-  - name: uses 24h time format when specified
-    values:
-      provider: generic
-      dev: true
-      time_format: 24h
-      network: *default-network
-      cluster: *default-cluster
-    expect:
-      kustomize:
-        - name: observability
-          substitutions:
             date_full: "YYYY-MM-DD HH:mm:ss"
             date_interval_second: "HH:mm:ss"
             date_interval_minute: "HH:mm"
             date_interval_hour: "MM/DD HH:mm"
             date_interval_day: "MM/DD"
 
-  - name: creates observability when addon explicitly enabled
+  # Full: Test all configurable options with stdout driver
+  - name: full config with stdout driver creates FluentD pipeline and log filtering
     values:
       provider: generic
-      network: *default-network
-      cluster: *default-cluster
-      addons:
-        observability:
-          enabled: true
-    expect:
-      kustomize:
-        - name: observability
-          path: observability
-
-  - name: excludes observability when addon disabled
-    values:
-      provider: generic
-      ingress: *ingress-disabled
-      network: *default-network
-      cluster: *default-cluster
-      addons:
-        observability:
-          enabled: false
-    exclude:
-      kustomize:
-        - name: observability
-
-  - name: creates FluentD stdout pipeline with otel filter
-    values:
-      provider: generic
+      dns:
+        domain: full.example.com
+      time_format: 24h
+      log_level: warn
+      ingress:
+        enabled: true
+        driver: nginx
       network: *default-network
       cluster: *default-cluster
       addons:
@@ -116,22 +76,47 @@ cases:
           logs_driver: stdout
     expect:
       kustomize:
+        - name: observability
+          path: observability
+          timeout: 15m
+          interval: 10m
+          components:
+            - grafana
+            - grafana/prometheus
+            - grafana/dashboards/node
+            - grafana/dashboards/kubernetes
+            - grafana/dashboards/flux
+            - grafana/dashboards/cert-manager
+            - grafana/dashboards/nginx
+            - grafana/ingress
+            - fluentd
+            - fluentd/filters/otel
+            - fluentd/outputs/stdout
+            - fluentd/filters/log-level/warn
+          substitutions:
+            external_domain: full.example.com
+            date_full: "YYYY-MM-DD HH:mm:ss"
+            date_interval_second: "HH:mm:ss"
+            date_interval_minute: "HH:mm"
+            date_interval_hour: "MM/DD HH:mm"
+            date_interval_day: "MM/DD"
+        - name: observability
+          dependsOn:
+            - ingress
+          components:
+            - grafana/ingress
         - name: telemetry-resources
           dependsOn:
             - telemetry-base
           components:
             - fluentbit/fluentd
-        - name: observability
-          dependsOn:
-            - telemetry-resources
-          components:
-            - fluentd
-            - fluentd/filters/otel
-            - fluentd/outputs/stdout
 
-  - name: creates Quickwit storage pipeline with PVC and dashboards
+  # Full: Test Quickwit storage driver with all components
+  - name: full config with quickwit driver creates storage pipeline with PVC and dashboards
     values:
       provider: generic
+      dns:
+        domain: quickwit.example.com
       network: *default-network
       cluster: *default-cluster
       addons:
@@ -153,12 +138,22 @@ cases:
             - quickwit/prometheus
             - grafana/quickwit
             - grafana/dashboards/logs/quickwit
+            - fluentd/filters/log-level/info
+        - name: telemetry-resources
+          dependsOn:
+            - telemetry-base
+          components:
+            - fluentbit/fluentd
 
-  - name: creates ELK stack with filebeat telemetry
+  # Full: Test Elasticsearch driver with ELK stack
+  - name: full config with elasticsearch driver creates ELK stack with filebeat
     values:
       provider: generic
       dns:
         domain: elk.example.com
+      ingress:
+        enabled: true
+        driver: nginx
       network: *default-network
       cluster: *default-cluster
       addons:
@@ -190,38 +185,8 @@ cases:
             - prometheus
             - prometheus/flux
 
-  - name: creates log level filter for warn level
-    values:
-      provider: generic
-      network: *default-network
-      cluster: *default-cluster
-      addons:
-        observability:
-          enabled: true
-          logs_driver: stdout
-      log_level: warn
-    expect:
-      kustomize:
-        - name: observability
-          components:
-            - fluentd/filters/log-level/warn
-
-  - name: uses default info log level filter
-    values:
-      provider: generic
-      network: *default-network
-      cluster: *default-cluster
-      addons:
-        observability:
-          enabled: true
-          logs_driver: stdout
-    expect:
-      kustomize:
-        - name: observability
-          components:
-            - fluentd/filters/log-level/info
-
-  - name: creates stdout pipeline without log filter when trace level selected
+  # Edge case: Addon disabled
+  - name: excludes observability when addon disabled
     values:
       provider: generic
       ingress: *ingress-disabled
@@ -229,12 +194,27 @@ cases:
       cluster: *default-cluster
       addons:
         observability:
+          enabled: false
+    exclude:
+      kustomize:
+        - name: observability
+
+  # Edge case: Trace log level skips log filter - stdout output without log-level filter
+  - name: trace log level creates stdout pipeline without log filter
+    values:
+      provider: generic
+      ingress: *ingress-disabled
+      network: *default-network
+      cluster: *default-cluster
+      log_level: trace
+      addons:
+        observability:
           enabled: true
           logs_driver: stdout
-      log_level: trace
     expect:
       kustomize:
         - name: observability
+          path: observability
           dependsOn:
             - telemetry-resources
           components:
@@ -242,6 +222,7 @@ cases:
             - fluentd/filters/otel
             - fluentd/outputs/stdout
 
+  # Edge case: Elasticsearch without ingress fails
   - name: fails when elasticsearch selected without ingress
     values:
       provider: generic

--- a/contexts/_template/tests/addon-observability.test.yaml
+++ b/contexts/_template/tests/addon-observability.test.yaml
@@ -1,0 +1,257 @@
+# Note: All tests with provider: generic require cluster.controlplanes.nodes and network
+
+# Common configurations
+x-defaults:
+  network: &default-network
+    loadbalancer_driver: kube-vip
+    loadbalancer_mode: arp
+    loadbalancer_ips:
+      start: "10.5.1.10"
+      end: "10.5.1.100"
+
+  cluster: &default-cluster
+    controlplanes:
+      nodes:
+        controlplane-1:
+          endpoint: 10.5.0.10:50000
+          node: 10.5.0.10
+          hostname: controlplane-1
+    workers:
+      volumes:
+        - /var/local
+
+  ingress-disabled: &ingress-disabled
+    enabled: false
+    driver: nginx
+
+cases:
+  - name: creates observability with Grafana dashboards and ingress in dev mode
+    values:
+      provider: generic
+      dev: true
+      dns:
+        domain: example.local
+      timezone: America/New_York
+      time_format: 12h
+      ingress:
+        enabled: true
+        driver: nginx
+      network: *default-network
+      cluster: *default-cluster
+    expect:
+      kustomize:
+        - name: observability
+          path: observability
+          timeout: 15m
+          interval: 10m
+          components:
+            - grafana
+            - grafana/prometheus
+            - grafana/dashboards/node
+            - grafana/dashboards/kubernetes
+            - grafana/dashboards/flux
+            - grafana/dashboards/cert-manager
+            - grafana/dashboards/nginx
+          substitutions:
+            external_domain: example.local
+            timezone: America/New_York
+            date_full: "MMM DD, YYYY @ hh:mm:ss a"
+        - name: observability
+          dependsOn:
+            - ingress
+          components:
+            - grafana/ingress
+
+  - name: uses 24h time format when specified
+    values:
+      provider: generic
+      dev: true
+      time_format: 24h
+      network: *default-network
+      cluster: *default-cluster
+    expect:
+      kustomize:
+        - name: observability
+          substitutions:
+            date_full: "YYYY-MM-DD HH:mm:ss"
+            date_interval_second: "HH:mm:ss"
+            date_interval_minute: "HH:mm"
+            date_interval_hour: "MM/DD HH:mm"
+            date_interval_day: "MM/DD"
+
+  - name: creates observability when addon explicitly enabled
+    values:
+      provider: generic
+      network: *default-network
+      cluster: *default-cluster
+      addons:
+        observability:
+          enabled: true
+    expect:
+      kustomize:
+        - name: observability
+          path: observability
+
+  - name: excludes observability when addon disabled
+    values:
+      provider: generic
+      ingress: *ingress-disabled
+      network: *default-network
+      cluster: *default-cluster
+      addons:
+        observability:
+          enabled: false
+    exclude:
+      kustomize:
+        - name: observability
+
+  - name: creates FluentD stdout pipeline with otel filter
+    values:
+      provider: generic
+      network: *default-network
+      cluster: *default-cluster
+      addons:
+        observability:
+          enabled: true
+          logs_driver: stdout
+    expect:
+      kustomize:
+        - name: telemetry-resources
+          dependsOn:
+            - telemetry-base
+          components:
+            - fluentbit/fluentd
+        - name: observability
+          dependsOn:
+            - telemetry-resources
+          components:
+            - fluentd
+            - fluentd/filters/otel
+            - fluentd/outputs/stdout
+
+  - name: creates Quickwit storage pipeline with PVC and dashboards
+    values:
+      provider: generic
+      network: *default-network
+      cluster: *default-cluster
+      addons:
+        observability:
+          enabled: true
+          logs_driver: quickwit
+    expect:
+      kustomize:
+        - name: observability
+          dependsOn:
+            - csi
+            - telemetry-resources
+          components:
+            - fluentd
+            - fluentd/filters/otel
+            - fluentd/outputs/quickwit
+            - quickwit
+            - quickwit/pvc
+            - quickwit/prometheus
+            - grafana/quickwit
+            - grafana/dashboards/logs/quickwit
+
+  - name: creates ELK stack with filebeat telemetry
+    values:
+      provider: generic
+      dns:
+        domain: elk.example.com
+      network: *default-network
+      cluster: *default-cluster
+      addons:
+        observability:
+          enabled: true
+          logs_driver: elasticsearch
+    expect:
+      kustomize:
+        - name: observability
+          dependsOn:
+            - csi
+            - ingress
+          components:
+            - elasticsearch
+            - kibana
+            - kibana/ingress
+          substitutions:
+            external_domain: elk.example.com
+        - name: telemetry-base
+          strategy: replace
+          components:
+            - prometheus
+            - prometheus/flux
+            - filebeat
+        - name: telemetry-resources
+          strategy: replace
+          components:
+            - metrics-server
+            - prometheus
+            - prometheus/flux
+
+  - name: creates log level filter for warn level
+    values:
+      provider: generic
+      network: *default-network
+      cluster: *default-cluster
+      addons:
+        observability:
+          enabled: true
+          logs_driver: stdout
+      log_level: warn
+    expect:
+      kustomize:
+        - name: observability
+          components:
+            - fluentd/filters/log-level/warn
+
+  - name: uses default info log level filter
+    values:
+      provider: generic
+      network: *default-network
+      cluster: *default-cluster
+      addons:
+        observability:
+          enabled: true
+          logs_driver: stdout
+    expect:
+      kustomize:
+        - name: observability
+          components:
+            - fluentd/filters/log-level/info
+
+  - name: creates stdout pipeline without log filter when trace level selected
+    values:
+      provider: generic
+      ingress: *ingress-disabled
+      network: *default-network
+      cluster: *default-cluster
+      addons:
+        observability:
+          enabled: true
+          logs_driver: stdout
+      log_level: trace
+    expect:
+      kustomize:
+        - name: observability
+          dependsOn:
+            - telemetry-resources
+          components:
+            - fluentd
+            - fluentd/filters/otel
+            - fluentd/outputs/stdout
+
+  - name: fails when elasticsearch selected without ingress
+    values:
+      provider: generic
+      vm:
+        driver: docker-desktop
+      ingress: *ingress-disabled
+      network: *default-network
+      cluster: *default-cluster
+      addons:
+        observability:
+          enabled: true
+          logs_driver: elasticsearch
+    expectError: true

--- a/contexts/_template/tests/addon-private-ca.test.yaml
+++ b/contexts/_template/tests/addon-private-ca.test.yaml
@@ -1,4 +1,5 @@
-# Note: All tests with provider: generic require cluster.controlplanes.nodes and network
+# addon-private-ca.yaml facet tests
+# Tests private Certificate Authority with trust-manager integration
 
 # Common configurations
 x-defaults:
@@ -25,7 +26,8 @@ x-defaults:
     driver: nginx
 
 cases:
-  - name: creates private CA when dev mode enabled
+  # Minimal: Test default behavior with dev mode (implicit enablement)
+  - name: minimal config creates private CA with defaults via dev mode
     values:
       provider: generic
       dev: true
@@ -34,15 +36,22 @@ cases:
     expect:
       kustomize:
         - name: pki-base
+          path: pki/base
+          timeout: 10m
+          interval: 5m
           components:
             - trust-manager
         - name: pki-resources
+          path: pki/resources
           dependsOn:
             - pki-base
+          timeout: 5m
+          interval: 5m
           components:
             - private-issuer/ca
 
-  - name: creates private CA when addon explicitly enabled
+  # Full: Test explicit enablement (same output as minimal - no additional options)
+  - name: full config creates private CA when addon explicitly enabled
     values:
       provider: generic
       network: *default-network
@@ -53,14 +62,21 @@ cases:
     expect:
       kustomize:
         - name: pki-base
+          path: pki/base
+          timeout: 10m
+          interval: 5m
           components:
             - trust-manager
         - name: pki-resources
+          path: pki/resources
           dependsOn:
             - pki-base
+          timeout: 5m
+          interval: 5m
           components:
             - private-issuer/ca
 
+  # Edge case: Addon disabled
   - name: excludes private CA when addon disabled
     values:
       provider: generic

--- a/contexts/_template/tests/addon-private-ca.test.yaml
+++ b/contexts/_template/tests/addon-private-ca.test.yaml
@@ -1,0 +1,77 @@
+# Note: All tests with provider: generic require cluster.controlplanes.nodes and network
+
+# Common configurations
+x-defaults:
+  network: &default-network
+    loadbalancer_driver: kube-vip
+    loadbalancer_mode: arp
+    loadbalancer_ips:
+      start: "10.5.1.10"
+      end: "10.5.1.100"
+
+  cluster: &default-cluster
+    controlplanes:
+      nodes:
+        controlplane-1:
+          endpoint: 10.5.0.10:50000
+          node: 10.5.0.10
+          hostname: controlplane-1
+    workers:
+      volumes:
+        - /var/local
+
+  ingress-disabled: &ingress-disabled
+    enabled: false
+    driver: nginx
+
+cases:
+  - name: creates private CA when dev mode enabled
+    values:
+      provider: generic
+      dev: true
+      network: *default-network
+      cluster: *default-cluster
+    expect:
+      kustomize:
+        - name: pki-base
+          components:
+            - trust-manager
+        - name: pki-resources
+          dependsOn:
+            - pki-base
+          components:
+            - private-issuer/ca
+
+  - name: creates private CA when addon explicitly enabled
+    values:
+      provider: generic
+      network: *default-network
+      cluster: *default-cluster
+      addons:
+        private_ca:
+          enabled: true
+    expect:
+      kustomize:
+        - name: pki-base
+          components:
+            - trust-manager
+        - name: pki-resources
+          dependsOn:
+            - pki-base
+          components:
+            - private-issuer/ca
+
+  - name: excludes private CA when addon disabled
+    values:
+      provider: generic
+      ingress: *ingress-disabled
+      network: *default-network
+      cluster: *default-cluster
+      addons:
+        private_ca:
+          enabled: false
+    exclude:
+      kustomize:
+        - name: pki-resources
+          components:
+            - private-issuer/ca

--- a/contexts/_template/tests/addon-private-dns.test.yaml
+++ b/contexts/_template/tests/addon-private-dns.test.yaml
@@ -1,4 +1,5 @@
-# Note: All tests with provider: generic require cluster.controlplanes.nodes and network
+# addon-private-dns.yaml facet tests
+# Tests CoreDNS for private DNS zones with external-dns integration
 
 # Common configurations
 x-defaults:
@@ -25,7 +26,8 @@ x-defaults:
     driver: nginx
 
 cases:
-  - name: creates CoreDNS when dev mode enabled
+  # Minimal: Test default behavior with dev mode (implicit enablement)
+  - name: minimal config creates CoreDNS with defaults via dev mode
     values:
       provider: generic
       dev: true
@@ -37,6 +39,8 @@ cases:
           path: dns
           dependsOn:
             - pki-base
+          timeout: 10m
+          interval: 5m
           components:
             - coredns
             - coredns/etcd
@@ -44,27 +48,40 @@ cases:
             - external-dns/coredns
             - external-dns/ingress
 
-  - name: creates CoreDNS when addon explicitly enabled
+  # Full: Test all options with ingress and Docker Desktop
+  - name: full config creates CoreDNS with localhost external-dns on Docker Desktop
     values:
       provider: generic
+      dev: true
+      vm:
+        driver: docker-desktop
+      ingress:
+        enabled: true
+        driver: nginx
       network: *default-network
       cluster: *default-cluster
-      addons:
-        private_dns:
-          enabled: true
     expect:
       kustomize:
         - name: dns
           path: dns
           dependsOn:
             - pki-base
+          timeout: 10m
+          interval: 5m
           components:
             - coredns
             - coredns/etcd
             - external-dns
             - external-dns/coredns
             - external-dns/ingress
+            - external-dns/localhost
+        - name: ingress
+          dependsOn:
+            - pki-base
+          components:
+            - nginx/coredns
 
+  # Edge case: Addon disabled
   - name: excludes DNS when addon disabled
     values:
       provider: generic
@@ -77,34 +94,3 @@ cases:
     exclude:
       kustomize:
         - name: dns
-
-  - name: adds localhost external-dns on Docker Desktop
-    values:
-      provider: generic
-      dev: true
-      vm:
-        driver: docker-desktop
-      network: *default-network
-      cluster: *default-cluster
-    expect:
-      kustomize:
-        - name: dns
-          components:
-            - external-dns/localhost
-
-  - name: adds nginx coredns when ingress and DNS enabled
-    values:
-      provider: generic
-      dev: true
-      ingress:
-        enabled: true
-        driver: nginx
-      network: *default-network
-      cluster: *default-cluster
-    expect:
-      kustomize:
-        - name: ingress
-          dependsOn:
-            - pki-base
-          components:
-            - nginx/coredns

--- a/contexts/_template/tests/addon-private-dns.test.yaml
+++ b/contexts/_template/tests/addon-private-dns.test.yaml
@@ -1,0 +1,110 @@
+# Note: All tests with provider: generic require cluster.controlplanes.nodes and network
+
+# Common configurations
+x-defaults:
+  network: &default-network
+    loadbalancer_driver: kube-vip
+    loadbalancer_mode: arp
+    loadbalancer_ips:
+      start: "10.5.1.10"
+      end: "10.5.1.100"
+
+  cluster: &default-cluster
+    controlplanes:
+      nodes:
+        controlplane-1:
+          endpoint: 10.5.0.10:50000
+          node: 10.5.0.10
+          hostname: controlplane-1
+    workers:
+      volumes:
+        - /var/local
+
+  ingress-disabled: &ingress-disabled
+    enabled: false
+    driver: nginx
+
+cases:
+  - name: creates CoreDNS when dev mode enabled
+    values:
+      provider: generic
+      dev: true
+      network: *default-network
+      cluster: *default-cluster
+    expect:
+      kustomize:
+        - name: dns
+          path: dns
+          dependsOn:
+            - pki-base
+          components:
+            - coredns
+            - coredns/etcd
+            - external-dns
+            - external-dns/coredns
+            - external-dns/ingress
+
+  - name: creates CoreDNS when addon explicitly enabled
+    values:
+      provider: generic
+      network: *default-network
+      cluster: *default-cluster
+      addons:
+        private_dns:
+          enabled: true
+    expect:
+      kustomize:
+        - name: dns
+          path: dns
+          dependsOn:
+            - pki-base
+          components:
+            - coredns
+            - coredns/etcd
+            - external-dns
+            - external-dns/coredns
+            - external-dns/ingress
+
+  - name: excludes DNS when addon disabled
+    values:
+      provider: generic
+      ingress: *ingress-disabled
+      network: *default-network
+      cluster: *default-cluster
+      addons:
+        private_dns:
+          enabled: false
+    exclude:
+      kustomize:
+        - name: dns
+
+  - name: adds localhost external-dns on Docker Desktop
+    values:
+      provider: generic
+      dev: true
+      vm:
+        driver: docker-desktop
+      network: *default-network
+      cluster: *default-cluster
+    expect:
+      kustomize:
+        - name: dns
+          components:
+            - external-dns/localhost
+
+  - name: adds nginx coredns when ingress and DNS enabled
+    values:
+      provider: generic
+      dev: true
+      ingress:
+        enabled: true
+        driver: nginx
+      network: *default-network
+      cluster: *default-cluster
+    expect:
+      kustomize:
+        - name: ingress
+          dependsOn:
+            - pki-base
+          components:
+            - nginx/coredns

--- a/contexts/_template/tests/base.test.yaml
+++ b/contexts/_template/tests/base.test.yaml
@@ -1,0 +1,68 @@
+# Base facet tests - uses provider: aws to avoid cluster.controlplanes.nodes requirement
+cases:
+  - name: creates foundational components with correct dependencies and timeouts
+    values:
+      provider: aws
+      ingress:
+        enabled: false
+        driver: nginx
+    expect:
+      kustomize:
+        - name: cleanup
+          path: cleanup
+          destroyOnly: true
+          components:
+            - ingresses
+            - loadbalancers
+            - pvcs
+          timeout: 10m
+          interval: 5m
+        - name: policy-base
+          path: policy/base
+          components:
+            - kyverno
+          timeout: 30m
+          interval: 5m
+        - name: policy-resources
+          path: policy/resources
+          dependsOn:
+            - policy-base
+          components:
+            - kyverno/audit-resource-limits-requests
+            - kyverno/require-image-digest
+          timeout: 5m
+          interval: 5m
+        - name: pki-base
+          path: pki/base
+          dependsOn:
+            - policy-resources
+            - telemetry-base
+          components:
+            - cert-manager
+            - cert-manager/prometheus
+          timeout: 20m
+          interval: 5m
+        - name: telemetry-base
+          path: telemetry/base
+          components:
+            - prometheus
+            - prometheus/flux
+            - fluentbit
+            - fluentbit/prometheus
+          timeout: 30m
+          interval: 10m
+        - name: telemetry-resources
+          path: telemetry/resources
+          dependsOn:
+            - telemetry-base
+          components:
+            - metrics-server
+            - prometheus
+            - prometheus/flux
+            - fluentbit
+            - fluentbit/containerd
+            - fluentbit/kubernetes
+            - fluentbit/parser
+            - fluentbit/systemd
+          timeout: 10m
+          interval: 5m

--- a/contexts/_template/tests/local-dev.test.yaml
+++ b/contexts/_template/tests/local-dev.test.yaml
@@ -1,4 +1,5 @@
-# Note: All tests with provider: generic require cluster.controlplanes.nodes and network
+# local-dev.yaml facet tests
+# Tests local development overrides for VM environments
 
 # Common configurations
 x-defaults:
@@ -25,10 +26,35 @@ x-defaults:
     driver: nginx
 
 cases:
-  - name: configures gitops with dev credentials and computed concurrency
+  # Minimal: Test default dev mode behavior with no optional values
+  - name: minimal dev config creates gitops with empty credentials and computed concurrency
     values:
       provider: generic
       dev: true
+      network: *default-network
+      cluster: *default-cluster
+    expect:
+      terraform:
+        - name: gitops
+          inputs:
+            git_username: ""
+            git_password: ""
+            webhook_token: abcdef123456
+            concurrency: 2
+      kustomize:
+        - name: pki-resources
+          path: pki/resources
+          dependsOn:
+            - pki-base
+          components:
+            - public-issuer/selfsigned
+
+  # Full: Test all configurable dev options together
+  - name: full dev config creates gitops with credentials, demo mode, custom Grafana password, and computed concurrency
+    values:
+      provider: generic
+      dev: true
+      demo: true
       network: *default-network
       cluster:
         controlplanes:
@@ -46,6 +72,10 @@ cases:
         livereload:
           username: devuser
           password: devpass
+      addons:
+        observability:
+          enabled: true
+          admin_password: supersecret
     expect:
       terraform:
         - name: gitops
@@ -54,28 +84,6 @@ cases:
             git_password: devpass
             webhook_token: abcdef123456
             concurrency: 4
-
-  - name: uses empty git credentials when not specified
-    values:
-      provider: generic
-      dev: true
-      network: *default-network
-      cluster: *default-cluster
-    expect:
-      terraform:
-        - name: gitops
-          inputs:
-            git_username: ""
-            git_password: ""
-            webhook_token: abcdef123456
-
-  - name: creates selfsigned issuer and Grafana dev config
-    values:
-      provider: generic
-      dev: true
-      network: *default-network
-      cluster: *default-cluster
-    expect:
       kustomize:
         - name: pki-resources
           path: pki/resources
@@ -87,32 +95,7 @@ cases:
           components:
             - grafana/dev
           substitutions:
-            admin_password: grafana
-
-  - name: uses custom Grafana admin password when specified
-    values:
-      provider: generic
-      dev: true
-      network: *default-network
-      cluster: *default-cluster
-      addons:
-        observability:
-          admin_password: supersecret
-    expect:
-      kustomize:
-        - name: observability
-          substitutions:
             admin_password: supersecret
-
-  - name: creates demo database when demo mode enabled
-    values:
-      provider: generic
-      dev: true
-      demo: true
-      network: *default-network
-      cluster: *default-cluster
-    expect:
-      kustomize:
         - name: demo-database
           path: demo
           dependsOn:
@@ -120,19 +103,8 @@ cases:
           components:
             - database
 
-  - name: excludes demo database when demo mode disabled
-    values:
-      provider: generic
-      dev: true
-      demo: false
-      ingress: *ingress-disabled
-      network: *default-network
-      cluster: *default-cluster
-    exclude:
-      kustomize:
-        - name: demo-database
-
-  - name: uses nodeport ingress on Docker Desktop
+  # Edge case: Docker Desktop uses nodeport ingress
+  - name: Docker Desktop uses nodeport ingress
     values:
       provider: generic
       dev: true
@@ -153,3 +125,16 @@ cases:
             - nginx/prometheus
           timeout: 10m
           interval: 5m
+
+  # Edge case: Demo mode disabled
+  - name: excludes demo database when demo mode disabled
+    values:
+      provider: generic
+      dev: true
+      demo: false
+      ingress: *ingress-disabled
+      network: *default-network
+      cluster: *default-cluster
+    exclude:
+      kustomize:
+        - name: demo-database

--- a/contexts/_template/tests/local-dev.test.yaml
+++ b/contexts/_template/tests/local-dev.test.yaml
@@ -1,0 +1,155 @@
+# Note: All tests with provider: generic require cluster.controlplanes.nodes and network
+
+# Common configurations
+x-defaults:
+  network: &default-network
+    loadbalancer_driver: kube-vip
+    loadbalancer_mode: arp
+    loadbalancer_ips:
+      start: "10.5.1.10"
+      end: "10.5.1.100"
+
+  cluster: &default-cluster
+    controlplanes:
+      nodes:
+        controlplane-1:
+          endpoint: 10.5.0.10:50000
+          node: 10.5.0.10
+          hostname: controlplane-1
+    workers:
+      volumes:
+        - /var/local
+
+  ingress-disabled: &ingress-disabled
+    enabled: false
+    driver: nginx
+
+cases:
+  - name: configures gitops with dev credentials and computed concurrency
+    values:
+      provider: generic
+      dev: true
+      network: *default-network
+      cluster:
+        controlplanes:
+          cpu: 8
+          memory: 16
+          nodes:
+            controlplane-1:
+              endpoint: 10.5.0.10:50000
+              node: 10.5.0.10
+              hostname: controlplane-1
+        workers:
+          volumes:
+            - /var/local
+      git:
+        livereload:
+          username: devuser
+          password: devpass
+    expect:
+      terraform:
+        - name: gitops
+          inputs:
+            git_username: devuser
+            git_password: devpass
+            webhook_token: abcdef123456
+            concurrency: 4
+
+  - name: uses empty git credentials when not specified
+    values:
+      provider: generic
+      dev: true
+      network: *default-network
+      cluster: *default-cluster
+    expect:
+      terraform:
+        - name: gitops
+          inputs:
+            git_username: ""
+            git_password: ""
+            webhook_token: abcdef123456
+
+  - name: creates selfsigned issuer and Grafana dev config
+    values:
+      provider: generic
+      dev: true
+      network: *default-network
+      cluster: *default-cluster
+    expect:
+      kustomize:
+        - name: pki-resources
+          path: pki/resources
+          dependsOn:
+            - pki-base
+          components:
+            - public-issuer/selfsigned
+        - name: observability
+          components:
+            - grafana/dev
+          substitutions:
+            admin_password: grafana
+
+  - name: uses custom Grafana admin password when specified
+    values:
+      provider: generic
+      dev: true
+      network: *default-network
+      cluster: *default-cluster
+      addons:
+        observability:
+          admin_password: supersecret
+    expect:
+      kustomize:
+        - name: observability
+          substitutions:
+            admin_password: supersecret
+
+  - name: creates demo database when demo mode enabled
+    values:
+      provider: generic
+      dev: true
+      demo: true
+      network: *default-network
+      cluster: *default-cluster
+    expect:
+      kustomize:
+        - name: demo-database
+          path: demo
+          dependsOn:
+            - database
+          components:
+            - database
+
+  - name: excludes demo database when demo mode disabled
+    values:
+      provider: generic
+      dev: true
+      demo: false
+      ingress: *ingress-disabled
+      network: *default-network
+      cluster: *default-cluster
+    exclude:
+      kustomize:
+        - name: demo-database
+
+  - name: uses nodeport ingress on Docker Desktop
+    values:
+      provider: generic
+      dev: true
+      vm:
+        driver: docker-desktop
+      ingress:
+        enabled: true
+        driver: nginx
+      network: *default-network
+      cluster: *default-cluster
+    expect:
+      kustomize:
+        - name: ingress
+          dependsOn:
+            - pki-base
+          components:
+            - nginx/nodeport
+            - nginx/prometheus
+          timeout: 10m
+          interval: 5m

--- a/contexts/_template/tests/provider-aws.test.yaml
+++ b/contexts/_template/tests/provider-aws.test.yaml
@@ -1,0 +1,53 @@
+cases:
+  - name: creates VPC, EKS, and GitOps terraform chain
+    values:
+      provider: aws
+      ingress:
+        enabled: false
+        driver: nginx
+    expect:
+      terraform:
+        - name: network
+          path: network/aws-vpc
+        - name: cluster
+          path: cluster/aws-eks
+          dependsOn:
+            - network
+        - name: cluster-additions
+          path: cluster/aws-eks/additions
+          dependsOn:
+            - cluster
+        - name: gitops
+          path: gitops/flux
+          dependsOn:
+            - cluster
+      kustomize:
+        - name: csi
+          dependsOn:
+            - policy-resources
+
+  - name: creates nginx ingress without CoreDNS when enabled
+    values:
+      provider: aws
+      ingress:
+        enabled: true
+        driver: nginx
+    expect:
+      kustomize:
+        - name: ingress
+          dependsOn:
+            - pki-base
+          components:
+            - nginx
+            - nginx/web
+            - nginx/prometheus
+
+  - name: excludes ingress when disabled
+    values:
+      provider: aws
+      ingress:
+        enabled: false
+        driver: nginx
+    exclude:
+      kustomize:
+        - name: ingress

--- a/contexts/_template/tests/provider-aws.test.yaml
+++ b/contexts/_template/tests/provider-aws.test.yaml
@@ -1,5 +1,9 @@
+# provider-aws.yaml facet tests
+# Tests AWS EKS infrastructure with VPC networking
+
 cases:
-  - name: creates VPC, EKS, and GitOps terraform chain
+  # Minimal: Test default behavior with required fields only
+  - name: minimal config creates VPC, EKS, and GitOps terraform chain
     values:
       provider: aws
       ingress:
@@ -21,27 +25,64 @@ cases:
           path: gitops/flux
           dependsOn:
             - cluster
+          inputs:
+            concurrency: 5
       kustomize:
         - name: csi
+          path: csi
           dependsOn:
             - policy-resources
+          components:
+            - aws-ebs
+          timeout: 5m
+          interval: 5m
 
-  - name: creates nginx ingress without CoreDNS when enabled
+  # Full: Test with ingress enabled
+  - name: full config creates nginx ingress without CoreDNS
     values:
       provider: aws
       ingress:
         enabled: true
         driver: nginx
     expect:
+      terraform:
+        - name: network
+          path: network/aws-vpc
+        - name: cluster
+          path: cluster/aws-eks
+          dependsOn:
+            - network
+        - name: cluster-additions
+          path: cluster/aws-eks/additions
+          dependsOn:
+            - cluster
+        - name: gitops
+          path: gitops/flux
+          dependsOn:
+            - cluster
+          inputs:
+            concurrency: 5
       kustomize:
+        - name: csi
+          path: csi
+          dependsOn:
+            - policy-resources
+          components:
+            - aws-ebs
+          timeout: 5m
+          interval: 5m
         - name: ingress
+          path: ingress
           dependsOn:
             - pki-base
           components:
             - nginx
             - nginx/web
             - nginx/prometheus
+          timeout: 10m
+          interval: 5m
 
+  # Edge case: Ingress disabled
   - name: excludes ingress when disabled
     values:
       provider: aws

--- a/contexts/_template/tests/provider-azure.test.yaml
+++ b/contexts/_template/tests/provider-azure.test.yaml
@@ -1,0 +1,50 @@
+cases:
+  - name: creates VNet, AKS, and GitOps terraform chain
+    values:
+      provider: azure
+      ingress:
+        enabled: false
+        driver: nginx
+    expect:
+      terraform:
+        - name: network
+          path: network/azure-vnet
+        - name: cluster
+          path: cluster/azure-aks
+          dependsOn:
+            - network
+        - name: gitops
+          path: gitops/flux
+          dependsOn:
+            - cluster
+      kustomize:
+        - name: csi
+          dependsOn:
+            - policy-resources
+          components:
+            - azure-disk
+
+  - name: creates nginx ingress with CoreDNS when enabled
+    values:
+      provider: azure
+      ingress:
+        enabled: true
+        driver: nginx
+    expect:
+      kustomize:
+        - name: ingress
+          dependsOn:
+            - pki-base
+          components:
+            - nginx
+            - nginx/coredns
+
+  - name: excludes ingress when disabled
+    values:
+      provider: azure
+      ingress:
+        enabled: false
+        driver: nginx
+    exclude:
+      kustomize:
+        - name: ingress

--- a/contexts/_template/tests/provider-generic.test.yaml
+++ b/contexts/_template/tests/provider-generic.test.yaml
@@ -1,0 +1,216 @@
+# Note: All tests with provider: generic require cluster.controlplanes.nodes
+# because provider-generic derives cluster_endpoint from the first node.
+
+# Common configurations
+x-defaults:
+  network: &default-network
+    loadbalancer_driver: kube-vip
+    loadbalancer_mode: arp
+    loadbalancer_ips:
+      start: "10.5.1.10"
+      end: "10.5.1.100"
+
+  cluster: &default-cluster
+    controlplanes:
+      nodes:
+        controlplane-1: &cp1-node
+          endpoint: 10.5.0.10:50000
+          node: 10.5.0.10
+          hostname: controlplane-1
+    workers:
+      volumes:
+        - /var/local
+
+  ingress-disabled: &ingress-disabled
+    enabled: false
+    driver: nginx
+
+cases:
+  - name: creates Talos cluster with computed inputs
+    values:
+      provider: generic
+      ingress: *ingress-disabled
+      network: *default-network
+      cluster:
+        controlplanes:
+          cpu: 4
+          memory: 8
+          nodes:
+            controlplane-1: *cp1-node
+        workers:
+          volumes:
+            - /var/local
+    expect:
+      terraform:
+        - name: cluster
+          path: cluster/talos
+          parallelism: 1
+          inputs:
+            cluster_endpoint: https://10.5.0.10:6443
+            cluster_name: talos
+        - name: gitops
+          path: gitops/flux
+          dependsOn:
+            - cluster
+          destroy: false
+          inputs:
+            concurrency: 2
+      kustomize:
+        - name: csi
+          dependsOn:
+            - policy-resources
+          components:
+            - openebs
+            - openebs/dynamic-localpv
+          substitutions:
+            local_volume_path: /var/local
+          timeout: 20m
+          interval: 5m
+
+  - name: computes gitops concurrency from cluster resources
+    values:
+      provider: generic
+      ingress: *ingress-disabled
+      network: *default-network
+      cluster:
+        controlplanes:
+          cpu: 20
+          memory: 32
+          nodes:
+            controlplane-1: *cp1-node
+        workers:
+          volumes:
+            - /var/local
+    expect:
+      terraform:
+        - name: gitops
+          inputs:
+            concurrency: 10
+
+  - name: excludes load balancer on Docker Desktop
+    values:
+      provider: generic
+      vm:
+        driver: docker-desktop
+      ingress: *ingress-disabled
+      network: *default-network
+      cluster: *default-cluster
+    exclude:
+      kustomize:
+        - name: lb-base
+        - name: lb-resources
+
+  - name: computes loadbalancer IP range from network config
+    values:
+      provider: generic
+      vm:
+        driver: colima
+      ingress: *ingress-disabled
+      network:
+        loadbalancer_driver: kube-vip
+        loadbalancer_mode: arp
+        loadbalancer_ips:
+          start: "192.168.1.100"
+          end: "192.168.1.200"
+      cluster: *default-cluster
+    expect:
+      kustomize:
+        - name: lb-resources
+          dependsOn:
+            - lb-base
+          substitutions:
+            loadbalancer_ip_range: 192.168.1.100-192.168.1.200
+
+  - name: uses default loadbalancer IP range when not specified
+    values:
+      provider: generic
+      vm:
+        driver: colima
+      ingress: *ingress-disabled
+      network: *default-network
+      cluster: *default-cluster
+    expect:
+      kustomize:
+        - name: lb-resources
+          substitutions:
+            loadbalancer_ip_range: 10.5.1.10-10.5.1.100
+
+  - name: creates MetalLB when metallb driver selected
+    values:
+      provider: generic
+      vm:
+        driver: colima
+      network:
+        loadbalancer_driver: metallb
+        loadbalancer_mode: layer2
+        loadbalancer_ips:
+          start: "10.5.1.10"
+          end: "10.5.1.100"
+      ingress: *ingress-disabled
+      cluster: *default-cluster
+    expect:
+      kustomize:
+        - name: lb-base
+          components:
+            - metallb
+        - name: lb-resources
+          components:
+            - metallb
+            - metallb/layer2
+
+  - name: creates kube-vip with arp mode by default
+    values:
+      provider: generic
+      vm:
+        driver: colima
+      network: *default-network
+      ingress: *ingress-disabled
+      cluster: *default-cluster
+    expect:
+      kustomize:
+        - name: lb-resources
+          components:
+            - kube-vip
+            - kube-vip/arp
+
+  - name: creates nginx ingress with CoreDNS when enabled
+    values:
+      provider: generic
+      vm:
+        driver: colima
+      ingress:
+        enabled: true
+        driver: nginx
+      network: *default-network
+      cluster: *default-cluster
+    expect:
+      kustomize:
+        - name: ingress
+          dependsOn:
+            - pki-base
+          components:
+            - nginx
+            - nginx/coredns
+            - nginx/web
+            - nginx/prometheus
+          timeout: 10m
+          interval: 5m
+
+  - name: uses custom worker volume path for CSI
+    values:
+      provider: generic
+      ingress: *ingress-disabled
+      network: *default-network
+      cluster:
+        controlplanes:
+          nodes:
+            controlplane-1: *cp1-node
+        workers:
+          count: 1
+          volumes:
+            - /mnt/data
+    expect:
+      kustomize:
+        - name: csi
+          substitutions:
+            local_volume_path: /mnt/data

--- a/contexts/_template/tests/provider-generic.test.yaml
+++ b/contexts/_template/tests/provider-generic.test.yaml
@@ -1,5 +1,8 @@
-# Note: All tests with provider: generic require cluster.controlplanes.nodes
-# because provider-generic derives cluster_endpoint from the first node.
+# provider-generic.yaml facet tests
+# Tests Talos cluster infrastructure with load balancer and ingress configuration
+#
+# Note: provider: generic requires cluster.controlplanes.nodes because
+# cluster_endpoint is derived from the first node.
 
 # Common configurations
 x-defaults:
@@ -26,20 +29,13 @@ x-defaults:
     driver: nginx
 
 cases:
-  - name: creates Talos cluster with computed inputs
+  # Minimal: Test default behavior with required fields only
+  - name: minimal config creates Talos cluster with kube-vip and default CSI
     values:
       provider: generic
       ingress: *ingress-disabled
       network: *default-network
-      cluster:
-        controlplanes:
-          cpu: 4
-          memory: 8
-          nodes:
-            controlplane-1: *cp1-node
-        workers:
-          volumes:
-            - /var/local
+      cluster: *default-cluster
     expect:
       terraform:
         - name: cluster
@@ -57,6 +53,7 @@ cases:
             concurrency: 2
       kustomize:
         - name: csi
+          path: csi
           dependsOn:
             - policy-resources
           components:
@@ -66,12 +63,33 @@ cases:
             local_volume_path: /var/local
           timeout: 20m
           interval: 5m
+        - name: lb-resources
+          path: lb/resources
+          dependsOn:
+            - lb-base
+          components:
+            - kube-vip
+            - kube-vip/arp
+          substitutions:
+            loadbalancer_ip_range: 10.5.1.10-10.5.1.100
+          timeout: 5m
+          interval: 5m
 
-  - name: computes gitops concurrency from cluster resources
+  # Full: Test all configurable options together
+  - name: full config with MetalLB, custom resources, ingress, and custom worker volume
     values:
       provider: generic
-      ingress: *ingress-disabled
-      network: *default-network
+      vm:
+        driver: colima
+      ingress:
+        enabled: true
+        driver: nginx
+      network:
+        loadbalancer_driver: metallb
+        loadbalancer_mode: layer2
+        loadbalancer_ips:
+          start: "192.168.1.100"
+          end: "192.168.1.200"
       cluster:
         controlplanes:
           cpu: 20
@@ -79,15 +97,69 @@ cases:
           nodes:
             controlplane-1: *cp1-node
         workers:
+          count: 1
           volumes:
-            - /var/local
+            - /mnt/data
     expect:
       terraform:
+        - name: cluster
+          path: cluster/talos
+          parallelism: 1
+          inputs:
+            cluster_endpoint: https://10.5.0.10:6443
+            cluster_name: talos
         - name: gitops
+          path: gitops/flux
+          dependsOn:
+            - cluster
+          destroy: false
           inputs:
             concurrency: 10
+      kustomize:
+        - name: csi
+          path: csi
+          dependsOn:
+            - policy-resources
+          components:
+            - openebs
+            - openebs/dynamic-localpv
+          substitutions:
+            local_volume_path: /mnt/data
+          timeout: 20m
+          interval: 5m
+        - name: lb-base
+          path: lb/base
+          dependsOn:
+            - policy-resources
+          components:
+            - metallb
+          timeout: 5m
+          interval: 5m
+        - name: lb-resources
+          path: lb/resources
+          dependsOn:
+            - lb-base
+          components:
+            - metallb
+            - metallb/layer2
+          substitutions:
+            loadbalancer_ip_range: 192.168.1.100-192.168.1.200
+          timeout: 5m
+          interval: 5m
+        - name: ingress
+          path: ingress
+          dependsOn:
+            - pki-base
+          components:
+            - nginx
+            - nginx/coredns
+            - nginx/web
+            - nginx/prometheus
+          timeout: 10m
+          interval: 5m
 
-  - name: excludes load balancer on Docker Desktop
+  # Edge case: Docker Desktop excludes load balancer
+  - name: Docker Desktop excludes load balancer
     values:
       provider: generic
       vm:
@@ -99,118 +171,3 @@ cases:
       kustomize:
         - name: lb-base
         - name: lb-resources
-
-  - name: computes loadbalancer IP range from network config
-    values:
-      provider: generic
-      vm:
-        driver: colima
-      ingress: *ingress-disabled
-      network:
-        loadbalancer_driver: kube-vip
-        loadbalancer_mode: arp
-        loadbalancer_ips:
-          start: "192.168.1.100"
-          end: "192.168.1.200"
-      cluster: *default-cluster
-    expect:
-      kustomize:
-        - name: lb-resources
-          dependsOn:
-            - lb-base
-          substitutions:
-            loadbalancer_ip_range: 192.168.1.100-192.168.1.200
-
-  - name: uses default loadbalancer IP range when not specified
-    values:
-      provider: generic
-      vm:
-        driver: colima
-      ingress: *ingress-disabled
-      network: *default-network
-      cluster: *default-cluster
-    expect:
-      kustomize:
-        - name: lb-resources
-          substitutions:
-            loadbalancer_ip_range: 10.5.1.10-10.5.1.100
-
-  - name: creates MetalLB when metallb driver selected
-    values:
-      provider: generic
-      vm:
-        driver: colima
-      network:
-        loadbalancer_driver: metallb
-        loadbalancer_mode: layer2
-        loadbalancer_ips:
-          start: "10.5.1.10"
-          end: "10.5.1.100"
-      ingress: *ingress-disabled
-      cluster: *default-cluster
-    expect:
-      kustomize:
-        - name: lb-base
-          components:
-            - metallb
-        - name: lb-resources
-          components:
-            - metallb
-            - metallb/layer2
-
-  - name: creates kube-vip with arp mode by default
-    values:
-      provider: generic
-      vm:
-        driver: colima
-      network: *default-network
-      ingress: *ingress-disabled
-      cluster: *default-cluster
-    expect:
-      kustomize:
-        - name: lb-resources
-          components:
-            - kube-vip
-            - kube-vip/arp
-
-  - name: creates nginx ingress with CoreDNS when enabled
-    values:
-      provider: generic
-      vm:
-        driver: colima
-      ingress:
-        enabled: true
-        driver: nginx
-      network: *default-network
-      cluster: *default-cluster
-    expect:
-      kustomize:
-        - name: ingress
-          dependsOn:
-            - pki-base
-          components:
-            - nginx
-            - nginx/coredns
-            - nginx/web
-            - nginx/prometheus
-          timeout: 10m
-          interval: 5m
-
-  - name: uses custom worker volume path for CSI
-    values:
-      provider: generic
-      ingress: *ingress-disabled
-      network: *default-network
-      cluster:
-        controlplanes:
-          nodes:
-            controlplane-1: *cp1-node
-        workers:
-          count: 1
-          volumes:
-            - /mnt/data
-    expect:
-      kustomize:
-        - name: csi
-          substitutions:
-            local_volume_path: /mnt/data

--- a/contexts/_template/tests/provider-incus.test.yaml
+++ b/contexts/_template/tests/provider-incus.test.yaml
@@ -1,0 +1,261 @@
+# Note: Tests must provide terraformOutputs.compute to mock terraform_output() calls.
+# YAML anchors reduce duplication for common cluster and terraform output configurations.
+
+# Common configurations
+x-defaults:
+  network: &default-network
+    cidr_block: 10.5.0.0/16
+    loadbalancer_driver: kube-vip
+    loadbalancer_mode: arp
+    loadbalancer_ips:
+      start: "10.5.1.10"
+      end: "10.5.1.100"
+
+  cluster: &default-cluster
+    controlplanes:
+      nodes:
+        controlplane-1: &cp1-node
+          endpoint: 10.5.0.10:50000
+          node: 10.5.0.10
+          hostname: controlplane-1
+    workers: &default-workers
+      count: 1
+      volumes:
+        - /var/local
+      nodes:
+        worker-1: &wk1-node
+          endpoint: 10.5.0.20:50000
+          node: 10.5.0.20
+          hostname: worker-1
+
+  terraform-outputs: &default-terraform-outputs
+    compute:
+      controlplanes:
+        - endpoint: 10.5.0.10:6443
+          node: 10.5.0.10
+          hostname: controlplane-1
+      workers:
+        - endpoint: 10.5.0.20:50000
+          node: 10.5.0.20
+          hostname: worker-1
+
+  ingress-disabled: &ingress-disabled
+    enabled: false
+    driver: nginx
+
+cases:
+  - name: creates compute and cluster terraform chain with mocked outputs
+    values:
+      provider: incus
+      ingress: *ingress-disabled
+      network:
+        cidr_block: 10.10.0.0/16
+        loadbalancer_driver: kube-vip
+        loadbalancer_mode: arp
+        loadbalancer_ips:
+          start: "10.10.1.10"
+          end: "10.10.1.100"
+      cluster:
+        controlplanes:
+          count: 3
+          cpu: 4
+          memory: 8
+          root_disk_size: 50
+          nodes:
+            controlplane-1:
+              endpoint: 10.10.0.10:50000
+              node: 10.10.0.10
+              hostname: cp-1
+        workers:
+          count: 2
+          cpu: 8
+          memory: 16
+          nodes:
+            worker-1:
+              endpoint: 10.10.0.20:50000
+              node: 10.10.0.20
+              hostname: wk-1
+    terraformOutputs:
+      compute:
+        controlplanes:
+          - endpoint: 10.10.0.10:6443
+            node: 10.10.0.10
+            hostname: cp-1
+        workers:
+          - endpoint: 10.10.0.20:50000
+            node: 10.10.0.20
+            hostname: wk-1
+    expect:
+      terraform:
+        - name: compute
+          path: compute/incus
+          inputs:
+            network_name: ""
+            create_network: true
+            network_cidr: 10.10.0.0/16
+        - name: cluster
+          path: cluster/talos
+          dependsOn:
+            - compute
+          parallelism: 1
+          inputs:
+            cluster_endpoint: https://10.10.0.10:6443
+            cluster_name: talos
+        - name: gitops
+          path: gitops/flux
+          dependsOn:
+            - cluster
+          destroy: false
+          inputs:
+            concurrency: 4
+      kustomize:
+        - name: csi
+          path: csi
+          dependsOn:
+            - policy-resources
+          components:
+            - openebs
+            - openebs/dynamic-localpv
+          timeout: 20m
+          interval: 5m
+        - name: lb-base
+          path: lb/base
+          dependsOn:
+            - policy-resources
+          timeout: 5m
+          interval: 5m
+        - name: lb-resources
+          path: lb/resources
+          dependsOn:
+            - lb-base
+          components:
+            - kube-vip
+            - kube-vip/arp
+          substitutions:
+            loadbalancer_ip_range: 10.5.1.10-10.5.1.100
+          timeout: 5m
+          interval: 5m
+
+  - name: configures Colima-specific storage and network
+    values:
+      provider: incus
+      vm:
+        driver: colima
+      ingress: *ingress-disabled
+      network: *default-network
+      cluster: *default-cluster
+    terraformOutputs: *default-terraform-outputs
+    expect:
+      terraform:
+        - name: compute
+          path: compute/incus
+          inputs:
+            network_name: incusbr0
+            create_network: false
+
+  - name: uses custom loadbalancer IP range
+    values:
+      provider: incus
+      ingress: *ingress-disabled
+      network:
+        cidr_block: 10.5.0.0/16
+        loadbalancer_driver: kube-vip
+        loadbalancer_mode: arp
+        loadbalancer_ips:
+          start: "192.168.50.100"
+          end: "192.168.50.200"
+      cluster: *default-cluster
+    terraformOutputs: *default-terraform-outputs
+    expect:
+      kustomize:
+        - name: lb-resources
+          substitutions:
+            loadbalancer_ip_range: 192.168.50.100-192.168.50.200
+
+  - name: creates MetalLB when metallb driver selected
+    values:
+      provider: incus
+      ingress: *ingress-disabled
+      network:
+        cidr_block: 10.5.0.0/16
+        loadbalancer_driver: metallb
+        loadbalancer_mode: layer2
+        loadbalancer_ips:
+          start: "10.5.1.10"
+          end: "10.5.1.100"
+      cluster: *default-cluster
+    terraformOutputs: *default-terraform-outputs
+    expect:
+      kustomize:
+        - name: lb-base
+          components:
+            - metallb
+        - name: lb-resources
+          components:
+            - metallb
+            - metallb/layer2
+
+  - name: creates nginx ingress with CoreDNS when enabled
+    values:
+      provider: incus
+      ingress:
+        enabled: true
+        driver: nginx
+      network: *default-network
+      cluster: *default-cluster
+    terraformOutputs: *default-terraform-outputs
+    expect:
+      kustomize:
+        - name: ingress
+          path: ingress
+          dependsOn:
+            - pki-base
+          components:
+            - nginx
+            - nginx/coredns
+            - nginx/web
+            - nginx/prometheus
+          timeout: 10m
+          interval: 5m
+
+  - name: uses worker volume path for CSI
+    values:
+      provider: incus
+      ingress: *ingress-disabled
+      network: *default-network
+      cluster:
+        controlplanes:
+          nodes:
+            controlplane-1: *cp1-node
+        workers:
+          count: 1
+          volumes:
+            - /mnt/storage
+          nodes:
+            worker-1: *wk1-node
+    terraformOutputs: *default-terraform-outputs
+    expect:
+      kustomize:
+        - name: csi
+          substitutions:
+            local_volume_path: /mnt/storage
+
+  - name: uses controlplane volume path when schedulable
+    values:
+      provider: incus
+      ingress: *ingress-disabled
+      network: *default-network
+      cluster:
+        controlplanes:
+          schedulable: true
+          volumes:
+            - /data/local
+          nodes:
+            controlplane-1: *cp1-node
+        workers: *default-workers
+    terraformOutputs: *default-terraform-outputs
+    expect:
+      kustomize:
+        - name: csi
+          substitutions:
+            local_volume_path: /data/local

--- a/contexts/_template/tests/provider-incus.test.yaml
+++ b/contexts/_template/tests/provider-incus.test.yaml
@@ -132,7 +132,7 @@ cases:
             - kube-vip
             - kube-vip/arp
           substitutions:
-            loadbalancer_ip_range: 10.5.1.10-10.5.1.100
+            loadbalancer_ip_range: 10.10.1.10-10.10.1.100
           timeout: 5m
           interval: 5m
 

--- a/contexts/_template/tests/provider-incus.test.yaml
+++ b/contexts/_template/tests/provider-incus.test.yaml
@@ -1,5 +1,7 @@
+# provider-incus.yaml facet tests
+# Tests Incus compute platform with Talos cluster infrastructure
+#
 # Note: Tests must provide terraformOutputs.compute to mock terraform_output() calls.
-# YAML anchors reduce duplication for common cluster and terraform output configurations.
 
 # Common configurations
 x-defaults:
@@ -44,14 +46,78 @@ x-defaults:
     driver: nginx
 
 cases:
-  - name: creates compute and cluster terraform chain with mocked outputs
+  # Minimal: Test default behavior with minimal required fields
+  - name: minimal config creates compute and cluster terraform chain with defaults
     values:
       provider: incus
       ingress: *ingress-disabled
+      network: *default-network
+      cluster: *default-cluster
+    terraformOutputs: *default-terraform-outputs
+    expect:
+      terraform:
+        - name: compute
+          path: compute/incus
+          inputs:
+            network_name: ""
+            create_network: true
+            network_cidr: 10.5.0.0/16
+        - name: cluster
+          path: cluster/talos
+          dependsOn:
+            - compute
+          parallelism: 1
+          inputs:
+            cluster_endpoint: https://10.5.0.10:6443
+            cluster_name: talos
+        - name: gitops
+          path: gitops/flux
+          dependsOn:
+            - cluster
+          destroy: false
+          inputs:
+            concurrency: 2
+      kustomize:
+        - name: csi
+          path: csi
+          dependsOn:
+            - policy-resources
+          components:
+            - openebs
+            - openebs/dynamic-localpv
+          substitutions:
+            local_volume_path: /var/local
+          timeout: 20m
+          interval: 5m
+        - name: lb-base
+          path: lb/base
+          dependsOn:
+            - policy-resources
+          timeout: 5m
+          interval: 5m
+        - name: lb-resources
+          path: lb/resources
+          dependsOn:
+            - lb-base
+          components:
+            - kube-vip
+            - kube-vip/arp
+          substitutions:
+            loadbalancer_ip_range: 10.5.1.10-10.5.1.100
+          timeout: 5m
+          interval: 5m
+
+  # Full: Test all configurable options together
+  - name: full config with custom network, MetalLB, ingress, and all cluster options
+    values:
+      provider: incus
+      ingress:
+        enabled: true
+        driver: nginx
       network:
         cidr_block: 10.10.0.0/16
-        loadbalancer_driver: kube-vip
-        loadbalancer_mode: arp
+        loadbalancer_driver: metallb
+        loadbalancer_mode: layer2
         loadbalancer_ips:
           start: "10.10.1.10"
           end: "10.10.1.100"
@@ -70,6 +136,8 @@ cases:
           count: 2
           cpu: 8
           memory: 16
+          volumes:
+            - /mnt/storage
           nodes:
             worker-1:
               endpoint: 10.10.0.20:50000
@@ -107,7 +175,7 @@ cases:
             - cluster
           destroy: false
           inputs:
-            concurrency: 4
+            concurrency: 2
       kustomize:
         - name: csi
           path: csi
@@ -116,12 +184,16 @@ cases:
           components:
             - openebs
             - openebs/dynamic-localpv
+          substitutions:
+            local_volume_path: /mnt/storage
           timeout: 20m
           interval: 5m
         - name: lb-base
           path: lb/base
           dependsOn:
             - policy-resources
+          components:
+            - metallb
           timeout: 5m
           interval: 5m
         - name: lb-resources
@@ -129,14 +201,26 @@ cases:
           dependsOn:
             - lb-base
           components:
-            - kube-vip
-            - kube-vip/arp
+            - metallb
+            - metallb/layer2
           substitutions:
             loadbalancer_ip_range: 10.10.1.10-10.10.1.100
           timeout: 5m
           interval: 5m
+        - name: ingress
+          path: ingress
+          dependsOn:
+            - pki-base
+          components:
+            - nginx
+            - nginx/coredns
+            - nginx/web
+            - nginx/prometheus
+          timeout: 10m
+          interval: 5m
 
-  - name: configures Colima-specific storage and network
+  # Edge case: Colima uses existing network
+  - name: Colima uses existing incusbr0 network
     values:
       provider: incus
       vm:
@@ -153,94 +237,8 @@ cases:
             network_name: incusbr0
             create_network: false
 
-  - name: uses custom loadbalancer IP range
-    values:
-      provider: incus
-      ingress: *ingress-disabled
-      network:
-        cidr_block: 10.5.0.0/16
-        loadbalancer_driver: kube-vip
-        loadbalancer_mode: arp
-        loadbalancer_ips:
-          start: "192.168.50.100"
-          end: "192.168.50.200"
-      cluster: *default-cluster
-    terraformOutputs: *default-terraform-outputs
-    expect:
-      kustomize:
-        - name: lb-resources
-          substitutions:
-            loadbalancer_ip_range: 192.168.50.100-192.168.50.200
-
-  - name: creates MetalLB when metallb driver selected
-    values:
-      provider: incus
-      ingress: *ingress-disabled
-      network:
-        cidr_block: 10.5.0.0/16
-        loadbalancer_driver: metallb
-        loadbalancer_mode: layer2
-        loadbalancer_ips:
-          start: "10.5.1.10"
-          end: "10.5.1.100"
-      cluster: *default-cluster
-    terraformOutputs: *default-terraform-outputs
-    expect:
-      kustomize:
-        - name: lb-base
-          components:
-            - metallb
-        - name: lb-resources
-          components:
-            - metallb
-            - metallb/layer2
-
-  - name: creates nginx ingress with CoreDNS when enabled
-    values:
-      provider: incus
-      ingress:
-        enabled: true
-        driver: nginx
-      network: *default-network
-      cluster: *default-cluster
-    terraformOutputs: *default-terraform-outputs
-    expect:
-      kustomize:
-        - name: ingress
-          path: ingress
-          dependsOn:
-            - pki-base
-          components:
-            - nginx
-            - nginx/coredns
-            - nginx/web
-            - nginx/prometheus
-          timeout: 10m
-          interval: 5m
-
-  - name: uses worker volume path for CSI
-    values:
-      provider: incus
-      ingress: *ingress-disabled
-      network: *default-network
-      cluster:
-        controlplanes:
-          nodes:
-            controlplane-1: *cp1-node
-        workers:
-          count: 1
-          volumes:
-            - /mnt/storage
-          nodes:
-            worker-1: *wk1-node
-    terraformOutputs: *default-terraform-outputs
-    expect:
-      kustomize:
-        - name: csi
-          substitutions:
-            local_volume_path: /mnt/storage
-
-  - name: uses controlplane volume path when schedulable
+  # Edge case: Schedulable controlplanes use controlplane volume path
+  - name: schedulable controlplanes use controlplane volume path for CSI
     values:
       provider: incus
       ingress: *ingress-disabled


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces comprehensive Windsor blueprint tests and aligns facet templates for consistent evaluation.
> 
> - Adds blueprint test suites for `addon-*` and `provider-*` plus base/local-dev under `contexts/_template/tests/`
> - Updates `Taskfile.yaml` with `test`, `test:terraform`, and `test:blueprint` targets
> - CI: replaces Terraform-only tests with a unified "Tests" job that installs Windsor CLI and runs `task test`
> - Normalizes facet `when`/substitution syntax (removes `?.`, standardizes `${dns.domain}`, etc.) across facet files
> - Observability facet: decouples base dashboards from ingress and adds a separate `grafana/ingress` block when ingress is enabled
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36efe46c20e259cdcbfc68c67d1de0654e10c5ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->