### PR TITLE
chore(blueprint): Standardize on provider => platform

### DIFF
--- a/contexts/_template/facets/addon-private-dns.yaml
+++ b/contexts/_template/facets/addon-private-dns.yaml
@@ -4,7 +4,7 @@ metadata:
   name: private-dns
   description: Self-hosted CoreDNS for private DNS zones
 
-when: (platform ?? provider) != 'none' && (addons.private_dns.enabled == true || dev == true)
+when: platform != 'none' && (addons.private_dns.enabled == true || dev == true)
 
 kustomize:
 

--- a/contexts/_template/facets/addon-private-dns.yaml
+++ b/contexts/_template/facets/addon-private-dns.yaml
@@ -4,7 +4,7 @@ metadata:
   name: private-dns
   description: Self-hosted CoreDNS for private DNS zones
 
-when: platform != 'none' && (addons.private_dns.enabled == true || dev == true)
+when: addons.private_dns.enabled == true || dev == true
 
 kustomize:
 

--- a/contexts/_template/facets/config-talos.yaml
+++ b/contexts/_template/facets/config-talos.yaml
@@ -8,27 +8,25 @@ when: cluster.driver == 'talos'
 
 config:
   - name: talos_common
-    vars:
+    value:
       allowSchedulingOnControlPlanes: "${cluster.controlplanes.schedulable ?? false}"
       controlplane_volumes: "${cluster.controlplanes.volumes ?? []}"
       worker_volumes: "${cluster.workers.volumes ?? []}"
       csi_local_volume_path: "${cluster.storage.local_base_path ?? \"/var/mnt/local\"}"
       controlplane_disks: "${cluster.controlplanes.disks ?? []}"
       worker_disks: "${cluster.workers.disks ?? []}"
-    patchVars:
+      common_patch:
+        cluster:
+          allowSchedulingOnControlPlanes: ${talos_common.allowSchedulingOnControlPlanes}
+          extraManifests:
+            - "https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml"
+        machine:
+          kubelet:
+            extraArgs:
+              rotate-server-certificates: "true"
       common_config_patches: "${string(talos_common.common_patch)}"
-    common_patch:
-      cluster:
-        allowSchedulingOnControlPlanes: ${talos_common.vars.allowSchedulingOnControlPlanes}
-        extraManifests:
-          - "https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml"
-      machine:
-        kubelet:
-          extraArgs:
-            rotate-server-certificates: "true"
 
   - name: talos
-    # renovate: datasource=docker depName=ghcr.io/siderolabs/talos package=ghcr.io/siderolabs/talos
-    image: ghcr.io/siderolabs/talos:v1.12.1
-    # renovate: datasource=github-releases depName=talos package=siderolabs/talos
-    talos_version: "1.12.1"
+    value:
+      image: ghcr.io/siderolabs/talos:v1.12.1
+      talos_version: "1.12.1"

--- a/contexts/_template/facets/option-ingress.yaml
+++ b/contexts/_template/facets/option-ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ingress
   description: "Configurable ingress controller"
 
-when: (platform ?? provider) != 'none' && ingress.enabled == true && ingress.driver == 'nginx'
+when: platform != 'none' && ingress.enabled == true && ingress.driver == 'nginx'
 
 kustomize:
 
@@ -14,9 +14,9 @@ kustomize:
     - pki-base
   components:
     - nginx
-    - "${(workstation.runtime ?? ((platform ?? provider) == 'docker' ? 'docker-desktop' : '')) == 'docker-desktop' ? 'nginx/nodeport' : 'nginx/loadbalancer'}"
+    - "${(workstation.runtime ?? (platform == 'docker' ? 'docker-desktop' : '')) == 'docker-desktop' ? 'nginx/nodeport' : 'nginx/loadbalancer'}"
     - nginx/web
-    - "${addons.private_dns.enabled == true && (workstation.runtime ?? ((platform ?? provider) == 'docker' ? 'docker-desktop' : '')) != 'docker-desktop' ? 'nginx/coredns' : ''}"
+    - "${addons.private_dns.enabled == true && (workstation.runtime ?? (platform == 'docker' ? 'docker-desktop' : '')) != 'docker-desktop' ? 'nginx/coredns' : ''}"
     - nginx/prometheus
   timeout: 10m
   interval: 5m

--- a/contexts/_template/facets/option-ingress.yaml
+++ b/contexts/_template/facets/option-ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ingress
   description: "Configurable ingress controller"
 
