### PR TITLE
feat(workstation): Add support for incus workstation

### DIFF
--- a/contexts/_template/facets/config-talos.yaml
+++ b/contexts/_template/facets/config-talos.yaml
@@ -30,5 +30,3 @@ config:
     value:
       # renovate: datasource=github-releases depName=talos package=siderolabs/talos
       talos_version: "1.12.1"
-      docker_image: "ghcr.io/siderolabs/talos:v${talos.talos_version ?? '1.12.1'}"
-      incus_image: "${(workstation.enabled ?? false) ? 'windsor:talos/v' + (talos.talos_version ?? '1.12.1') + '/arm64' : 'windsor:talos/v' + (talos.talos_version ?? '1.12.1') + '/amd64'}"

--- a/contexts/_template/facets/config-talos.yaml
+++ b/contexts/_template/facets/config-talos.yaml
@@ -28,7 +28,8 @@ config:
 
   - name: talos
     value:
-      # renovate: datasource=docker depName=ghcr.io/siderolabs/talos package=ghcr.io/siderolabs/talos
-      image: ghcr.io/siderolabs/talos:v1.12.1
       # renovate: datasource=github-releases depName=talos package=siderolabs/talos
       talos_version: "1.12.1"
+      incus_image_arm: "windsor:talos/v${talos.talos_version}/arm64"
+      incus_image_amd: "windsor:talos/v${talos.talos_version}/amd64"
+      image: "${platform == 'docker' ? 'ghcr.io/siderolabs/talos:v' + talos.talos_version : (workstation.enabled ? talos.incus_image_arm : talos.incus_image_amd)}"

--- a/contexts/_template/facets/config-talos.yaml
+++ b/contexts/_template/facets/config-talos.yaml
@@ -30,6 +30,5 @@ config:
     value:
       # renovate: datasource=github-releases depName=talos package=siderolabs/talos
       talos_version: "1.12.1"
-      incus_image_arm: "windsor:talos/v${talos.talos_version}/arm64"
-      incus_image_amd: "windsor:talos/v${talos.talos_version}/amd64"
-      image: "${platform == 'docker' ? 'ghcr.io/siderolabs/talos:v' + talos.talos_version : (workstation.enabled ? talos.incus_image_arm : talos.incus_image_amd)}"
+      docker_image: "ghcr.io/siderolabs/talos:v${talos.talos_version ?? '1.12.1'}"
+      incus_image: "${(workstation.enabled ?? false) ? 'windsor:talos/v' + (talos.talos_version ?? '1.12.1') + '/arm64' : 'windsor:talos/v' + (talos.talos_version ?? '1.12.1') + '/amd64'}"

--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -129,6 +129,105 @@ terraform:
     enable_git: ${workstation.services.git ?? true}
     registries: ${workstation_registries.registries ?? {}}
 
