### PR TITLE
chore: Update facet config blocks to use "value"

### DIFF
--- a/contexts/_template/blueprint.yaml
+++ b/contexts/_template/blueprint.yaml
@@ -1,7 +1,7 @@
 kind: Blueprint
 apiVersion: blueprints.windsorcli.dev/v1alpha1
 metadata:
-  name: template
+  name: core
   description: Base blueprint template for core services
 sources: []
 terraform: []

--- a/contexts/_template/facets/addon-private-dns.yaml
+++ b/contexts/_template/facets/addon-private-dns.yaml
@@ -21,7 +21,7 @@ kustomize:
     - external-dns
     - external-dns/coredns
     - external-dns/ingress
-    - "${workstation.runtime == 'docker-desktop' ? 'external-dns/localhost' : ''}"
+    - "${(workstation.runtime ?? vm.driver) == 'docker-desktop' ? 'external-dns/localhost' : ''}"
   substitutions:
     external_domain: ${dns.domain}
 

--- a/contexts/_template/facets/config-talos.yaml
+++ b/contexts/_template/facets/config-talos.yaml
@@ -8,27 +8,27 @@ when: cluster.driver == 'talos'
 
 config:
   - name: talos_common
-    vars:
+    value:
       allowSchedulingOnControlPlanes: "${cluster.controlplanes.schedulable ?? false}"
       controlplane_volumes: "${cluster.controlplanes.volumes ?? []}"
       worker_volumes: "${cluster.workers.volumes ?? []}"
       csi_local_volume_path: "${cluster.storage.local_base_path ?? \"/var/mnt/local\"}"
       controlplane_disks: "${cluster.controlplanes.disks ?? []}"
       worker_disks: "${cluster.workers.disks ?? []}"
-    patchVars:
+      common_patch:
+        cluster:
+          allowSchedulingOnControlPlanes: ${talos_common.allowSchedulingOnControlPlanes}
+          extraManifests:
+            - "https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml"
+        machine:
+          kubelet:
+            extraArgs:
+              rotate-server-certificates: "true"
       common_config_patches: "${string(talos_common.common_patch)}"
-    common_patch:
-      cluster:
-        allowSchedulingOnControlPlanes: ${talos_common.vars.allowSchedulingOnControlPlanes}
-        extraManifests:
-          - "https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml"
-      machine:
-        kubelet:
-          extraArgs:
-            rotate-server-certificates: "true"
 
   - name: talos
-    # renovate: datasource=docker depName=ghcr.io/siderolabs/talos package=ghcr.io/siderolabs/talos
-    image: ghcr.io/siderolabs/talos:v1.12.1
-    # renovate: datasource=github-releases depName=talos package=siderolabs/talos
-    talos_version: "1.12.1"
+    value:
+      # renovate: datasource=docker depName=ghcr.io/siderolabs/talos package=ghcr.io/siderolabs/talos
+      image: ghcr.io/siderolabs/talos:v1.12.1
+      # renovate: datasource=github-releases depName=talos package=siderolabs/talos
+      talos_version: "1.12.1"

--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -8,12 +8,13 @@ when: workstation.enabled == true && (platform ?? provider) == 'docker'
 
 config:
   - name: workstation
-    runtime: "${workstation.runtime ?? vm.driver ?? \"colima\"}"
+    value:
+      runtime: "${workstation.runtime ?? vm.driver ?? \"colima\"}"
 
   # Effective registries for workstation Terraform and Talos patch: empty when services.registries false, else docker.registries or default.
   - name: workstation_registries