-when: platform != 'none' && ingress.enabled == true && ingress.driver == 'nginx'
+when: ingress.enabled == true && ingress.driver == 'nginx'
 
 kustomize:
 

--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -4,8 +4,8 @@ metadata:
   name: workstation
   description: Workstation stack for local development and cluster infrastructure.
 
-# Use context-wins expression so facet applies when context has provider: incus even if block whens see raw platform (CLI may not merge provider into scope).
-when: "platform == 'incus' || (platform == 'docker' && (workstation.enabled ?? true))"
+# Docker: facet applies when workstation not disabled (default on). Incus: facet applies only when workstation enabled (default off). Workstation stack blocks are gated per block.
+when: "(platform == 'docker' && (workstation.enabled ?? true)) || (platform == 'incus' && (workstation.enabled ?? false))"
 
 config:
   - name: workstation
@@ -88,7 +88,7 @@ terraform:
 # Workstation stack for docker-desktop: DNS, registries, git livereload. No loadbalancer; DNS forwards to
 # node hostport (e.g. first node :8053).
 - name: workstation
-  when: workstation.runtime == "docker-desktop"
+  when: "platform == 'docker' && workstation.runtime == \"docker-desktop\""
   path: workstation/docker
   inputs:
     runtime: 'docker-desktop'
@@ -105,7 +105,7 @@ terraform:
 # Workstation stack for colima/docker/linux: same as above but loadbalancer exists; DNS/webhook use loadbalancer IP.
 # runtime from config workstation.runtime (docker -> linux for Terraform).
 - name: workstation
-  when: workstation.runtime != "docker-desktop"
+  when: "platform == 'docker' && workstation.runtime != \"docker-desktop\""
   path: workstation/docker
   inputs:
     runtime: >-
@@ -123,7 +123,7 @@ terraform:
 # Compute/docker: run Talos controlplane/worker containers on workstation network.
 # cluster/talos consumes compute outputs (endpoints, etc.) via provider-docker.
 - name: compute
-  when: (platform ?? provider) == 'docker' && (cluster.enabled ?? true) == true
+  when: "platform == 'docker' && (cluster.enabled ?? true) == true"
   path: compute/docker
   dependsOn:
     - workstation

--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -4,7 +4,8 @@ metadata:
   name: workstation
   description: Workstation stack for local development and cluster infrastructure.
 
-when: workstation.enabled == true && (platform ?? provider) == 'docker'
+# Use context-wins expression so facet applies when context has provider: incus even if block whens see raw platform (CLI may not merge provider into scope).
+when: "platform == 'incus' || (platform == 'docker' && (workstation.enabled ?? true))"
 
 config:
   - name: workstation

--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -86,7 +86,8 @@ terraform:
     webhook_token: ${git.livereload.webhook_token ?? "abcdef123456"}
 
 # Workstation stack for docker-desktop: DNS, registries, git livereload. No loadbalancer; DNS forwards to
-# node hostport (e.g. first node :8053).
+# first node. Use container port 30053 (not host 8053) so the DNS container on the same network can reach the node.
+# 30053 = NodePort for DNS set in kustomize/ingress/nginx/coredns/patches/helm-release.yaml; cluster.*.hostports must use same container port (e.g. 8053:30053/udp).
 - name: workstation
   when: "platform == 'docker' && workstation.runtime == \"docker-desktop\""
   path: workstation/docker
@@ -95,12 +96,12 @@ terraform:
     domain_name: ${dns.domain}
     network_name: windsor-${context}
     network_cidr: ${network.cidr_block}
-    dns_forward_target: "${cidrhost(network.cidr_block, 4 + int(workstation_registries.vars.registry_count)) + \":8053\"}"
-    webhook_host: "${cidrhost(network.cidr_block, 4 + int(workstation_registries.vars.registry_count))}"
-    primary_node_ip: "${cidrhost(network.cidr_block, 4 + int(workstation_registries.vars.registry_count))}"
+    dns_forward_target: "${cidrhost(network.cidr_block, 4 + int(workstation_registries.vars.registry_count ?? 0)) + \":30053\"}"
+    webhook_host: "${cidrhost(network.cidr_block, 4 + int(workstation_registries.vars.registry_count ?? 0))}"
+    primary_node_ip: "${cidrhost(network.cidr_block, 4 + int(workstation_registries.vars.registry_count ?? 0))}"
     enable_dns: ${workstation.services.dns ?? true}
     enable_git: ${workstation.services.git ?? true}