+
+- name: workstation
+  when: "platform == 'incus'"
+  path: workstation/incus
+  inputs:
+    domain_name: ${dns.domain}
+    network_name: "${(workstation.runtime ?? '') == 'colima' ? 'incusbr0' : ''}"
+    create_network: "${(workstation.runtime ?? '') != 'colima'}"
+    network_cidr: ${network.cidr_block}
+    loadbalancer_start_ip: ${network.loadbalancer_ips.start}
+    dns_forward_target: ${network.loadbalancer_ips.start}
+    webhook_host: ${network.loadbalancer_ips.start}
+    primary_node_ip: ${network.loadbalancer_ips.start}
+    enable_dns: ${workstation.services.dns ?? true}
+    enable_git: ${workstation.services.git ?? true}
+    registries: ${workstation_registries.registries ?? {}}
+    webhook_token: ${git.livereload.webhook_token ?? "abcdef123456"}
+    git_username: ${git.livereload.username ?? "local"}
+    git_password: ${git.livereload.password ?? "local"}
+
+# Compute/incus: run after workstation (DNS, git, registries). Same pattern as compute/docker.
+- name: compute
+  when: "platform == 'incus' && (cluster.enabled ?? true)"
+  path: compute/incus
+  dependsOn:
+    - workstation
+  inputs:
+    network_name: "${(workstation.runtime ?? '') == 'colima' ? 'incusbr0' : ''}"
+    create_network: "${(workstation.runtime ?? '') != 'colima'}"
+    network_cidr: ${network.cidr_block}
+    storage_pools:
+      local:
+        driver: "${(workstation.runtime ?? '') == 'colima' ? 'dir' : null}"
+    instances:
+      - name: controlplane
+        role: controlplane
+        count: ${cluster.controlplanes.count ?? 1}
+        ipv4: ${cidrhost(network.cidr_block, 10)}
+        image: ${cluster.controlplanes.image ?? talos.image}
+        type: virtual-machine
+        description: Talos control plane node
+        storage_pool: "${(workstation.runtime ?? '') == 'colima' ? 'local' : 'default'}"
+        root_disk_size: ${string(cluster.controlplanes.root_disk_size ?? 30) + "GB"}
+        limits:
+          cpu: ${string(cluster.controlplanes.cpu ?? 2)}
+          memory: ${string(cluster.controlplanes.memory ?? 2) + "GB"}
+        disks: ${cluster.controlplanes.disks ?? []}
+        config:
+          user.hostname: ${values(cluster.controlplanes.nodes)[0].hostname ?? "controlplane-1"}
+          environment.TALOSSKU: ${string(cluster.controlplanes.cpu ?? 2) + "CPU-" + string((cluster.controlplanes.memory ?? 2) * 1024) + "RAM"}
+          raw.qemu: -boot order=c,menu=off
+      - name: worker
+        role: worker
+        count: ${cluster.workers.count ?? 0}
+        ipv4: ${cidrhost(network.cidr_block, 20)}
+        image: ${cluster.workers.image ?? talos.image}
+        type: virtual-machine
+        description: Talos worker node
+        storage_pool: "${(workstation.runtime ?? '') == 'colima' ? 'local' : 'default'}"
+        root_disk_size: ${string(cluster.workers.root_disk_size ?? 50) + "GB"}
+        limits:
+          cpu: ${string(cluster.workers.cpu ?? 4)}
+          memory: ${string(cluster.workers.memory ?? 4) + "GB"}
+        disks: ${cluster.workers.disks ?? []}
+        config:
+          user.hostname: "${cluster.workers.nodes != null ? (values(cluster.workers.nodes)[0].hostname ?? 'worker-1') : 'worker-1'}"
+          environment.TALOSSKU: "${string(cluster.workers.cpu ?? 4) + 'CPU-' + string((cluster.workers.memory ?? 4) * 1024) + 'RAM'}"
+          raw.qemu: -boot order=c,menu=off
+
+# cluster/talos for incus: strip hostname from compute output (Incus sets it via user.hostname; Talos 1.12 rejects "static hostname is already set").
+- name: cluster
+  when: "platform == 'incus' && (cluster.enabled ?? true)"
+  path: cluster/talos
+  dependsOn:
+    - compute
+  parallelism: 1
+  inputs:
+    cluster_endpoint: >-
+      ${cluster.endpoint ?? (
+        len(terraform_output("compute", "controlplanes") ?? []) > 0 && terraform_output("compute", "controlplanes")[0].endpoint != null
+          ? "https://" + split(terraform_output("compute", "controlplanes")[0].endpoint, ":")[0] + ":6443"
+          : "https://" + cidrhost(network.cidr_block, 10) + ":6443"
+      )}
+    cluster_name: talos
+    talos_version: ${talos.talos_version}
+    controlplanes: >-
+      ${len(terraform_output("compute", "controlplanes") ?? []) > 0
+        ? map(terraform_output("compute", "controlplanes"), fromPairs(concat(filter(toPairs(#), get(#, 0) != "hostname"), [["hostname", null]])))
+        : values(cluster.controlplanes.nodes)}
+    workers: >-
+      ${len(terraform_output("compute", "controlplanes") ?? []) > 0
+        ? map(terraform_output("compute", "workers") ?? [], fromPairs(concat(filter(toPairs(#), get(#, 0) != "hostname"), [["hostname", null]])))
+        : ((cluster.workers.count ?? 0) > 0 ? values(cluster.workers.nodes) : [])}
+    controlplane_disks: ${talos_common.controlplane_disks}
+    worker_disks: ${talos_common.worker_disks}
+    common_config_patches: ${talos_common.common_config_patches}
+    controlplane_volumes: ${talos_common.controlplane_volumes ?? []}
+    worker_volumes: ${talos_common.worker_volumes ?? []}
+
 # Compute/docker: run Talos controlplane/worker containers on workstation network.
 # cluster/talos consumes compute outputs (endpoints, etc.) via provider-docker.
 - name: compute

--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -209,7 +209,7 @@ terraform:
       ${cluster.endpoint ?? (
         len(terraform_output("compute", "controlplanes") ?? []) > 0 && terraform_output("compute", "controlplanes")[0].endpoint != null
           ? "https://" + split(terraform_output("compute", "controlplanes")[0].endpoint, ":")[0] + ":6443"
-          : "https://" + cidrhost(network.cidr_block, 10) + ":6443"
+          : ""
       )}
     cluster_name: talos
     talos_version: ${talos.talos_version}

--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -11,6 +11,13 @@ config:
   - name: workstation
     value:
       runtime: "${workstation.runtime ?? vm.driver ?? \"colima\"}"
+      arch: "${workstation.arch ?? 'amd64'}"
+
+  # Talos image refs for workstation compute (docker/incus). Only relevant when workstation stack runs; providers use talos_version fallback when not.
+  - name: talos
+    value:
+      docker_image: "ghcr.io/siderolabs/talos:v${talos.talos_version}"
+      incus_image: "windsor:talos/v${talos.talos_version}/${workstation.arch ?? 'amd64'}"
 
   # Effective registries for workstation Terraform and Talos patch: empty when services.registries false, else docker.registries or default.
   - name: workstation_registries

--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -149,16 +149,15 @@ terraform:
     git_username: ${git.livereload.username ?? "local"}
     git_password: ${git.livereload.password ?? "local"}
 
-# Compute/incus: run after workstation (DNS, git, registries). Same pattern as compute/docker.
 - name: compute
   when: "platform == 'incus' && (cluster.enabled ?? true)"
   path: compute/incus
   dependsOn:
     - workstation
   inputs:
-    network_name: "${(workstation.runtime ?? '') == 'colima' ? 'incusbr0' : ''}"
-    create_network: "${(workstation.runtime ?? '') != 'colima'}"
-    network_cidr: ${network.cidr_block}
+    create_network: false
+    network_name: ${terraform_output("workstation", "network_name")}
+    network_cidr: ${terraform_output("workstation", "network_cidr")}
     storage_pools:
       local:
         driver: "${(workstation.runtime ?? '') == 'colima' ? 'dir' : null}"

--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -167,7 +167,7 @@ terraform:
         role: controlplane
         count: ${cluster.controlplanes.count ?? 1}
         ipv4: ${cidrhost(network.cidr_block, 10)}
-        image: ${cluster.controlplanes.image ?? talos.image}
+        image: ${cluster.controlplanes.image ?? talos.incus_image}
         type: virtual-machine
         description: Talos control plane node
         storage_pool: "${(workstation.runtime ?? '') == 'colima' ? 'local' : 'default'}"
@@ -184,7 +184,7 @@ terraform:
         role: worker
         count: ${cluster.workers.count ?? 0}
         ipv4: ${cidrhost(network.cidr_block, 20)}
-        image: ${cluster.workers.image ?? talos.image}
+        image: ${cluster.workers.image ?? talos.incus_image}
         type: virtual-machine
         description: Talos worker node
         storage_pool: "${(workstation.runtime ?? '') == 'colima' ? 'local' : 'default'}"
@@ -245,14 +245,14 @@ terraform:
     cluster_nodes:
       controlplanes:
         count: ${cluster.controlplanes.count ?? 1}
-        image: ${cluster.controlplanes.image ?? talos.image}
+        image: ${cluster.controlplanes.image ?? talos.docker_image}
         cpu: ${cluster.controlplanes.cpu ?? 2}
         memory: ${cluster.controlplanes.memory ?? 2}
         hostports: "${workstation.runtime == \"docker-desktop\" ? (cluster.controlplanes.hostports ?? []) : []}"
         volumes: ${cluster.controlplanes.volumes ?? []}
       workers:
         count: ${cluster.workers.count ?? 0}
-        image: ${cluster.workers.image ?? talos.image}
+        image: ${cluster.workers.image ?? talos.docker_image}
         cpu: ${cluster.workers.cpu ?? 4}
         memory: ${cluster.workers.memory ?? 4}
         hostports: "${workstation.runtime == \"docker-desktop\" ? (cluster.workers.hostports ?? []) : []}"

--- a/contexts/_template/facets/provider-incus.yaml
+++ b/contexts/_template/facets/provider-incus.yaml
@@ -14,12 +14,13 @@ config:
         len(terraform_output("compute", "controlplanes") ?? []) > 0
         && terraform_output("compute", "controlplanes")[0].endpoint != null
           ? "https://" + split(terraform_output("compute", "controlplanes")[0].endpoint, ":")[0] + ":6443"
-          : "https://localhost:6443"
+          : ""
       }
 
 terraform:
 
 - name: compute
+  when: "(workstation.enabled != true)"
   path: compute/incus
   inputs:
     network_name: "${(workstation.runtime ?? '') == 'colima' ? 'incusbr0' : ''}"
@@ -33,7 +34,7 @@ terraform:
         role: controlplane
         count: ${cluster.controlplanes.count ?? 1}
         ipv4: ${cidrhost(network.cidr_block, 10)}
-        image: windsor:talos/v1.12.1/arm64
+        image: ${cluster.controlplanes.image ?? talos.image}
         type: virtual-machine
         description: Talos control plane node
         storage_pool: "${(workstation.runtime ?? '') == 'colima' ? 'local' : 'default'}"
@@ -50,7 +51,7 @@ terraform:
         role: worker
         count: ${cluster.workers.count ?? 0}
         ipv4: ${cidrhost(network.cidr_block, 20)}
-        image: windsor:talos/v1.12.1/arm64
+        image: ${cluster.workers.image ?? talos.image}
         type: virtual-machine
         description: Talos worker node
         storage_pool: "${(workstation.runtime ?? '') == 'colima' ? 'local' : 'default'}"
@@ -65,6 +66,7 @@ terraform:
           raw.qemu: -boot order=c,menu=off
 
 - name: cluster
+  when: "(workstation.enabled != true)"
   path: cluster/talos
   dependsOn:
   - compute

--- a/contexts/_template/facets/provider-incus.yaml
+++ b/contexts/_template/facets/provider-incus.yaml
@@ -34,7 +34,7 @@ terraform:
         role: controlplane
         count: ${cluster.controlplanes.count ?? 1}
         ipv4: ${cidrhost(network.cidr_block, 10)}
-        image: ${cluster.controlplanes.image ?? talos.incus_image}
+        image: ${cluster.controlplanes.image ?? ("windsor:talos/v" + talos.talos_version + "/amd64")}
         type: virtual-machine
         description: Talos control plane node
         storage_pool: "${(workstation.runtime ?? '') == 'colima' ? 'local' : 'default'}"
@@ -51,7 +51,7 @@ terraform:
         role: worker
         count: ${cluster.workers.count ?? 0}
         ipv4: ${cidrhost(network.cidr_block, 20)}
-        image: ${cluster.workers.image ?? talos.incus_image}
+        image: ${cluster.workers.image ?? ("windsor:talos/v" + talos.talos_version + "/amd64")}
         type: virtual-machine
         description: Talos worker node
         storage_pool: "${(workstation.runtime ?? '') == 'colima' ? 'local' : 'default'}"

--- a/contexts/_template/facets/provider-incus.yaml
+++ b/contexts/_template/facets/provider-incus.yaml
@@ -34,7 +34,7 @@ terraform:
         role: controlplane
         count: ${cluster.controlplanes.count ?? 1}
         ipv4: ${cidrhost(network.cidr_block, 10)}
-        image: ${cluster.controlplanes.image ?? talos.image}
+        image: ${cluster.controlplanes.image ?? talos.incus_image}
         type: virtual-machine
         description: Talos control plane node
         storage_pool: "${(workstation.runtime ?? '') == 'colima' ? 'local' : 'default'}"
@@ -51,7 +51,7 @@ terraform:
         role: worker
         count: ${cluster.workers.count ?? 0}
         ipv4: ${cidrhost(network.cidr_block, 20)}
-        image: ${cluster.workers.image ?? talos.image}
+        image: ${cluster.workers.image ?? talos.incus_image}
         type: virtual-machine
         description: Talos worker node
         storage_pool: "${(workstation.runtime ?? '') == 'colima' ? 'local' : 'default'}"

--- a/contexts/_template/schema.yaml
+++ b/contexts/_template/schema.yaml
@@ -432,6 +432,13 @@ properties:
         type: boolean
         default: false
         description: Enable workstation stack (DNS, registries, git livereload)
+      arch:
+        type: string
+        enum:
+          - amd64
+          - arm64
+        default: amd64
+        description: CPU architecture for Incus Talos images (host arch when workstation enabled; target arch for server deployments). Used by talos.incus_image.
       address:
         type: string
         description: Address of the workstation, used for SSH to configure workstation networking

--- a/contexts/_template/tests/option-workstation.test.yaml
+++ b/contexts/_template/tests/option-workstation.test.yaml
@@ -172,6 +172,57 @@ cases:
           path: gitops/flux
           destroy: false
 
+  # Incus with workstation enabled: option-workstation contributes workstation/incus, compute/incus, cluster/talos
+  - name: incus with workstation enabled creates workstation/incus compute cluster chain
+    values:
+      provider: incus
+      workstation:
+        enabled: true
+      vm:
+        driver: colima
+      dns: *default-dns
+      ingress: *ingress-disabled
+      network: *default-network
+      cluster:
+        driver: talos
+        controlplanes:
+          nodes:
+            controlplane-1:
+              endpoint: 10.5.0.10:50000
+              node: 10.5.0.10
+              hostname: controlplane-1
+        workers:
+          count: 1
+          volumes:
+            - /var/mnt/local
+          nodes:
+            worker-1:
+              endpoint: 10.5.0.20:50000
+              node: 10.5.0.20
+              hostname: worker-1
+    terraformOutputs:
+      compute:
+        controlplanes:
+          - endpoint: 10.5.0.10:6443
+            node: 10.5.0.10
+            hostname: controlplane-1
+        workers:
+          - endpoint: 10.5.0.20:50000
+            node: 10.5.0.20
+            hostname: worker-1
+    expect:
+      terraform:
+        - name: workstation
+          path: workstation/incus
+        - name: compute
+          path: compute/incus
+          dependsOn:
+            - workstation
+        - name: cluster
+          path: cluster/talos
+          dependsOn:
+            - compute
+
   # Edge: vm.driver docker-desktop — no lb kustomize components
   - name: docker-desktop workstation has node hostport dns and no lb
     values:

--- a/terraform/cluster/talos/main.tf
+++ b/terraform/cluster/talos/main.tf
@@ -21,6 +21,13 @@ terraform {
 # so controlplane container and its volumes are removed, then windsor up (fresh node + fresh secrets).
 resource "talos_machine_secrets" "this" {
   talos_version = "v${var.talos_version}"
+
+  lifecycle {
+    precondition {
+      condition     = local.cluster_endpoint != "" && can(regex("^https://", local.cluster_endpoint))
+      error_message = "cluster_endpoint could not be derived: set cluster.endpoint or ensure compute is applied so controlplanes have endpoints."
+    }
+  }
 }
 
 #-----------------------------------------------------------------------------------------------------------------------
@@ -31,6 +38,8 @@ locals {
   talosconfig      = data.talos_client_configuration.this.talos_config
   talosconfig_path = "${var.context_path}/.talos/config"
   kubeconfig_path  = "${var.context_path}/.kube/config"
+
+  cluster_endpoint = var.cluster_endpoint != "" ? var.cluster_endpoint : (length(var.controlplanes) > 0 ? "https://${split(":", var.controlplanes[0].endpoint)[0]}:6443" : "")
 
   # extraMounts from raw volume strings (path or host:dest; path = part after ":" if present).
   # yamlencode() produces quoted keys (Terraform/Go); common_config_patches from blueprint is unquoted YAML. Both valid.
@@ -58,7 +67,7 @@ module "controlplane_bootstrap" {
   wipe_disk            = lookup(var.controlplanes[0], "wipe_disk", true)
   extra_kernel_args    = lookup(var.controlplanes[0], "extra_kernel_args", [])
   cluster_name         = var.cluster_name
-  cluster_endpoint     = var.cluster_endpoint
+  cluster_endpoint     = local.cluster_endpoint
   kubernetes_version   = var.kubernetes_version
   talos_version        = var.talos_version
   machine_type         = "controlplane"
@@ -88,7 +97,7 @@ module "controlplanes" {
   wipe_disk            = lookup(var.controlplanes[count.index + 1], "wipe_disk", true)
   extra_kernel_args    = lookup(var.controlplanes[count.index + 1], "extra_kernel_args", [])
   cluster_name         = var.cluster_name
-  cluster_endpoint     = var.cluster_endpoint
+  cluster_endpoint     = local.cluster_endpoint
   kubernetes_version   = var.kubernetes_version
   talos_version        = var.talos_version
   machine_type         = "controlplane"
@@ -122,7 +131,7 @@ module "workers" {
   wipe_disk            = lookup(var.workers[count.index], "wipe_disk", true)
   extra_kernel_args    = lookup(var.workers[count.index], "extra_kernel_args", [])
   cluster_name         = var.cluster_name
-  cluster_endpoint     = var.cluster_endpoint
+  cluster_endpoint     = local.cluster_endpoint
   kubernetes_version   = var.kubernetes_version
   talos_version        = var.talos_version
   machine_type         = "worker"

--- a/terraform/cluster/talos/modules/machine/main.tf
+++ b/terraform/cluster/talos/modules/machine/main.tf
@@ -96,10 +96,6 @@ resource "local_sensitive_file" "kubeconfig" {
   content         = talos_cluster_kubeconfig.this[0].kubeconfig_raw
   filename        = var.kubeconfig_path
   file_permission = "0600" // Set file permissions to read/write for owner only
-
-  lifecycle {
-    ignore_changes = [content] // Ignore changes to content to prevent unnecessary updates
-  }
 }
 
 #-----------------------------------------------------------------------------------------------------------------------

--- a/terraform/cluster/talos/variables.tf
+++ b/terraform/cluster/talos/variables.tf
@@ -37,12 +37,12 @@ variable "cluster_name" {
 }
 
 variable "cluster_endpoint" {
-  description = "The external controlplane API endpoint of the kubernetes API."
+  description = "The external controlplane API endpoint (https://host:6443). If empty, derived from first controlplane's endpoint (Talos host:port → https://host:6443)."
   type        = string
   default     = "https://localhost:6443"
   validation {
-    condition     = can(regex("^https://", var.cluster_endpoint))
-    error_message = "The external controlplane API endpoint must start with 'https://'."
+    condition     = var.cluster_endpoint == "" || can(regex("^https://", var.cluster_endpoint))
+    error_message = "cluster_endpoint must be empty or start with 'https://'."
   }
 }
 

--- a/terraform/workstation/docker/.terraform.lock.hcl
+++ b/terraform/workstation/docker/.terraform.lock.hcl
@@ -6,6 +6,8 @@ provider "registry.terraform.io/kreuzwerker/docker" {
   constraints = "3.6.2"
   hashes = [
     "h1:/Oe7tViXf/xyQ4Pg8cDifMlD3RthOYkslwQiRgx7BTE=",
+    "h1:1K3j0xUY2D0+E+DBDQc6k1u6Al9MkuNWrIC9rnvwFSM=",
+    "h1:HtO3oxIOR3aAqAMZMRc9T2cOY0vtRSFlk0Wnf4CryeA=",
     "zh:22b51a8fb63481d290bdad9a221bc8c9e45d66d1a0cd45beed3f3627bf1debd8",
     "zh:2b902eb80a1ae033af1135cc165d192668820a7f8ea15beb5472f811c18bea1f",
     "zh:57815dcea28aedb86ed33924cd186aaee8bd31670bd78437a2a2daf2b00ce2ae",

--- a/terraform/workstation/docker/main.tf
+++ b/terraform/workstation/docker/main.tf
@@ -117,7 +117,8 @@ resource "docker_image" "coredns" {
 
 resource "docker_image" "git_livereload" {
   count = var.enable_git ? 1 : 0
-  name  = "ghcr.io/windsorcli/git-livereload:v0.2.1"
+  # renovate: datasource=github-releases depName=windsorcli/git-livereload
+  name = "ghcr.io/windsorcli/git-livereload:v0.2.1"
 }
 
 # =============================================================================

--- a/terraform/workstation/incus/.terraform.lock.hcl
+++ b/terraform/workstation/incus/.terraform.lock.hcl
@@ -1,0 +1,43 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.7.0"
+  constraints = "~> 2.5"
+  hashes = [
+    "h1:sSwlfp2etjCaE9hIF7bJBDjRIhDCVFglEOVyiCI7vgs=",
+    "zh:261fec71bca13e0a7812dc0d8ae9af2b4326b24d9b2e9beab3d2400fab5c5f9a",
+    "zh:308da3b5376a9ede815042deec5af1050ec96a5a5410a2206ae847d82070a23e",
+    "zh:3d056924c420464dc8aba10e1915956b2e5c4d55b11ffff79aa8be563fbfe298",
+    "zh:643256547b155459c45e0a3e8aab0570db59923c68daf2086be63c444c8c445b",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7aa4d0b853f84205e8cf79f30c9b2c562afbfa63592f7231b6637e5d7a6b5b27",
+    "zh:7dc251bbc487d58a6ab7f5b07ec9edc630edb45d89b761dba28e0e2ba6b1c11f",
+    "zh:7ee0ca546cd065030039168d780a15cbbf1765a4c70cd56d394734ab112c93da",
+    "zh:b1d5d80abb1906e6c6b3685a52a0192b4ca6525fe090881c64ec6f67794b1300",
+    "zh:d81ea9856d61db3148a4fc6c375bf387a721d78fc1fea7a8823a027272a47a78",
+    "zh:df0a1f0afc947b8bfc88617c1ad07a689ce3bd1a29fd97318392e6bdd32b230b",
+    "zh:dfbcad800240e0c68c43e0866f2a751cff09777375ec701918881acf67a268da",
+  ]
+}
+
+provider "registry.terraform.io/lxc/incus" {
+  version     = "1.0.2"
+  constraints = "~> 1.0.2"
+  hashes = [
+    "h1:kC+CG07f6XtyPT4Gm2e4KITX2Nr+EiXbtB9e5NJddII=",
+    "zh:0f312afd0bc27c111c5b4e41b6274dfe4401c3b5c60e4bd519425c547c5c2316",
+    "zh:396587c30adce1b57400ecf1a43df8d4fcbdf5172e3e359f58f7147520891546",
+    "zh:40310405f58493af0e68b1040d62286cd5e6d25b96b5e2d1534d155a98375eba",
+    "zh:4991adf7f290ffc840a1123b300163b8db25a6c4b096648c7b576a6661980ed5",
+    "zh:5d71a5c949a5ad01d075f856475e7de95df16b50d52e546a2257e5c56bfa9150",
+    "zh:60e5fde27aa605abab8487d6ed8a8bb66de88f5e1ba31bb05364b4379fde5f83",
+    "zh:63f9b65382bcb88efd0d9aa8422987405fcf00d4f5b63fbe1ae030438fb55eb7",
+    "zh:79acebe8ed9627dffc369058e54bbb933b5568fee02de3cc353274d728c07597",
+    "zh:97170106b7520d7c025ccfe392a0b7c2d172e63f00f656989b08d0b6ece56573",
+    "zh:9c8fc5d4b26dc21e6d75d6ac127502a797d7e9253bd10b236914db51fa1fc4d7",
+    "zh:b2b8cabdfa681efffa3599468257b185f7a7e24ec6e624e57f75920aa1e7c134",
+    "zh:d32129503b83790752482e0d794ffb9b04f7a893cc113d834654a8ddb028402f",
+    "zh:ebd2fb8d94d72bc28c5655c29c6e6048cc31ef3650d0e166aaf3d82a31673cd5",
+  ]
+}

--- a/terraform/workstation/incus/.terraform.lock.hcl
+++ b/terraform/workstation/incus/.terraform.lock.hcl
@@ -3,8 +3,10 @@
 
 provider "registry.terraform.io/hashicorp/local" {
   version     = "2.7.0"
-  constraints = "~> 2.5"
+  constraints = "2.7.0"
   hashes = [
+    "h1:2RYa3j7m/0WmET2fqotY4CHxE1Hpk0fgn47/126l+Og=",
+    "h1:SY06ZmR7rY7QMGoVEkeFrERVitBp2GKl/ATz9tbjXlk=",
     "h1:sSwlfp2etjCaE9hIF7bJBDjRIhDCVFglEOVyiCI7vgs=",
     "zh:261fec71bca13e0a7812dc0d8ae9af2b4326b24d9b2e9beab3d2400fab5c5f9a",
     "zh:308da3b5376a9ede815042deec5af1050ec96a5a5410a2206ae847d82070a23e",
@@ -23,9 +25,11 @@ provider "registry.terraform.io/hashicorp/local" {
 
 provider "registry.terraform.io/lxc/incus" {
   version     = "1.0.2"
-  constraints = "~> 1.0.2"
+  constraints = "1.0.2"
   hashes = [
+    "h1:V2mCllVU6/8rgb5O/7Far5D8JH0vv2/J5Kg9XykCpnI=",
     "h1:kC+CG07f6XtyPT4Gm2e4KITX2Nr+EiXbtB9e5NJddII=",
+    "h1:skSyqJPnvwhbfSrmVVY05I/js7qvX8T8Cd182tnTetc=",
     "zh:0f312afd0bc27c111c5b4e41b6274dfe4401c3b5c60e4bd519425c547c5c2316",
     "zh:396587c30adce1b57400ecf1a43df8d4fcbdf5172e3e359f58f7147520891546",
     "zh:40310405f58493af0e68b1040d62286cd5e6d25b96b5e2d1534d155a98375eba",

--- a/terraform/workstation/incus/main.tf
+++ b/terraform/workstation/incus/main.tf
@@ -149,7 +149,7 @@ resource "incus_instance" "dns" {
     }
   }
 
-  depends_on = [local_file.corefile]
+  depends_on = [incus_network.main, local_file.corefile]
 
   lifecycle {
     replace_triggered_by = [local_file.corefile]
@@ -180,7 +180,7 @@ resource "incus_instance" "registry" {
   type     = "container"
   # renovate: datasource=docker depName=library/registry package=library/registry
   image      = "docker:library/registry:3.0.0"
-  depends_on = [terraform_data.registry_cache_dirs]
+  depends_on = [incus_network.main, terraform_data.registry_cache_dirs]
   config = each.value.remote != null ? {
     "environment.REGISTRY_PROXY_REMOTEURL" = each.value.remote
   } : {}
@@ -209,9 +209,10 @@ resource "incus_instance" "registry" {
 # =============================================================================
 
 resource "incus_instance" "git" {
-  count = var.enable_git ? 1 : 0
-  name  = replace("git.${local.domain_name}", ".", "-")
-  type  = "container"
+  count      = var.enable_git ? 1 : 0
+  depends_on = [incus_network.main]
+  name       = replace("git.${local.domain_name}", ".", "-")
+  type       = "container"
   # renovate: datasource=github-releases depName=windsorcli/git-livereload
   image = "ghcr:windsorcli/git-livereload:v0.2.1"
   config = {

--- a/terraform/workstation/incus/main.tf
+++ b/terraform/workstation/incus/main.tf
@@ -20,6 +20,21 @@ terraform {
   }
 }
 
+provider "incus" {
+  remote {
+    name     = "docker"
+    address  = "https://registry-1.docker.io/v2"
+    protocol = "oci"
+    public   = true
+  }
+  remote {
+    name     = "ghcr"
+    address  = "https://ghcr.io"
+    protocol = "oci"
+    public   = true
+  }
+}
+
 # =============================================================================
 # Locals
 # =============================================================================

--- a/terraform/workstation/incus/main.tf
+++ b/terraform/workstation/incus/main.tf
@@ -45,9 +45,8 @@ locals {
   domain_name           = coalesce(var.domain_name, var.context)
   network_name_resolved = coalesce(var.network_name, "windsor-${var.context}")
   compose_project       = "workstation-windsor-${var.context}"
-  # Incus: bridge networking only; no localhost/port-publish mode like docker-desktop
+  # Incus: bridge networking only; no localhost/port-publish mode like docker-desktop (docker uses loadbalancer_cidr for that)
   loadbalancer_start_ip = coalesce(var.loadbalancer_start_ip, cidrhost(cidrsubnet(var.network_cidr, 8, 1), 1))
-  loadbalancer_cidr     = "${join(".", concat(slice(split(".", local.loadbalancer_start_ip), 0, 3), ["0"]))}/24"
   webhook_host_derived  = local.loadbalancer_start_ip
   webhook_host          = coalesce(var.webhook_host, var.primary_node_ip, local.webhook_host_derived)
   webhook_url           = "http://${local.webhook_host}:9292/hook/${var.webhook_token}"

--- a/terraform/workstation/incus/main.tf
+++ b/terraform/workstation/incus/main.tf
@@ -1,0 +1,225 @@
+# The Incus Workstation module creates Windsor local-development containers using the Incus provider.
+# It optionally creates a bridge network (create_network=true) or uses an existing one (e.g. incusbr0 when runtime is colima).
+# Same IP layout as workstation/docker: 1=gateway, 2=dns, 3=git, 4+=registries. Use compute/incus when cluster is enabled.
+
+# =============================================================================
+# Provider Configuration
+# =============================================================================
+
+terraform {
+  required_version = ">=1.8"
+  required_providers {
+    incus = {
+      source  = "lxc/incus"
+      version = "1.0.2"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "2.7.0"
+    }
+  }
+}
+
+# =============================================================================
+# Locals
+# =============================================================================
+
+locals {
+  domain_name           = coalesce(var.domain_name, var.context)
+  network_name_resolved = coalesce(var.network_name, "windsor-${var.context}")
+  compose_project       = "workstation-windsor-${var.context}"
+  # Incus: bridge networking only; no localhost/port-publish mode like docker-desktop
+  loadbalancer_start_ip = coalesce(var.loadbalancer_start_ip, cidrhost(cidrsubnet(var.network_cidr, 8, 1), 1))
+  loadbalancer_cidr     = "${join(".", concat(slice(split(".", local.loadbalancer_start_ip), 0, 3), ["0"]))}/24"
+  webhook_host_derived  = local.loadbalancer_start_ip
+  webhook_host          = coalesce(var.webhook_host, var.primary_node_ip, local.webhook_host_derived)
+  webhook_url           = "http://${local.webhook_host}:9292/hook/${var.webhook_token}"
+  gateway               = cidrhost(var.network_cidr, 1)
+  dns_ip                = cidrhost(var.network_cidr, 2)
+  attached_network      = var.create_network ? local.network_name_resolved : var.network_name
+  git_ip                = cidrhost(var.network_cidr, 3)
+  registry_keys_sorted  = sort(keys(var.registries))
+  registry_ips = {
+    for i, k in local.registry_keys_sorted : k => cidrhost(var.network_cidr, 4 + i)
+  }
+  # Strip trailing TLD from registry key so hostname is registry.k8s.test not registry.k8s.io.test
+  registry_hostname_tlds = toset(["io", "com", "test", "dev", "org", "net"])
+  registry_hostname_base = {
+    for k in local.registry_keys_sorted : k => (
+      length(split(".", k)) > 1 && contains(local.registry_hostname_tlds, element(split(".", k), length(split(".", k)) - 1))
+      ? join(".", slice(split(".", k), 0, length(split(".", k)) - 1))
+      : k
+    )
+  }
+  registry_hostname = { for k in local.registry_keys_sorted : k => "${local.registry_hostname_base[k]}.${local.domain_name}" }
+  service_ips = merge(
+    { dns = local.dns_ip, git = local.git_ip },
+    local.registry_ips
+  )
+  dns_forward_target = coalesce(var.dns_forward_target, local.loadbalancer_start_ip)
+  corefile_host_entries = concat(
+    var.enable_dns ? ["${local.dns_ip} dns.${local.domain_name}"] : [],
+    [for k in local.registry_keys_sorted : "${local.registry_ips[k]} ${local.registry_hostname[k]}"],
+    var.enable_git ? ["${local.git_ip} git.${local.domain_name}"] : []
+  )
+  corefile_content = var.enable_dns ? templatefile("${path.module}/templates/Corefile.tpl", {
+    context            = local.domain_name
+    host_entries       = local.corefile_host_entries
+    dns_forward_target = local.dns_forward_target
+  }) : ""
+  corefile_path = var.enable_dns ? "${var.project_root}/.windsor/Corefile" : null
+}
+
+# =============================================================================
+# Network (only when create_network; else use existing e.g. incusbr0 for Colima)
+# =============================================================================
+
+resource "incus_network" "main" {
+  count = var.create_network ? 1 : 0
+
+  name = local.network_name_resolved
+  type = "bridge"
+  config = {
+    "ipv4.address" = "${local.gateway}/${split("/", var.network_cidr)[1]}"
+    "ipv4.dhcp"    = "true"
+    "ipv4.nat"     = "true"
+  }
+}
+
+# =============================================================================
+# Corefile on host (Incus mounts file; no in-container upload)
+# =============================================================================
+
+resource "local_file" "corefile" {
+  count = var.enable_dns ? 1 : 0
+
+  content         = local.corefile_content
+  filename        = local.corefile_path
+  file_permission = "0644"
+}
+
+# =============================================================================
+# Instance: dns
+# =============================================================================
+
+resource "incus_instance" "dns" {
+  count = var.enable_dns ? 1 : 0
+  name  = replace("dns.${local.domain_name}", ".", "-")
+  type  = "container"
+  image = "docker:coredns/coredns:1.14.1"
+  config = {
+    "raw.lxc"        = "lxc.apparmor.profile=unconfined"
+    "oci.entrypoint" = "/coredns -conf /etc/coredns/Corefile"
+  }
+
+  device {
+    name = "eth0"
+    type = "nic"
+    properties = {
+      network        = local.attached_network
+      "ipv4.address" = local.dns_ip
+    }
+  }
+
+  device {
+    name = "corefile"
+    type = "disk"
+    properties = {
+      source   = local.corefile_path
+      path     = "/etc/coredns/Corefile"
+      readonly = "true"
+    }
+  }
+
+  depends_on = [local_file.corefile]
+
+  lifecycle {
+    replace_triggered_by = [local_file.corefile]
+  }
+}
+
+# =============================================================================
+# Registry cache dirs (Incus requires disk source path to exist before create)
+# =============================================================================
+
+resource "terraform_data" "registry_cache_dirs" {
+  for_each = var.registries
+  triggers_replace = {
+    path = "${var.project_root}/.windsor/cache/docker/registries/${each.key}"
+  }
+  provisioner "local-exec" {
+    command = "mkdir -p '${var.project_root}/.windsor/cache/docker/registries/${each.key}'"
+  }
+}
+
+# =============================================================================
+# Instances: registries (from var.registries)
+# =============================================================================
+
+resource "incus_instance" "registry" {
+  for_each   = var.registries
+  name       = replace(local.registry_hostname[each.key], ".", "-")
+  type       = "container"
+  image      = "docker:registry:3.0.0"
+  depends_on = [terraform_data.registry_cache_dirs]
+  config = each.value.remote != null ? {
+    "environment.REGISTRY_PROXY_REMOTEURL" = each.value.remote
+  } : {}
+
+  device {
+    name = "eth0"
+    type = "nic"
+    properties = {
+      network        = local.attached_network
+      "ipv4.address" = local.registry_ips[each.key]
+    }
+  }
+
+  device {
+    name = "docker-cache"
+    type = "disk"
+    properties = {
+      source = "${var.project_root}/.windsor/cache/docker/registries/${each.key}"
+      path   = "/var/lib/registry"
+    }
+  }
+}
+
+# =============================================================================
+# Instance: git
+# =============================================================================
+
+resource "incus_instance" "git" {
+  count = var.enable_git ? 1 : 0
+  name  = replace("git.${local.domain_name}", ".", "-")
+  type  = "container"
+  # renovate: datasource=github-releases depName=windsorcli/git-livereload
+  image = "ghcr:windsorcli/git-livereload:v0.2.1"
+  config = {
+    "environment.GIT_PASSWORD"  = var.git_password
+    "environment.GIT_USERNAME"  = var.git_username
+    "environment.RSYNC_EXCLUDE" = var.git_rsync_exclude
+    "environment.RSYNC_INCLUDE" = var.git_rsync_include
+    "environment.RSYNC_PROTECT" = var.git_rsync_protect
+    "environment.VERIFY_SSL"    = "false"
+    "environment.WEBHOOK_URL"   = local.webhook_url
+  }
+
+  device {
+    name = "eth0"
+    type = "nic"
+    properties = {
+      network        = local.attached_network
+      "ipv4.address" = local.git_ip
+    }
+  }
+
+  device {
+    name = "project-root"
+    type = "disk"
+    properties = {
+      source = var.project_root
+      path   = "/repos/mount/core"
+    }
+  }
+}

--- a/terraform/workstation/incus/main.tf
+++ b/terraform/workstation/incus/main.tf
@@ -20,10 +20,12 @@ terraform {
   }
 }
 
+# OCI remotes for image pulls so docker: and ghcr: refs resolve. If you see "Image not found", ensure the Incus
+# client has these remotes (e.g. incus remote add docker https://docker.io --protocol=oci --public).
 provider "incus" {
   remote {
     name     = "docker"
-    address  = "https://registry-1.docker.io/v2"
+    address  = "https://docker.io"
     protocol = "oci"
     public   = true
   }
@@ -121,6 +123,7 @@ resource "incus_instance" "dns" {
   count = var.enable_dns ? 1 : 0
   name  = replace("dns.${local.domain_name}", ".", "-")
   type  = "container"
+  # renovate: datasource=docker depName=coredns/coredns package=coredns/coredns
   image = "docker:coredns/coredns:1.14.1"
   config = {
     "raw.lxc"        = "lxc.apparmor.profile=unconfined"
@@ -172,10 +175,11 @@ resource "terraform_data" "registry_cache_dirs" {
 # =============================================================================
 
 resource "incus_instance" "registry" {
-  for_each   = var.registries
-  name       = replace(local.registry_hostname[each.key], ".", "-")
-  type       = "container"
-  image      = "docker:registry:3.0.0"
+  for_each = var.registries
+  name     = replace(local.registry_hostname[each.key], ".", "-")
+  type     = "container"
+  # renovate: datasource=docker depName=library/registry package=library/registry
+  image      = "docker:library/registry:3.0.0"
   depends_on = [terraform_data.registry_cache_dirs]
   config = each.value.remote != null ? {
     "environment.REGISTRY_PROXY_REMOTEURL" = each.value.remote

--- a/terraform/workstation/incus/outputs.tf
+++ b/terraform/workstation/incus/outputs.tf
@@ -1,0 +1,63 @@
+# -----------------------------------------------------------------------------
+# Outputs
+# -----------------------------------------------------------------------------
+
+output "network_name" {
+  description = "Name of the Incus network (created or existing when create_network is false)."
+  value       = local.attached_network
+}
+
+output "network_cidr" {
+  description = "CIDR of the Incus network (same as var.network_cidr). Used by compute/incus when attaching to this network."
+  value       = var.network_cidr
+}
+
+output "compose_project" {
+  description = "Compose project name (workstation-windsor-{context}). Kept for API compatibility with workstation/docker; compute/incus does not use it."
+  value       = local.compose_project
+}
+
+output "next_ip" {
+  description = "Next available IP for sequential node assignment (first host after dns=2, git=3, registries=4..). Use as compute/incus start offset when attaching to this network."
+  value       = cidrhost(var.network_cidr, 4 + length(local.registry_keys_sorted))
+}
+
+output "dns_ip" {
+  description = "IPv4 address reserved for the DNS container (cidrhost(network_cidr, 2)). Present in service_ips.dns when enable_dns is true."
+  value       = local.dns_ip
+}
+
+output "domain_name" {
+  description = "Domain name used for DNS zone and hostnames (dns.domain_name, git.domain_name, etc.). Equal to var.domain_name when set, otherwise var.context."
+  value       = local.domain_name
+}
+
+output "corefile_path" {
+  description = "Path to the Corefile on the host (project_root/.windsor/Corefile). Written by Terraform when enable_dns is true."
+  value       = local.corefile_path
+}
+
+output "loadbalancer_start_ip" {
+  description = "First IP in the load balancer range. Derived from network_cidr (first host of next /24) when not set. Webhook host and dns_forward_target are derived from this."
+  value       = local.loadbalancer_start_ip
+}
+
+output "webhook_host" {
+  description = "IP (or host) used for the git livereload webhook URL. Derived from loadbalancer_start_ip when webhook_host and primary_node_ip are not set."
+  value       = local.webhook_host
+}
+
+output "service_ips" {
+  description = "IPv4 addresses from network_cidr (sequential: dns=2, git=3, registries=4+)."
+  value       = local.service_ips
+}
+
+output "containers" {
+  description = "Map of service name to instance name: dns, git (when enabled), and each registry key."
+  value = {
+    for k, v in merge(
+      { dns = try(incus_instance.dns[0].name, null), git = try(incus_instance.git[0].name, null) },
+      { for rk, rv in incus_instance.registry : rk => rv.name }
+    ) : k => v if v != null
+  }
+}

--- a/terraform/workstation/incus/templates/Corefile.tpl
+++ b/terraform/workstation/incus/templates/Corefile.tpl
@@ -1,0 +1,17 @@
+${context}:53 {
+    hosts {
+%{ for entry in host_entries ~}
+        ${entry}
+%{ endfor ~}
+        fallthrough
+    }
+
+    reload
+    loop
+    forward . ${dns_forward_target}
+}
+.:53 {
+    reload
+    loop
+    forward . 1.1.1.1 8.8.8.8
+}

--- a/terraform/workstation/incus/test.tftest.hcl
+++ b/terraform/workstation/incus/test.tftest.hcl
@@ -1,0 +1,239 @@
+# workstation/incus tests: minimal, full, conditional (disabled_services), webhook/loadbalancer derivation.
+mock_provider "incus" {
+  mock_resource "incus_network" {}
+  mock_resource "incus_instance" {}
+}
+
+mock_provider "local" {
+  mock_resource "local_file" {}
+}
+
+# Minimal: required variables only; defaults for network, domain_name. Asserts network name, webhook/loadbalancer derivation, sequential IPs (dns=2, git=3), instance names.
+run "minimal_configuration" {
+  command = plan
+
+  variables {
+    project_root = "/tmp/windsor-test"
+    context      = "test"
+  }
+
+  assert {
+    condition     = incus_network.main[0].name == "windsor-test"
+    error_message = "Network name should be windsor-{context} (windsor-test when context=test)"
+  }
+
+  assert {
+    condition     = local.webhook_host == local.loadbalancer_start_ip
+    error_message = "Incus uses loadbalancer_start_ip for webhook"
+  }
+
+  assert {
+    condition     = local.webhook_host == "10.5.1.1"
+    error_message = "With default network_cidr 10.5.0.0/16, loadbalancer_start_ip is 10.5.1.1"
+  }
+
+  assert {
+    condition     = local.domain_name == "test"
+    error_message = "domain_name should default to context when not set"
+  }
+
+  assert {
+    condition     = local.compose_project == "workstation-windsor-test"
+    error_message = "compose_project is workstation-windsor-{context}"
+  }
+
+  assert {
+    condition     = local.dns_ip == "10.5.0.2"
+    error_message = "Sequential IPs: dns should be host 2 in network_cidr"
+  }
+
+  assert {
+    condition     = local.git_ip == "10.5.0.3"
+    error_message = "Sequential IPs: git should be host 3 in network_cidr"
+  }
+
+  assert {
+    condition     = incus_instance.dns[0].name == "dns-test"
+    error_message = "DNS instance name should use domain_name (dns.test when domain_name defaults to context)"
+  }
+}
+
+# Full: all optional variables set; asserts custom network, domain_name, compose_project, custom registries, sequential IPs.
+run "full_configuration" {
+  command = plan
+
+  variables {
+    project_root = "/home/user/repo"
+    context      = "dev"
+    domain_name  = "local.dev"
+    network_name = "windsor-dev"
+    network_cidr = "10.20.0.0/16"
+    enable_dns   = true
+    enable_git   = true
+    registries = {
+      gcr  = { remote = "https://gcr.io" }
+      ghcr = { remote = "https://ghcr.io" }
+    }
+  }
+
+  assert {
+    condition     = incus_network.main[0].name == "windsor-dev"
+    error_message = "Network name should match variable"
+  }
+
+  assert {
+    condition     = local.domain_name == "local.dev"
+    error_message = "domain_name should override context when set"
+  }
+
+  assert {
+    condition     = local.compose_project == "workstation-windsor-dev"
+    error_message = "compose_project is workstation-windsor-{context}"
+  }
+
+  assert {
+    condition     = local.gateway == "10.20.0.1"
+    error_message = "Gateway should be host 1 in network_cidr"
+  }
+
+  assert {
+    condition     = local.dns_ip == "10.20.0.2" && local.git_ip == "10.20.0.3"
+    error_message = "Sequential IPs: dns=2, git=3"
+  }
+
+  assert {
+    condition     = local.service_ips["gcr"] == "10.20.0.4" && local.service_ips["ghcr"] == "10.20.0.5"
+    error_message = "Sequential IPs: first two registries at 4 and 5"
+  }
+
+  assert {
+    condition     = length(incus_instance.registry) == 2
+    error_message = "Exactly two registry instances for custom registries map"
+  }
+
+  assert {
+    condition     = incus_instance.dns[0].name == "dns-local-dev" && incus_instance.git[0].name == "git-local-dev"
+    error_message = "Instance names should be sanitized for Incus (dots to hyphens): dns-local-dev, git-local-dev"
+  }
+
+  assert {
+    condition     = length(incus_instance.dns) == 1 && length(incus_instance.git) == 1
+    error_message = "DNS and git instances should be created when enabled"
+  }
+}
+
+# Conditional: disabling DNS and git omits those instances and output keys.
+run "disabled_services" {
+  command = plan
+
+  variables {
+    project_root = "/tmp/windsor-test"
+    context      = "test"
+    enable_dns   = false
+    enable_git   = false
+  }
+
+  assert {
+    condition     = length(incus_instance.dns) == 0
+    error_message = "DNS instance should not be created when enable_dns is false"
+  }
+
+  assert {
+    condition     = length(incus_instance.git) == 0
+    error_message = "Git instance should not be created when enable_git is false"
+  }
+
+  assert {
+    condition     = length(incus_instance.registry) == 6
+    error_message = "Default 6 registries should be created"
+  }
+
+  assert {
+    condition     = !contains(keys(output.containers), "dns")
+    error_message = "containers output should not include dns when disabled"
+  }
+
+  assert {
+    condition     = !contains(keys(output.containers), "git")
+    error_message = "containers output should not include git when disabled"
+  }
+}
+
+# Webhook and loadbalancer derived from network_cidr.
+run "webhook_and_loadbalancer_derived_from_network_cidr" {
+  command = plan
+
+  variables {
+    project_root = "/tmp/windsor-test"
+    context      = "test"
+    network_cidr = "10.10.0.0/16"
+  }
+
+  assert {
+    condition     = local.loadbalancer_start_ip == "10.10.1.1"
+    error_message = "loadbalancer_start_ip should be first host of next /24 from network_cidr"
+  }
+
+  assert {
+    condition     = local.webhook_host == "10.10.1.1"
+    error_message = "Webhook host should be loadbalancer_start_ip"
+  }
+
+  assert {
+    condition     = local.dns_forward_target == "10.10.1.1"
+    error_message = "dns_forward_target should be loadbalancer_start_ip"
+  }
+}
+
+# Colima: use existing network (incusbr0); do not create. Same IP layout (dns=2, git=3, etc.).
+run "create_network_false_uses_existing_network" {
+  command = plan
+
+  variables {
+    project_root   = "/tmp/windsor-test"
+    context        = "test"
+    create_network = false
+    network_name   = "incusbr0"
+    network_cidr   = "10.5.0.0/16"
+  }
+
+  assert {
+    condition     = length(incus_network.main) == 0
+    error_message = "Network should not be created when create_network is false"
+  }
+
+  assert {
+    condition     = local.attached_network == "incusbr0"
+    error_message = "attached_network should be var.network_name when create_network is false"
+  }
+
+  assert {
+    condition     = local.dns_ip == "10.5.0.2" && local.git_ip == "10.5.0.3"
+    error_message = "IP layout unchanged: dns=2, git=3"
+  }
+}
+
+# Registry hostname normalization: keys with trailing TLD (e.g. gcr.io, registry.k8s.io) get single .test.
+run "registry_hostname_normalization" {
+  command = plan
+
+  variables {
+    project_root = "/tmp/windsor-test"
+    context      = "test"
+    registries = {
+      "gcr.io"          = { remote = "https://gcr.io" }
+      "registry.k8s.io" = { remote = "https://registry.k8s.io" }
+      "registry.test"   = { hostport = 5001 }
+    }
+  }
+
+  assert {
+    condition     = local.registry_hostname["gcr.io"] == "gcr.test" && local.registry_hostname["registry.k8s.io"] == "registry.k8s.test" && local.registry_hostname["registry.test"] == "registry.test"
+    error_message = "Trailing TLD stripped from registry key so hostname has single domain: gcr.test, registry.k8s.test, registry.test"
+  }
+
+  assert {
+    condition     = incus_instance.registry["gcr.io"].name == "gcr-test" && incus_instance.registry["registry.k8s.io"].name == "registry-k8s-test" && incus_instance.registry["registry.test"].name == "registry-test"
+    error_message = "Incus instance names are sanitized (dots to hyphens) from normalized hostname"
+  }
+}

--- a/terraform/workstation/incus/variables.tf
+++ b/terraform/workstation/incus/variables.tf
@@ -1,0 +1,141 @@
+# -----------------------------------------------------------------------------
+# Variables
+# -----------------------------------------------------------------------------
+
+variable "project_root" {
+  description = "Absolute path to the project root. Used for bind mounts (Corefile, .windsor/cache, repo). Universal variable provided by the environment."
+  type        = string
+}
+
+variable "context" {
+  description = "Windsor context name (e.g. local, test). Used for network name and instance names; container names use domain_name (which defaults to context). Universal variable provided by the environment."
+  type        = string
+}
+
+variable "domain_name" {
+  description = "Domain name used for DNS zone and hostnames in the Corefile (e.g. dns.domain_name, git.domain_name). Defaults to context when not set."
+  type        = string
+  default     = null
+}
+
+variable "network_name" {
+  description = "Name of the Incus bridge network. When create_network is true, defaults to windsor-{context}. When create_network is false, must be the existing network (e.g. incusbr0 for Colima)."
+  type        = string
+  default     = null
+}
+
+variable "create_network" {
+  description = "Whether to create the Incus network. If false, use network_name as existing network (e.g. incusbr0 when runtime is colima)."
+  type        = bool
+  default     = true
+}
+
+variable "network_cidr" {
+  description = "CIDR for the Incus network (e.g. 10.5.0.0/16). Service IPs are assigned sequentially: 1=gateway, 2=dns, 3=git, 4+=registries. Corefile, load balancer subnet, and webhook host are derived from this."
+  type        = string
+  default     = "10.5.0.0/16"
+}
+
+variable "loadbalancer_start_ip" {
+  description = "First IP in the load balancer range (e.g. 10.5.1.1). Used to derive webhook_host and dns_forward_target when not overridden. If null, derived as first host of next /24 from network_cidr."
+  type        = string
+  default     = null
+}
+
+variable "webhook_host" {
+  description = "IP (or host) for the git livereload webhook URL. If null, derived from loadbalancer_start_ip."
+  type        = string
+  default     = null
+}
+
+variable "primary_node_ip" {
+  description = "IP of the primary developing node (controlplane or worker) for NodePort webhook. If set and webhook_host is null, used as webhook host."
+  type        = string
+  default     = null
+}
+
+variable "dns_forward_target" {
+  description = "Target for Corefile forward directive (context zone). If null, uses loadbalancer_start_ip."
+  type        = string
+  default     = null
+}
+
+variable "enable_dns" {
+  description = "Create the DNS (CoreDNS) container."
+  type        = bool
+  default     = true
+}
+
+variable "enable_git" {
+  description = "Create the git livereload container."
+  type        = bool
+  default     = true
+}
+
+variable "registries" {
+  description = "Map of registry configs (aligned with windsor docker.registries). Key is hostname prefix (e.g. gcr, registry.k8s). Each entry: remote (proxy upstream URL), hostport (unused for Incus; kept for API compatibility), local. Omit remote for local-only registry."
+  type = map(object({
+    remote   = optional(string)
+    local    = optional(string)
+    hostport = optional(number)
+  }))
+  default = {
+    gcr = {
+      remote = "https://gcr.io"
+    }
+    ghcr = {
+      remote = "https://ghcr.io"
+    }
+    quay = {
+      remote = "https://quay.io"
+    }
+    "registry-1.docker" = {
+      remote = "https://registry-1.docker.io"
+      local  = "https://docker.io"
+    }
+    "registry.k8s" = {
+      remote = "https://registry.k8s.io"
+    }
+    registry = {
+      hostport = 5001
+    }
+  }
+}
+
+variable "webhook_token" {
+  description = "Token for the git livereload webhook URL. If not set, a placeholder is used (caller should replace or provide via env)."
+  type        = string
+  default     = "5dc88e45e809fb0872b749c0969067e2c1fd142e17aed07573fad20553cc0c59"
+  sensitive   = true
+}
+
+variable "git_username" {
+  description = "Username for git livereload HTTP auth. Defaults to local."
+  type        = string
+  default     = "local"
+}
+
+variable "git_password" {
+  description = "Password for git livereload HTTP auth. Defaults to local."
+  type        = string
+  default     = "local"
+  sensitive   = true
+}
+
+variable "git_rsync_exclude" {
+  description = "Comma-separated list of paths to exclude from rsync (git livereload)."
+  type        = string
+  default     = ".windsor,.terraform,.volumes,.venv"
+}
+
+variable "git_rsync_include" {
+  description = "Comma-separated list of paths to include in rsync (git livereload)."
+  type        = string
+  default     = "kustomize"
+}
+
+variable "git_rsync_protect" {
+  description = "Comma-separated list of paths to protect from deletion in rsync (git livereload)."
+  type        = string
+  default     = "flux-system"
+}


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Incus-based workstation Terraform module and rewires Incus/Talos apply flow, which can affect local cluster bring-up and endpoint derivation. Also changes Talos cluster endpoint validation/derivation, potentially surfacing misconfigurations as hard failures.
> 
> **Overview**
> Enables **Incus workstation mode** by adding a new `terraform/workstation/incus` module that provisions an Incus bridge (optional), CoreDNS, registry proxies, and git-livereload containers with Docker/OCI remotes, plus outputs/tests.
> 
> Updates the blueprint facets/schema to support `workstation.arch`, introduces per-platform Talos image refs (`talos.docker_image`/`talos.incus_image`), and adds an Incus workstation→compute→`cluster/talos` chain (including stripping hostnames from Incus compute outputs to avoid Talos 1.12 conflicts). Separately, tightens Talos cluster bring-up by deriving `cluster_endpoint` from controlplane endpoints when unset, adding a precondition to fail fast when it can’t be derived, and adjusting Incus provider defaults to avoid falling back to `https://localhost:6443`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02175cbfe7beb4e99061bcf1a8c514bcd0936995. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->