### PR TITLE
Fix(schema): Add workstation.address to schema

### DIFF
--- a/contexts/_template/schema.yaml
+++ b/contexts/_template/schema.yaml
@@ -432,6 +432,9 @@ properties:
         type: boolean
         default: false
         description: Enable workstation stack (DNS, registries, git livereload)
+      address:
+        type: string
+        description: Address of the workstation, used for SSH to configure workstation networking
       runtime:
         type: string
         enum:


### PR DESCRIPTION
Fixes `Error: error starting workstation: error running virtual machine Up command: failed to set VM address in config handler: context value validation failed: [additional property not allowed: workstation.address]`