-    registries: ${workstation_registries.vars.value}
+    registries: ${workstation_registries.vars.value ?? {}}
 
 # Workstation stack for colima/docker/linux: same as above but loadbalancer exists; DNS/webhook use loadbalancer IP.
 # runtime from config workstation.runtime (docker -> linux for Terraform).

--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -9,12 +9,13 @@ when: "(platform == 'docker' && (workstation.enabled ?? true)) || (platform == '
 
 config:
   - name: workstation
-    runtime: "${workstation.runtime ?? vm.driver ?? \"colima\"}"
+    value:
+      runtime: "${workstation.runtime ?? vm.driver ?? \"colima\"}"
 
   # Effective registries for workstation Terraform and Talos patch: empty when services.registries false, else docker.registries or default.
   - name: workstation_registries
-    vars:
-      value: |
+    value:
+      registries: |
         ${(workstation.services.registries ?? true) == false ? {} : (docker.registries ?? {
           "gcr.io": { "remote": "https://gcr.io" },
           "ghcr.io": { "remote": "https://ghcr.io" },
@@ -26,10 +27,10 @@ config:
       registry_count: "${(workstation.services.registries ?? true) == false ? 0 : len(docker.registries ?? {\"gcr.io\": {}, \"ghcr.io\": {}, \"quay.io\": {}, \"registry-1.docker.io\": {}, \"registry.k8s.io\": {}, \"registry.test\": {}})}"
 
   # certSANs for Talos when compute runs. Include localhost/127.0.0.1 for docker-desktop so host→container works.
-  # Kept as vars so it is evaluated when building cluster inputs (after compute). Apply when docker provider + talos.
+  # Kept so it is evaluated when building cluster inputs (after compute). Apply when docker provider + talos.
   - name: certSANs_from_compute
     when: (cluster.enabled ?? true) && cluster.driver == 'talos'
-    vars:
+    value:
       list: |-
         ${(cluster.controlplanes.count ?? 1) == 0 ? ["localhost", "127.0.0.1"] : (
           let cp = terraform_output("compute", "controlplanes");
@@ -45,31 +46,31 @@ config:
   # Talos common patch when docker provider + talos: certSANs (localhost/127.0.0.1 for docker-desktop), registries, etc.
   - name: common_patch_docker
     when: (cluster.enabled ?? true) && cluster.driver == 'talos'
-    content:
+    value:
       cluster:
         apiServer:
-          certSANs: ${certSANs_from_compute.vars.list}
+          certSANs: ${certSANs_from_compute.list}
         allowSchedulingOnControlPlanes: ${cluster.controlplanes.schedulable ?? ((cluster.workers.count ?? 0) == 0)}
         extraManifests:
           - "https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml"
       machine:
-        certSANs: ${certSANs_from_compute.vars.list}
+        certSANs: ${certSANs_from_compute.list}
         kubelet:
           extraArgs:
             rotate-server-certificates: "true"
         registries:
           mirrors: |-
             ${fromPairs(map(
-              filter(toPairs(workstation_registries.vars.value), { (get(#, 1)?.hostname ?? "") != "" }),
+              filter(toPairs(workstation_registries.registries ?? {}), { (get(#, 1)?.hostname ?? "") != "" }),
               { [(get(#, 1)?.local ?? "") != "" ? get(#, 1).local : get(#, 0), { endpoints: ["http://" + get(#, 1).hostname + ":5000"] }] }
             ))}
         network: '${workstation.runtime == "docker-desktop" ? {interfaces: [{ignore: true, interface: "eth0"}]} : {}}'
 
-  # Expose common_patch_docker as patchVars for provider-docker cluster input. When no compute, provider-docker uses docker_desktop_common_patches instead.
+  # Expose common_patch_docker for provider-docker cluster input. When no compute, provider-docker uses docker_desktop_common_patches instead.
   - name: talos_common_docker
     when: (cluster.enabled ?? true) && cluster.driver == 'talos'
-    patchVars:
-      common_config_patches: ${string(common_patch_docker.content)}
+    value:
+      common_config_patches: ${string(common_patch_docker)}
       controlplane_config_patches: ""
       worker_config_patches: ""
 
@@ -96,12 +97,12 @@ terraform:
     domain_name: ${dns.domain}
     network_name: windsor-${context}
     network_cidr: ${network.cidr_block}
-    dns_forward_target: "${cidrhost(network.cidr_block, 4 + int(workstation_registries.vars.registry_count ?? 0)) + \":30053\"}"
-    webhook_host: "${cidrhost(network.cidr_block, 4 + int(workstation_registries.vars.registry_count ?? 0))}"
-    primary_node_ip: "${cidrhost(network.cidr_block, 4 + int(workstation_registries.vars.registry_count ?? 0))}"
+    dns_forward_target: "${cidrhost(network.cidr_block, 4 + int(workstation_registries.registry_count ?? 0)) + \":30053\"}"
+    webhook_host: "${cidrhost(network.cidr_block, 4 + int(workstation_registries.registry_count ?? 0))}"
+    primary_node_ip: "${cidrhost(network.cidr_block, 4 + int(workstation_registries.registry_count ?? 0))}"
     enable_dns: ${workstation.services.dns ?? true}
     enable_git: ${workstation.services.git ?? true}
-    registries: ${workstation_registries.vars.value ?? {}}
+    registries: ${workstation_registries.registries ?? {}}
 
 # Workstation stack for colima/docker/linux: same as above but loadbalancer exists; DNS/webhook use loadbalancer IP.
 # runtime from config workstation.runtime (docker -> linux for Terraform).
@@ -119,7 +120,7 @@ terraform:
     primary_node_ip: ${network.loadbalancer_ips.start}
     enable_dns: ${workstation.services.dns ?? true}
     enable_git: ${workstation.services.git ?? true}
-    registries: ${workstation_registries.vars.value}
+    registries: ${workstation_registries.registries ?? {}}
 
 # Compute/docker: run Talos controlplane/worker containers on workstation network.
 # cluster/talos consumes compute outputs (endpoints, etc.) via provider-docker.

--- a/contexts/_template/facets/provider-aws.yaml
+++ b/contexts/_template/facets/provider-aws.yaml
@@ -4,7 +4,7 @@ metadata:
   name: aws
   description: "AWS provider basic infrastructure"
 
-when: (platform ?? provider) == 'aws'
+when: platform == 'aws'
 
 terraform:
 - name: network

--- a/contexts/_template/facets/provider-azure.yaml
+++ b/contexts/_template/facets/provider-azure.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure
   description: "Azure provider basic infrastructure"
 
-when: (platform ?? provider) == 'azure'
+when: platform == 'azure'
 
 terraform:
 - name: network

--- a/contexts/_template/facets/provider-base.yaml
+++ b/contexts/_template/facets/provider-base.yaml
@@ -8,8 +8,7 @@ when: (platform ?? provider) != 'none'
 
 config:
 - name: platform
-  vars:
-    value: "${platform ?? provider ?? 'none'}"
+  value: "${platform ?? provider ?? 'none'}"
 
 kustomize:
 

--- a/contexts/_template/facets/provider-base.yaml
+++ b/contexts/_template/facets/provider-base.yaml
@@ -7,9 +7,9 @@ metadata:
 when: (platform ?? provider) != 'none'
 
 config:
-- name: effective_provider
+- name: platform
   vars:
-    value: "${(platform ?? provider) ?? 'none'}"
+    value: "${platform ?? provider ?? 'none'}"
 
 kustomize:
 

--- a/contexts/_template/facets/provider-base.yaml
+++ b/contexts/_template/facets/provider-base.yaml
@@ -9,6 +9,9 @@ when: (platform ?? provider) != 'none'
 config:
 - name: platform
   value: "${platform ?? provider ?? 'none'}"
+- name: workstation
+  value:
+    runtime: "${workstation.runtime ?? vm.driver ?? ''}"
 
 kustomize:
 

--- a/contexts/_template/facets/provider-base.yaml
+++ b/contexts/_template/facets/provider-base.yaml
@@ -7,10 +7,9 @@ metadata:
 when: (platform ?? provider) != 'none'
 
 config:
-# Effective provider: platform ?? provider. Use this instead of provider so platform can override.
 - name: effective_provider
   vars:
-    value: "${platform ?? provider ?? \"none\"}"
+    value: "${(platform ?? provider) ?? 'none'}"
 
 kustomize:
 

--- a/contexts/_template/facets/provider-docker.yaml
+++ b/contexts/_template/facets/provider-docker.yaml
@@ -10,7 +10,7 @@ config:
 # Fallback cluster API endpoint: compute first cp host; else no compute → localhost:6443 (docker-desktop); else colima/linux from context.
 # With provider docker, no compute implies host→container so use localhost. Referenced by cluster_endpoint input.
 - name: cluster_endpoint_fallback
-  vars:
+  value:
     endpoint: >-
       ${len(terraform_output("compute", "controlplanes") ?? []) > 0
         && terraform_output("compute", "controlplanes")[0].endpoint != null
@@ -25,7 +25,7 @@ config:
 # talos_common_docker only runs when compute runs; no-compute path (docker-desktop) needs these certSANs.
 - name: docker_desktop_common_patches
   when: len(terraform_output("compute", "controlplanes") ?? []) == 0
-  patchVars:
+  value:
     common_config_patches: >-
       cluster:
         apiServer:
@@ -54,7 +54,7 @@ terraform:
     - compute
   parallelism: 1
   inputs:
-    cluster_endpoint: "${cluster.endpoint ?? cluster_endpoint_fallback.vars.endpoint}"
+    cluster_endpoint: "${cluster.endpoint ?? cluster_endpoint_fallback.endpoint}"
     cluster_name: talos
     talos_version: ${talos.talos_version}
     # When compute output exists, strip hostname from each node (Docker sets it; Talos 1.12 rejects override).
@@ -85,14 +85,14 @@ terraform:
     worker_disks: ${cluster.workers.disks ?? []}
     common_config_patches: >-
       ${len(terraform_output("compute", "controlplanes") ?? []) == 0
-        ? docker_desktop_common_patches.patchVars.common_config_patches
-        : (talos_common_docker.patchVars.common_config_patches ?? talos_common.patchVars.common_config_patches)}
+        ? docker_desktop_common_patches.common_config_patches
+        : (talos_common_docker.common_config_patches ?? talos_common.common_config_patches)}
     controlplane_config_patches: >-
-      ${len(terraform_output("compute", "controlplanes") ?? []) == 0 ? "" : (talos_common_docker.patchVars.controlplane_config_patches ?? "")}
+      ${len(terraform_output("compute", "controlplanes") ?? []) == 0 ? "" : (talos_common_docker.controlplane_config_patches ?? "")}
     worker_config_patches: >-
-      ${len(terraform_output("compute", "controlplanes") ?? []) == 0 ? "" : (talos_common_docker.patchVars.worker_config_patches ?? "")}
-    controlplane_volumes: ${talos_common.vars.controlplane_volumes ?? []}
-    worker_volumes: ${talos_common.vars.worker_volumes ?? []}
+      ${len(terraform_output("compute", "controlplanes") ?? []) == 0 ? "" : (talos_common_docker.worker_config_patches ?? "")}
+    controlplane_volumes: ${talos_common.controlplane_volumes ?? []}
+    worker_volumes: ${talos_common.worker_volumes ?? []}
 
 # Run gitops/flux after cluster. Skipped when workstation enabled (workstation facet owns gitops in that mode).
 - name: gitops
@@ -145,6 +145,6 @@ kustomize:
     - openebs
     - openebs/dynamic-localpv
   substitutions:
-    local_volume_path: ${talos_common.vars.csi_local_volume_path}
+    local_volume_path: ${talos_common.csi_local_volume_path}
   timeout: 20m
   interval: 5m

--- a/contexts/_template/facets/provider-docker.yaml
+++ b/contexts/_template/facets/provider-docker.yaml
@@ -4,7 +4,7 @@ metadata:
   name: docker
   description: "Docker provider basic infrastructure for local development"
 
-when: (platform ?? provider) == 'docker' && cluster.driver == 'talos'
+when: "platform == 'docker' && cluster.driver == 'talos'"
 
 config:
 # Fallback cluster API endpoint: compute first cp host; else no compute → localhost:6443 (docker-desktop); else colima/linux from context.

--- a/contexts/_template/facets/provider-incus.yaml
+++ b/contexts/_template/facets/provider-incus.yaml
@@ -8,7 +8,7 @@ when: "platform == 'incus' && cluster.driver == 'talos'"
 
 config:
 - name: cluster_endpoint_fallback
-  vars:
+  value:
     endpoint: >-
       ${
         len(terraform_output("compute", "controlplanes") ?? []) > 0
@@ -70,16 +70,16 @@ terraform:
   - compute
   parallelism: 1
   inputs:
-    cluster_endpoint: "${cluster.endpoint ?? cluster_endpoint_fallback.vars.endpoint}"
+    cluster_endpoint: "${cluster.endpoint ?? cluster_endpoint_fallback.endpoint}"
     cluster_name: talos
     talos_version: ${talos.talos_version}
     controlplanes: ${terraform_output("compute", "controlplanes") ?? values(cluster.controlplanes.nodes)}
     workers: "${terraform_output(\"compute\", \"workers\") ?? ((cluster.workers.count ?? 0) > 0 ? values(cluster.workers.nodes) : [])}"
-    controlplane_disks: ${talos_common.vars.controlplane_disks}
-    worker_disks: ${talos_common.vars.worker_disks}
-    common_config_patches: ${talos_common.patchVars.common_config_patches}
-    controlplane_volumes: ${talos_common.vars.controlplane_volumes ?? []}
-    worker_volumes: ${talos_common.vars.worker_volumes ?? []}
+    controlplane_disks: ${talos_common.controlplane_disks}
+    worker_disks: ${talos_common.worker_disks}
+    common_config_patches: ${talos_common.common_config_patches}
+    controlplane_volumes: ${talos_common.controlplane_volumes ?? []}
+    worker_volumes: ${talos_common.worker_volumes ?? []}
 - name: gitops
   path: gitops/flux
   dependsOn:
@@ -99,7 +99,7 @@ kustomize:
   - openebs
   - openebs/dynamic-localpv
   substitutions:
-    local_volume_path: ${talos_common.vars.csi_local_volume_path}
+    local_volume_path: ${talos_common.csi_local_volume_path}
   timeout: 20m
   interval: 5m
 

--- a/contexts/_template/facets/provider-incus.yaml
+++ b/contexts/_template/facets/provider-incus.yaml
@@ -4,7 +4,7 @@ metadata:
   name: incus
   description: Incus compute platform infrastructure
 
-when: (platform ?? provider) == 'incus'
+when: "platform == 'incus' && cluster.driver == 'talos'"
 
 config:
 - name: cluster_endpoint_fallback

--- a/contexts/_template/facets/provider-metal.yaml
+++ b/contexts/_template/facets/provider-metal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: metal
   description: "Metal provider basic infrastructure"
 
-when: (platform ?? provider) == 'metal'
+when: platform == 'metal'
 
 terraform:
 - name: cluster

--- a/contexts/_template/facets/provider-metal.yaml
+++ b/contexts/_template/facets/provider-metal.yaml
@@ -16,11 +16,11 @@ terraform:
     talos_version: ${talos.talos_version}
     controlplanes: ${values(cluster.controlplanes.nodes)}
     workers: "${(cluster.workers.count ?? 0) > 0 ? values(cluster.workers.nodes) : []}"
-    controlplane_disks: ${talos_common.vars.controlplane_disks}
-    worker_disks: ${talos_common.vars.worker_disks}
-    common_config_patches: ${talos_common.patchVars.common_config_patches}
-    controlplane_volumes: ${talos_common.vars.controlplane_volumes ?? []}
-    worker_volumes: ${talos_common.vars.worker_volumes ?? []}
+    controlplane_disks: ${talos_common.controlplane_disks}
+    worker_disks: ${talos_common.worker_disks}
+    common_config_patches: ${talos_common.common_config_patches}
+    controlplane_volumes: ${talos_common.controlplane_volumes ?? []}
+    worker_volumes: ${talos_common.worker_volumes ?? []}
 - name: gitops
   path: gitops/flux
   dependsOn:
@@ -40,7 +40,7 @@ kustomize:
     - openebs
     - openebs/dynamic-localpv
   substitutions:
-    local_volume_path: ${talos_common.vars.csi_local_volume_path}
+    local_volume_path: ${talos_common.csi_local_volume_path}
   timeout: 20m
   interval: 5m
 

--- a/contexts/_template/tests/option-ingress.test.yaml
+++ b/contexts/_template/tests/option-ingress.test.yaml
@@ -106,6 +106,7 @@ cases:
         enabled: true
         driver: nginx
       workstation:
+        enabled: true
         runtime: colima
       network: *default-network
       cluster: *default-cluster


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes multiple facet gating conditions and platform detection, which can alter which Terraform/Kustomize blocks run for existing contexts (especially around Docker/Incus defaults and ingress/private DNS selection).
> 
> **Overview**
> Standardizes facet `when` expressions to key off `platform` (dropping many `(platform ?? provider)` checks) and introduces a `provider-base` config shim that normalizes `platform` and `workstation.runtime` from legacy `provider`/`vm.driver` inputs.
> 
> Refines local-dev behavior: `option-workstation` now applies to Docker by default (unless explicitly disabled) and to Incus only when explicitly enabled, while downstream blocks (workstation/compute/cluster, ingress/private DNS component selection) are updated to use the normalized `platform`/`workstation.runtime` semantics. Updates the ingress facet test to include `workstation.enabled` for Docker runtime selection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffeda555faa179a15edd89da43af9e88cfdd1199. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->