-    vars:
-      value: |
+    value:
+      registries: |
         ${(workstation.services.registries ?? true) == false ? {} : (docker.registries ?? {
           "gcr.io": { "remote": "https://gcr.io" },
           "ghcr.io": { "remote": "https://ghcr.io" },
@@ -25,10 +26,10 @@ config:
       registry_count: "${(workstation.services.registries ?? true) == false ? 0 : len(docker.registries ?? {\"gcr.io\": {}, \"ghcr.io\": {}, \"quay.io\": {}, \"registry-1.docker.io\": {}, \"registry.k8s.io\": {}, \"registry.test\": {}})}"
 
   # certSANs for Talos when compute runs. Include localhost/127.0.0.1 for docker-desktop so host→container works.
-  # Kept as vars so it is evaluated when building cluster inputs (after compute). Apply when docker provider + talos.
+  # Kept so it is evaluated when building cluster inputs (after compute). Apply when docker provider + talos.
   - name: certSANs_from_compute
     when: (cluster.enabled ?? true) && cluster.driver == 'talos'
-    vars:
+    value:
       list: |-
         ${(cluster.controlplanes.count ?? 1) == 0 ? ["localhost", "127.0.0.1"] : (
           let cp = terraform_output("compute", "controlplanes");
@@ -44,31 +45,31 @@ config:
   # Talos common patch when docker provider + talos: certSANs (localhost/127.0.0.1 for docker-desktop), registries, etc.
   - name: common_patch_docker
     when: (cluster.enabled ?? true) && cluster.driver == 'talos'
-    content:
+    value:
       cluster:
         apiServer:
-          certSANs: ${certSANs_from_compute.vars.list}
+          certSANs: ${certSANs_from_compute.list}
         allowSchedulingOnControlPlanes: ${cluster.controlplanes.schedulable ?? ((cluster.workers.count ?? 0) == 0)}
         extraManifests:
           - "https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml"
       machine:
-        certSANs: ${certSANs_from_compute.vars.list}
+        certSANs: ${certSANs_from_compute.list}
         kubelet:
           extraArgs:
             rotate-server-certificates: "true"
         registries:
           mirrors: |-
             ${fromPairs(map(
-              filter(toPairs(workstation_registries.vars.value), { (get(#, 1)?.hostname ?? "") != "" }),
+              filter(toPairs(workstation_registries.registries ?? {}), { (get(#, 1)?.hostname ?? "") != "" }),
               { [(get(#, 1)?.local ?? "") != "" ? get(#, 1).local : get(#, 0), { endpoints: ["http://" + get(#, 1).hostname + ":5000"] }] }
             ))}
         network: '${workstation.runtime == "docker-desktop" ? {interfaces: [{ignore: true, interface: "eth0"}]} : {}}'
 
-  # Expose common_patch_docker as patchVars for provider-docker cluster input. When no compute, provider-docker uses docker_desktop_common_patches instead.
+  # Expose common_patch_docker for provider-docker cluster input. When no compute, provider-docker uses docker_desktop_common_patches instead.
   - name: talos_common_docker
     when: (cluster.enabled ?? true) && cluster.driver == 'talos'
-    patchVars:
-      common_config_patches: ${string(common_patch_docker.content)}
+    value:
+      common_config_patches: ${string(common_patch_docker)}
       controlplane_config_patches: ""
       worker_config_patches: ""
 
@@ -85,7 +86,8 @@ terraform:
     webhook_token: ${git.livereload.webhook_token ?? "abcdef123456"}
 
 # Workstation stack for docker-desktop: DNS, registries, git livereload. No loadbalancer; DNS forwards to
-# node hostport (e.g. first node :8053).
+# first node. Use container port 30053 (not host 8053) so the DNS container on the same network can reach the node.
+# 30053 = NodePort for DNS set in kustomize/ingress/nginx/coredns/patches/helm-release.yaml; cluster.*.hostports must use same container port (e.g. 8053:30053/udp).
 - name: workstation
   when: workstation.runtime == "docker-desktop"
   path: workstation/docker
@@ -94,12 +96,12 @@ terraform:
     domain_name: ${dns.domain}
     network_name: windsor-${context}
     network_cidr: ${network.cidr_block}
-    dns_forward_target: "${cidrhost(network.cidr_block, 4 + int(workstation_registries.vars.registry_count)) + \":8053\"}"
-    webhook_host: "${cidrhost(network.cidr_block, 4 + int(workstation_registries.vars.registry_count))}"
-    primary_node_ip: "${cidrhost(network.cidr_block, 4 + int(workstation_registries.vars.registry_count))}"
+    dns_forward_target: "${cidrhost(network.cidr_block, 4 + int(workstation_registries.registry_count ?? 0)) + \":30053\"}"
+    webhook_host: "${cidrhost(network.cidr_block, 4 + int(workstation_registries.registry_count ?? 0))}"
+    primary_node_ip: "${cidrhost(network.cidr_block, 4 + int(workstation_registries.registry_count ?? 0))}"
     enable_dns: ${workstation.services.dns ?? true}
     enable_git: ${workstation.services.git ?? true}
-    registries: ${workstation_registries.vars.value}
+    registries: ${workstation_registries.registries ?? {}}
 
 # Workstation stack for colima/docker/linux: same as above but loadbalancer exists; DNS/webhook use loadbalancer IP.
 # runtime from config workstation.runtime (docker -> linux for Terraform).
@@ -117,7 +119,7 @@ terraform:
     primary_node_ip: ${network.loadbalancer_ips.start}
     enable_dns: ${workstation.services.dns ?? true}
     enable_git: ${workstation.services.git ?? true}
-    registries: ${workstation_registries.vars.value}
+    registries: ${workstation_registries.registries ?? {}}
 
 # Compute/docker: run Talos controlplane/worker containers on workstation network.
 # cluster/talos consumes compute outputs (endpoints, etc.) via provider-docker.

--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -74,13 +74,20 @@ config:
       worker_config_patches: ""
 
 terraform:
-# GitOps/flux with livereload credentials and webhook token. Runs when workstation enabled.
+# GitOps/flux with livereload credentials and webhook token. Runs when workstation + cluster enabled (depends on cluster).
 - name: gitops
+  when: (cluster.enabled ?? true)
   path: gitops/flux
   destroy: false
   dependsOn:
     - cluster
   inputs:
+    concurrency: >-
+      ${max(2, min(
+        floor((cluster.controlplanes.cpu ?? 4) / 2),
+        floor((cluster.controlplanes.memory ?? 4) / 2),
+        10
+      ))}
     git_username: ${git.livereload.username ?? "local"}
     git_password: ${git.livereload.password ?? "local"}
     webhook_token: ${git.livereload.webhook_token ?? "abcdef123456"}
@@ -124,7 +131,7 @@ terraform:
 # Compute/docker: run Talos controlplane/worker containers on workstation network.
 # cluster/talos consumes compute outputs (endpoints, etc.) via provider-docker.
 - name: compute
-  when: (platform ?? provider) == 'docker' && (cluster.enabled ?? true) == true
+  when: (platform ?? provider) == 'docker' && (cluster.enabled ?? true)
   path: compute/docker
   dependsOn:
     - workstation

--- a/contexts/_template/facets/provider-base.yaml
+++ b/contexts/_template/facets/provider-base.yaml
@@ -6,12 +6,6 @@ metadata:
 
 when: (platform ?? provider) != 'none'
 
-config:
-# Effective provider: platform ?? provider. Use this instead of provider so platform can override.
-- name: effective_provider
-  vars:
-    value: "${platform ?? provider ?? \"none\"}"
-
 kustomize:
 
 # Cleanup

--- a/contexts/_template/facets/provider-docker.yaml
+++ b/contexts/_template/facets/provider-docker.yaml
@@ -10,7 +10,7 @@ config:
 # Fallback cluster API endpoint: compute first cp host; else no compute → localhost:6443 (docker-desktop); else colima/linux from context.
 # With provider docker, no compute implies host→container so use localhost. Referenced by cluster_endpoint input.
 - name: cluster_endpoint_fallback
-  vars:
+  value:
     endpoint: >-
       ${len(terraform_output("compute", "controlplanes") ?? []) > 0
         && terraform_output("compute", "controlplanes")[0].endpoint != null
@@ -25,7 +25,7 @@ config:
 # talos_common_docker only runs when compute runs; no-compute path (docker-desktop) needs these certSANs.
 - name: docker_desktop_common_patches
   when: len(terraform_output("compute", "controlplanes") ?? []) == 0
-  patchVars:
+  value:
     common_config_patches: >-
       cluster:
         apiServer:
@@ -54,7 +54,7 @@ terraform:
     - compute
   parallelism: 1
   inputs:
-    cluster_endpoint: "${cluster.endpoint ?? cluster_endpoint_fallback.vars.endpoint}"
+    cluster_endpoint: "${cluster.endpoint ?? cluster_endpoint_fallback.endpoint}"
     cluster_name: talos
     talos_version: ${talos.talos_version}
     # When compute output exists, strip hostname from each node (Docker sets it; Talos 1.12 rejects override).
@@ -85,14 +85,14 @@ terraform:
     worker_disks: ${cluster.workers.disks ?? []}
     common_config_patches: >-
       ${len(terraform_output("compute", "controlplanes") ?? []) == 0
-        ? docker_desktop_common_patches.patchVars.common_config_patches
-        : (talos_common_docker.patchVars.common_config_patches ?? talos_common.patchVars.common_config_patches)}
+        ? docker_desktop_common_patches.common_config_patches
+        : (talos_common_docker.common_config_patches ?? talos_common.common_config_patches)}
     controlplane_config_patches: >-
-      ${len(terraform_output("compute", "controlplanes") ?? []) == 0 ? "" : (talos_common_docker.patchVars.controlplane_config_patches ?? "")}
+      ${len(terraform_output("compute", "controlplanes") ?? []) == 0 ? "" : (talos_common_docker.controlplane_config_patches ?? "")}
     worker_config_patches: >-
-      ${len(terraform_output("compute", "controlplanes") ?? []) == 0 ? "" : (talos_common_docker.patchVars.worker_config_patches ?? "")}
-    controlplane_volumes: ${talos_common.vars.controlplane_volumes ?? []}
-    worker_volumes: ${talos_common.vars.worker_volumes ?? []}
+      ${len(terraform_output("compute", "controlplanes") ?? []) == 0 ? "" : (talos_common_docker.worker_config_patches ?? "")}
+    controlplane_volumes: ${talos_common.controlplane_volumes ?? []}
+    worker_volumes: ${talos_common.worker_volumes ?? []}
 
 # Run gitops/flux after cluster. Skipped when workstation enabled (workstation facet owns gitops in that mode).
 - name: gitops
@@ -145,6 +145,6 @@ kustomize:
     - openebs
     - openebs/dynamic-localpv
   substitutions:
-    local_volume_path: ${talos_common.vars.csi_local_volume_path}
+    local_volume_path: ${talos_common.csi_local_volume_path}
   timeout: 20m
   interval: 5m

--- a/contexts/_template/facets/provider-docker.yaml
+++ b/contexts/_template/facets/provider-docker.yaml
@@ -46,9 +46,9 @@ config:
 terraform:
 # Run cluster/talos: secrets, config apply, bootstrap, kubeconfig. Inputs from compute output or context;
 # hostname stripped for containers (Talos 1.12 rejects setting hostname when runtime already set it).
-# When workstation enabled, cluster must wait for compute (workstation → compute → cluster). Omit cluster when workstation disabled (gitops-only path).
+# When workstation enabled and cluster enabled, cluster must wait for compute (workstation → compute → cluster). Omit when cluster disabled (no compute).
 - name: cluster
-  when: workstation.enabled == true
+  when: workstation.enabled == true && (cluster.enabled ?? true)
   path: cluster/talos
   dependsOn:
     - compute
@@ -93,21 +93,6 @@ terraform:
       ${len(terraform_output("compute", "controlplanes") ?? []) == 0 ? "" : (talos_common_docker.worker_config_patches ?? "")}
     controlplane_volumes: ${talos_common.controlplane_volumes ?? []}
     worker_volumes: ${talos_common.worker_volumes ?? []}
-
-# Run gitops/flux after cluster. Skipped when workstation enabled (workstation facet owns gitops in that mode).
-- name: gitops
-  path: gitops/flux
-  when: workstation.enabled == false
-  dependsOn:
-    - cluster
-  inputs:
-    concurrency: >-
-      ${max(2, min(
-        floor((cluster.controlplanes.cpu ?? 4) / 2),
-        floor((cluster.controlplanes.memory ?? 4) / 2),
-        10
-      ))}
-  destroy: false
 
 kustomize:
 

--- a/contexts/_template/facets/provider-incus.yaml
+++ b/contexts/_template/facets/provider-incus.yaml
@@ -8,7 +8,7 @@ when: (platform ?? provider) == 'incus'
 
 config:
 - name: cluster_endpoint_fallback
-  vars:
+  value:
     endpoint: >-
       ${
         len(terraform_output("compute", "controlplanes") ?? []) > 0
@@ -70,16 +70,16 @@ terraform:
   - compute
   parallelism: 1
   inputs:
-    cluster_endpoint: "${cluster.endpoint ?? cluster_endpoint_fallback.vars.endpoint}"
+    cluster_endpoint: "${cluster.endpoint ?? cluster_endpoint_fallback.endpoint}"
     cluster_name: talos
     talos_version: ${talos.talos_version}
     controlplanes: ${terraform_output("compute", "controlplanes") ?? values(cluster.controlplanes.nodes)}
     workers: "${terraform_output(\"compute\", \"workers\") ?? ((cluster.workers.count ?? 0) > 0 ? values(cluster.workers.nodes) : [])}"
-    controlplane_disks: ${talos_common.vars.controlplane_disks}
-    worker_disks: ${talos_common.vars.worker_disks}
-    common_config_patches: ${talos_common.patchVars.common_config_patches}
-    controlplane_volumes: ${talos_common.vars.controlplane_volumes ?? []}
-    worker_volumes: ${talos_common.vars.worker_volumes ?? []}
+    controlplane_disks: ${talos_common.controlplane_disks}
+    worker_disks: ${talos_common.worker_disks}
+    common_config_patches: ${talos_common.common_config_patches}
+    controlplane_volumes: ${talos_common.controlplane_volumes ?? []}
+    worker_volumes: ${talos_common.worker_volumes ?? []}
 - name: gitops
   path: gitops/flux
   dependsOn:
@@ -99,7 +99,7 @@ kustomize:
   - openebs
   - openebs/dynamic-localpv
   substitutions:
-    local_volume_path: ${talos_common.vars.csi_local_volume_path}
+    local_volume_path: ${talos_common.csi_local_volume_path}
   timeout: 20m
   interval: 5m
 

--- a/contexts/_template/facets/provider-incus.yaml
+++ b/contexts/_template/facets/provider-incus.yaml
@@ -22,12 +22,12 @@ terraform:
 - name: compute
   path: compute/incus
   inputs:
-    network_name: "${(workstation.runtime ?? '') == 'colima' ? 'incusbr0' : ''}"
-    create_network: "${(workstation.runtime ?? '') != 'colima'}"
+    network_name: "${(workstation.runtime ?? vm.driver ?? '') == 'colima' ? 'incusbr0' : ''}"
+    create_network: "${(workstation.runtime ?? vm.driver ?? '') != 'colima'}"
     network_cidr: ${network.cidr_block}
     storage_pools:
       local:
-        driver: "${(workstation.runtime ?? '') == 'colima' ? 'dir' : null}"
+        driver: "${(workstation.runtime ?? vm.driver ?? '') == 'colima' ? 'dir' : null}"
     instances:
       - name: controlplane
         role: controlplane
@@ -36,7 +36,7 @@ terraform:
         image: windsor:talos/v1.12.1/arm64
         type: virtual-machine
         description: Talos control plane node
-        storage_pool: "${(workstation.runtime ?? '') == 'colima' ? 'local' : 'default'}"
+        storage_pool: "${(workstation.runtime ?? vm.driver ?? '') == 'colima' ? 'local' : 'default'}"
         root_disk_size: ${string(cluster.controlplanes.root_disk_size ?? 30) + "GB"}
         limits:
           cpu: ${string(cluster.controlplanes.cpu ?? 2)}
@@ -53,7 +53,7 @@ terraform:
         image: windsor:talos/v1.12.1/arm64
         type: virtual-machine
         description: Talos worker node
-        storage_pool: "${(workstation.runtime ?? '') == 'colima' ? 'local' : 'default'}"
+        storage_pool: "${(workstation.runtime ?? vm.driver ?? '') == 'colima' ? 'local' : 'default'}"
         root_disk_size: ${string(cluster.workers.root_disk_size ?? 50) + "GB"}
         limits:
           cpu: ${string(cluster.workers.cpu ?? 4)}

--- a/contexts/_template/facets/provider-metal.yaml
+++ b/contexts/_template/facets/provider-metal.yaml
@@ -16,11 +16,11 @@ terraform:
     talos_version: ${talos.talos_version}
     controlplanes: ${values(cluster.controlplanes.nodes)}
     workers: "${(cluster.workers.count ?? 0) > 0 ? values(cluster.workers.nodes) : []}"
-    controlplane_disks: ${talos_common.vars.controlplane_disks}
-    worker_disks: ${talos_common.vars.worker_disks}
-    common_config_patches: ${talos_common.patchVars.common_config_patches}
-    controlplane_volumes: ${talos_common.vars.controlplane_volumes ?? []}
-    worker_volumes: ${talos_common.vars.worker_volumes ?? []}
+    controlplane_disks: ${talos_common.controlplane_disks}
+    worker_disks: ${talos_common.worker_disks}
+    common_config_patches: ${talos_common.common_config_patches}
+    controlplane_volumes: ${talos_common.controlplane_volumes ?? []}
+    worker_volumes: ${talos_common.worker_volumes ?? []}
 - name: gitops
   path: gitops/flux
   dependsOn:
@@ -40,7 +40,7 @@ kustomize:
     - openebs
     - openebs/dynamic-localpv
   substitutions:
-    local_volume_path: ${talos_common.vars.csi_local_volume_path}
+    local_volume_path: ${talos_common.csi_local_volume_path}
   timeout: 20m
   interval: 5m
 

--- a/contexts/_template/schema.yaml
+++ b/contexts/_template/schema.yaml
@@ -104,7 +104,7 @@ properties:
     type: string
     description: Context id (e.g. short identifier for this deployment)
 
-  # Infrastructure provider / platform. Use platform ?? provider as effective value; facets use effective_provider (provider-base).
+  # Infrastructure provider / platform. Use platform ?? provider as effective value;
   provider:
     type: string
     enum:

--- a/contexts/_template/tests/addon-database.test.yaml
+++ b/contexts/_template/tests/addon-database.test.yaml
@@ -4,6 +4,7 @@
 # Common configurations
 x-defaults:
   network: &default-network
+    cidr_block: 10.5.0.0/16
     loadbalancer_driver: kube-vip
     loadbalancer_mode: arp
     loadbalancer_ips:
@@ -11,6 +12,7 @@ x-defaults:
       end: "10.5.1.100"
 
   cluster: &default-cluster
+    driver: talos
     controlplanes:
       nodes:
         controlplane-1:

--- a/contexts/_template/tests/addon-object-store.test.yaml
+++ b/contexts/_template/tests/addon-object-store.test.yaml
@@ -4,6 +4,7 @@
 # Common configurations
 x-defaults:
   network: &default-network
+    cidr_block: 10.5.0.0/16
     loadbalancer_driver: kube-vip
     loadbalancer_mode: arp
     loadbalancer_ips:
@@ -11,6 +12,7 @@ x-defaults:
       end: "10.5.1.100"
 
   cluster: &default-cluster
+    driver: talos
     controlplanes:
       nodes:
         controlplane-1:

--- a/contexts/_template/tests/addon-observability.test.yaml
+++ b/contexts/_template/tests/addon-observability.test.yaml
@@ -4,6 +4,7 @@
 # Common configurations
 x-defaults:
   network: &default-network
+    cidr_block: 10.5.0.0/16
     loadbalancer_driver: kube-vip
     loadbalancer_mode: arp
     loadbalancer_ips:
@@ -11,6 +12,7 @@ x-defaults:
       end: "10.5.1.100"
 
   cluster: &default-cluster
+    driver: talos
     controlplanes:
       nodes:
         controlplane-1:

--- a/contexts/_template/tests/addon-private-ca.test.yaml
+++ b/contexts/_template/tests/addon-private-ca.test.yaml
@@ -4,6 +4,7 @@
 # Common configurations
 x-defaults:
   network: &default-network
+    cidr_block: 10.5.0.0/16
     loadbalancer_driver: kube-vip
     loadbalancer_mode: arp
     loadbalancer_ips:
@@ -11,6 +12,7 @@ x-defaults:
       end: "10.5.1.100"
 
   cluster: &default-cluster
+    driver: talos
     controlplanes:
       nodes:
         controlplane-1:

--- a/contexts/_template/tests/addon-private-dns.test.yaml
+++ b/contexts/_template/tests/addon-private-dns.test.yaml
@@ -4,6 +4,7 @@
 # Common configurations
 x-defaults:
   network: &default-network
+    cidr_block: 10.5.0.0/16
     loadbalancer_driver: kube-vip
     loadbalancer_mode: arp
     loadbalancer_ips:
@@ -11,6 +12,7 @@ x-defaults:
       end: "10.5.1.100"
 
   cluster: &default-cluster
+    driver: talos
     controlplanes:
       nodes:
         controlplane-1:

--- a/contexts/_template/tests/option-demo.test.yaml
+++ b/contexts/_template/tests/option-demo.test.yaml
@@ -4,6 +4,7 @@
 # Common configurations
 x-defaults:
   network: &default-network
+    cidr_block: 10.5.0.0/16
     loadbalancer_driver: kube-vip
     loadbalancer_mode: arp
     loadbalancer_ips:
@@ -11,6 +12,7 @@ x-defaults:
       end: "10.5.1.100"
 
   cluster: &default-cluster
+    driver: talos
     controlplanes:
       nodes:
         controlplane-1:

--- a/contexts/_template/tests/option-dev.test.yaml
+++ b/contexts/_template/tests/option-dev.test.yaml
@@ -4,6 +4,7 @@
 # Common configurations
 x-defaults:
   network: &default-network
+    cidr_block: 10.5.0.0/16
     loadbalancer_driver: kube-vip
     loadbalancer_mode: arp
     loadbalancer_ips:
@@ -11,6 +12,7 @@ x-defaults:
       end: "10.5.1.100"
 
   cluster: &default-cluster
+    driver: talos
     controlplanes:
       nodes:
         controlplane-1:

--- a/contexts/_template/tests/option-ingress.test.yaml
+++ b/contexts/_template/tests/option-ingress.test.yaml
@@ -4,6 +4,7 @@
 # Common configurations
 x-defaults:
   network: &default-network
+    cidr_block: 10.5.0.0/16
     loadbalancer_driver: kube-vip
     loadbalancer_mode: arp
     loadbalancer_ips:
@@ -11,6 +12,7 @@ x-defaults:
       end: "10.5.1.100"
 
   cluster: &default-cluster
+    driver: talos
     controlplanes:
       nodes:
         controlplane-1:
@@ -71,7 +73,7 @@ cases:
           timeout: 10m
           interval: 5m
 
-  # Docker Desktop intent: nodeport. Engine does not pass values.workstation/values.platform into kustomize expression scope (see docs/cli-bugs.md), so we expect loadbalancer until engine is fixed.
+  # Docker Desktop: nodeport (no loadbalancer); workstation.runtime in scope selects nginx/nodeport.
   - name: Docker Desktop uses nodeport ingress
     values:
       platform: docker
@@ -91,7 +93,7 @@ cases:
             - pki-base
           components:
             - nginx
-            - nginx/loadbalancer
+            - nginx/nodeport
             - nginx/web
             - nginx/prometheus
           timeout: 10m

--- a/contexts/_template/tests/option-workstation.test.yaml
+++ b/contexts/_template/tests/option-workstation.test.yaml
@@ -15,6 +15,7 @@ x-defaults:
     domain: test.local
 
   cluster: &default-cluster
+    driver: talos
     controlplanes:
       nodes:
         controlplane-1: &cp1-node
@@ -73,6 +74,7 @@ cases:
       ingress: *ingress-disabled
       network: *default-network
       cluster:
+        driver: talos
         controlplanes:
           cpu: 4
           memory: 8
@@ -95,7 +97,7 @@ cases:
           path: gitops/flux
           destroy: false
 
-  # Edge: cluster.enabled false with workstation enabled → no cluster (compute block also not run)
+  # Edge: cluster.enabled false with workstation enabled → no cluster, no flux (compute and gitops not run)
   - name: cluster disabled with workstation yields no cluster terraform
     values:
       provider: docker
@@ -107,6 +109,7 @@ cases:
       ingress: *ingress-disabled
       network: *default-network
       cluster:
+        driver: talos
         enabled: false
         controlplanes:
           nodes:
@@ -116,9 +119,8 @@ cases:
             - /var/mnt/local
     expect:
       terraform:
-        - name: gitops
-          path: gitops/flux
-          destroy: false
+        - name: workstation
+          path: workstation/docker
 
   # Edge: workstation.runtime set explicitly overrides vm.driver (config merge); runtime docker → loadbalancer present
   - name: workstation runtime override uses explicit runtime not vm.driver

--- a/contexts/_template/tests/provider-base.test.yaml
+++ b/contexts/_template/tests/provider-base.test.yaml
@@ -5,6 +5,7 @@
 # Common configurations
 x-defaults:
   network: &default-network
+    cidr_block: 10.5.0.0/16
     loadbalancer_driver: kube-vip
     loadbalancer_mode: arp
     loadbalancer_ips:
@@ -12,6 +13,7 @@ x-defaults:
       end: "10.5.1.100"
 
   cluster: &default-cluster
+    driver: talos
     controlplanes:
       nodes:
         controlplane-1:

--- a/contexts/_template/tests/provider-docker.test.yaml
+++ b/contexts/_template/tests/provider-docker.test.yaml
@@ -19,6 +19,7 @@ x-defaults:
     domain: test.local
 
   cluster: &default-cluster
+    driver: talos
     controlplanes:
       nodes:
         controlplane-1: &cp1-node
@@ -173,6 +174,7 @@ cases:
         driver: nginx
       network: *default-network
       cluster:
+        driver: talos
         controlplanes:
           cpu: 20
           memory: 32
@@ -289,7 +291,7 @@ cases:
           timeout: 20m
           interval: 5m
 
-  # Edge: docker without workstation yields no cluster (only gitops from provider-docker)
+  # Edge: docker without workstation yields no cluster and no gitops (gitops always dependsOn cluster; cluster only when workstation enabled).
   - name: docker without workstation has no cluster terraform
     values:
       provider: docker
@@ -301,10 +303,7 @@ cases:
       network: *default-network
       cluster: *default-cluster
     expect:
-      terraform:
-        - name: gitops
-          path: gitops/flux
-          destroy: false
+      terraform: []
 
   # Edge: Docker Desktop excludes load balancer (workstation enabled so cluster runs)
   - name: Docker Desktop excludes load balancer

--- a/contexts/_template/tests/provider-incus.test.yaml
+++ b/contexts/_template/tests/provider-incus.test.yaml
@@ -14,6 +14,7 @@ x-defaults:
       end: "10.5.1.100"
 
   cluster: &default-cluster
+    driver: talos
     controlplanes:
       nodes:
         controlplane-1: &cp1-node
@@ -125,6 +126,7 @@ cases:
           start: "10.10.1.10"
           end: "10.10.1.100"
       cluster:
+        driver: talos
         controlplanes:
           count: 3
           cpu: 4
@@ -267,6 +269,7 @@ cases:
       ingress: *ingress-disabled
       network: *default-network
       cluster:
+        driver: talos
         controlplanes:
           schedulable: true
           volumes:

--- a/contexts/_template/tests/provider-metal.test.yaml
+++ b/contexts/_template/tests/provider-metal.test.yaml
@@ -7,6 +7,7 @@
 # Common configurations
 x-defaults:
   network: &default-network
+    cidr_block: 10.5.0.0/16
     loadbalancer_driver: kube-vip
     loadbalancer_mode: arp
     loadbalancer_ips:
@@ -14,6 +15,7 @@ x-defaults:
       end: "10.5.1.100"
 
   cluster: &default-cluster
+    driver: talos
     controlplanes:
       nodes:
         controlplane-1: &cp1-node
@@ -149,6 +151,7 @@ cases:
           start: "192.168.1.100"
           end: "192.168.1.200"
       cluster:
+        driver: talos
         controlplanes:
           cpu: 20
           memory: 32


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core blueprint evaluation inputs/conditionals and provider/workstation wiring, so small schema or reference mistakes could break cluster provisioning paths (especially docker-desktop and talos patches).
> 
> **Overview**
> Refactors blueprint facet `config` blocks across Talos and provider facets to standardize on `value` (removing `vars`/`patchVars`) and updates all references accordingly (e.g., `talos_common.*`, cluster endpoint fallback, CSI path substitution).
> 
> Adjusts local-dev/workstation behavior: Docker Desktop DNS forwarding now targets NodePort `30053`, `gitops/flux` in the workstation facet only runs when the cluster is enabled, provider-docker no longer runs gitops when workstation is disabled, and several conditionals now fall back to `vm.driver` when `workstation.runtime` is unset. Template tests are updated to include required defaults (`network.cidr_block`, `cluster.driver`) and to reflect the Docker Desktop ingress/nodeport and terraform-chain expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 768f26b5c5336f9a50c837c770f708a50612b9b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->