### PR TITLE
fix(workstation): Correctly wire registry entries and light facet refactors

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -22,10 +22,8 @@ Reference:
 - Internal: See "Testing Patterns" section in terraform/STYLE.md
 - External: https://developer.hashicorp.com/terraform/language/tests
 
-## AUDIO NOTIFICATIONS
-Must use `say` command with Samantha voice for:
-- Test Completion: "All tests are now passing"
-- Test Failure: "Test failure detected in [test name]"
-- Source Code Bug: "Source code bug detected in [function]. Please review."
-- User Input Needed: "User input required for [specific issue]"
-- Work Complete: "Platform engineering work complete"
+## DESCRIPTIONS AND DOCUMENTATION
+Descriptions (schema, docs, UI copy) state what something is or does; they do not explain underlying mechanics, implementation, or justification. Keep explanations and rationale in chat or in code comments, not in user-facing descriptions.
+
+## BLUEPRINT DEBUGGING
+For facet/blueprint issues use: `windsor test` (blueprint tests) and `windsor show blueprint` (composed blueprint output) to inspect config and Terraform inputs. `windsor test` uses mocked terraformOutputs and does not run real composition—it can pass even when `windsor show blueprint` fails.

--- a/contexts/_template/facets/config-talos.yaml
+++ b/contexts/_template/facets/config-talos.yaml
@@ -15,15 +15,18 @@ config:
       csi_local_volume_path: "${cluster.storage.local_base_path ?? \"/var/mnt/local\"}"
       controlplane_disks: "${cluster.controlplanes.disks ?? []}"
       worker_disks: "${cluster.workers.disks ?? []}"
+      cert_rotation:
+        extra_manifests:
+          - "https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml"
+        kubelet_extra_args:
+          rotate-server-certificates: "true"
       common_patch:
         cluster:
           allowSchedulingOnControlPlanes: ${talos_common.allowSchedulingOnControlPlanes}
-          extraManifests:
-            - "https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml"
+          extraManifests: ${talos_common.cert_rotation.extra_manifests}
         machine:
           kubelet:
-            extraArgs:
-              rotate-server-certificates: "true"
+            extraArgs: ${talos_common.cert_rotation.kubelet_extra_args}
       common_config_patches: "${string(talos_common.common_patch)}"
 
   - name: talos

--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -66,11 +66,11 @@ config:
             mirrors: ${talos_registry_mirrors.mirrors}
             config: ${talos_registry_mirrors.config}
 
-  # Merge schedulable override for docker (colima + docker-desktop).
+  # Merge schedulable override for docker (colima + docker-desktop). When no workers, allow scheduling on control planes; otherwise use cluster.controlplanes.schedulable.
   - name: talos_common
     when: (cluster.enabled ?? true) && cluster.driver == 'talos' && platform == 'docker'
     value:
-      allowSchedulingOnControlPlanes: "${cluster.controlplanes.schedulable ?? ((cluster.workers.count ?? 0) == 0)}"
+      allowSchedulingOnControlPlanes: "${(cluster.workers.count ?? 0) == 0 ? true : (cluster.controlplanes.schedulable ?? false)}"
 
   # Merge network ignore (docker-desktop only).
   - name: talos_common

--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -31,53 +31,62 @@ config:
           "registry.k8s.io": { "remote": "https://registry.k8s.io" },
           "registry.test": {}
         })}
-      registry_count: "${(workstation.services.registries ?? true) == false ? 0 : len(docker.registries ?? {\"gcr.io\": {}, \"ghcr.io\": {}, \"quay.io\": {}, \"registry-1.docker.io\": {}, \"registry.k8s.io\": {}, \"registry.test\": {}})}"
+      registry_count: >-
+        ${(workstation.services.registries ?? true) == false
+          ? 0
+          : len(docker.registries ?? {
+              "gcr.io": {}, "ghcr.io": {}, "quay.io": {},
+              "registry-1.docker.io": {}, "registry.k8s.io": {}, "registry.test": {}
+            })}
 
-  # certSANs for Talos when compute runs. Include localhost/127.0.0.1 for docker-desktop so host→container works.
-  # Kept so it is evaluated when building cluster inputs (after compute). Apply when docker provider + talos.
-  - name: certSANs_from_compute
+  # Registry mirrors: built from workstation TF output "registries" (entries include hostname); nodes reach registries via DNS (hostname:5000).
+  # config: empty for HTTP mirrors—Talos errors "TLS config specified for non-HTTPS registry" if tls is set for http:// endpoints.
+  - name: talos_registry_mirrors
     when: (cluster.enabled ?? true) && cluster.driver == 'talos'
     value:
-      list: |-
-        ${(cluster.controlplanes.count ?? 1) == 0 ? ["localhost", "127.0.0.1"] : (
-          let cp = terraform_output("compute", "controlplanes");
-          cp == null || len(cp ?? []) == 0 ? ["localhost", "127.0.0.1"] : (
-            let hosts = map(cp, #?.node ?? split(string(#?.endpoint ?? ""), ":")[0]);
-            let names = map(cp, #?.hostname ?? "");
-            let fqdns = (dns.domain ?? "") != "" ? map(cp, (#?.hostname ?? "") != "" ? (#?.hostname ?? "") + "." + (dns.domain ?? "") : "") : [];
-            let base = concat(["localhost"], (workstation.runtime == "docker-desktop" ? ["127.0.0.1"] : []), filter(hosts, # != ""), filter(names, # != ""), filter(fqdns, # != ""));
-            uniq(base)
-          )
-        )}
+      mirrors: >-
+        ${fromPairs(map(
+          filter(toPairs(terraform_output("workstation", "registries") ?? {}),
+            get(get(#, 1), "hostname") != null && get(get(#, 1), "hostname") != ""
+          ),
+          [
+            (get(get(#, 1), "local") != null && get(get(#, 1), "local") != "" ? get(get(#, 1), "local") : get(#, 0)),
+            { endpoints: ["http://" + get(get(#, 1), "hostname") + ":5000"] }
+          ]
+        ))}
+      config: {}
 
-  # Talos common patch when docker provider + talos: certSANs (localhost/127.0.0.1 for docker-desktop), registries, etc.
-  - name: common_patch_docker
+  # Merge registries into common_patch (all workstation + talos).
+  - name: talos_common
     when: (cluster.enabled ?? true) && cluster.driver == 'talos'
     value:
-      cluster:
-        apiServer:
-          certSANs: ${certSANs_from_compute.list}
-        allowSchedulingOnControlPlanes: ${cluster.controlplanes.schedulable ?? ((cluster.workers.count ?? 0) == 0)}
-        extraManifests:
-          - "https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml"
-      machine:
-        certSANs: ${certSANs_from_compute.list}
-        kubelet:
-          extraArgs:
-            rotate-server-certificates: "true"
-        registries:
-          mirrors: |-
-            ${fromPairs(map(
-              filter(toPairs(workstation_registries.registries ?? {}), { (get(#, 1)?.hostname ?? "") != "" }),
-              { [(get(#, 1)?.local ?? "") != "" ? get(#, 1).local : get(#, 0), { endpoints: ["http://" + get(#, 1).hostname + ":5000"] }] }
-            ))}
-        network: '${workstation.runtime == "docker-desktop" ? {interfaces: [{ignore: true, interface: "eth0"}]} : {}}'
+      common_patch:
+        machine:
+          registries:
+            mirrors: ${talos_registry_mirrors.mirrors}
+            config: ${talos_registry_mirrors.config}
 
-  # Expose common_patch_docker for provider-docker cluster input. When no compute, provider-docker uses docker_desktop_common_patches instead.
+  # Merge schedulable override for docker (colima + docker-desktop).
+  - name: talos_common
+    when: (cluster.enabled ?? true) && cluster.driver == 'talos' && platform == 'docker'
+    value:
+      allowSchedulingOnControlPlanes: "${cluster.controlplanes.schedulable ?? ((cluster.workers.count ?? 0) == 0)}"
+
+  # Merge network ignore (docker-desktop only).
+  - name: talos_common
+    when: (cluster.enabled ?? true) && cluster.driver == 'talos' && workstation.runtime == 'docker-desktop'
+    value:
+      common_patch:
+        machine:
+          network:
+            interfaces:
+              - ignore: true
+                interface: eth0
+
+  # Expose controlplane/worker patches for provider-docker; common_config_patches from talos_common (config-talos stringifies after merge).
   - name: talos_common_docker
     when: (cluster.enabled ?? true) && cluster.driver == 'talos'
     value:
-      common_config_patches: ${string(common_patch_docker)}
       controlplane_config_patches: ""
       worker_config_patches: ""
 
@@ -105,7 +114,7 @@ terraform:
 # first node. Use container port 30053 (not host 8053) so the DNS container on the same network can reach the node.
 # 30053 = NodePort for DNS set in kustomize/ingress/nginx/coredns/patches/helm-release.yaml; cluster.*.hostports must use same container port (e.g. 8053:30053/udp).
 - name: workstation
-  when: "platform == 'docker' && workstation.runtime == \"docker-desktop\""
+  when: "platform == 'docker' && workstation.runtime == 'docker-desktop'"
   path: workstation/docker
   inputs:
     runtime: 'docker-desktop'

--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -30,7 +30,6 @@ config:
           "registry-1.docker.io": { "remote": "https://registry-1.docker.io", "local": "docker.io" },
           "registry.k8s.io": { "remote": "https://registry.k8s.io" }
         })}
-      registry_count: "${(workstation.services.registries ?? true) == false ? 0 : len(workstation_registries.registries ?? {})}"
 
   # Registry mirrors: built from workstation TF output "registries"; only entries with remote are included (Talos mirrors upstream remotes).
   # config: empty for HTTP mirrors—Talos errors "TLS config specified for non-HTTPS registry" if tls is set for http:// endpoints.

--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -28,18 +28,17 @@ config:
           "ghcr.io": { "remote": "https://ghcr.io" },
           "quay.io": { "remote": "https://quay.io" },
           "registry-1.docker.io": { "remote": "https://registry-1.docker.io", "local": "docker.io" },
-          "registry.k8s.io": { "remote": "https://registry.k8s.io" },
-          "registry.test": {}
+          "registry.k8s.io": { "remote": "https://registry.k8s.io" }
         })}
       registry_count: >-
         ${(workstation.services.registries ?? true) == false
           ? 0
           : len(docker.registries ?? {
               "gcr.io": {}, "ghcr.io": {}, "quay.io": {},
-              "registry-1.docker.io": {}, "registry.k8s.io": {}, "registry.test": {}
+              "registry-1.docker.io": {}, "registry.k8s.io": {}
             })}
 
-  # Registry mirrors: built from workstation TF output "registries" (entries include hostname); nodes reach registries via DNS (hostname:5000).
+  # Registry mirrors: built from workstation TF output "registries"; only entries with remote are included (Talos mirrors upstream remotes).
   # config: empty for HTTP mirrors—Talos errors "TLS config specified for non-HTTPS registry" if tls is set for http:// endpoints.
   - name: talos_registry_mirrors
     when: (cluster.enabled ?? true) && cluster.driver == 'talos'
@@ -47,7 +46,7 @@ config:
       mirrors: >-
         ${fromPairs(map(
           filter(toPairs(terraform_output("workstation", "registries") ?? {}),
-            get(get(#, 1), "hostname") != null && get(get(#, 1), "hostname") != ""
+            get(get(#, 1), "remote") != null && get(get(#, 1), "remote") != "" && get(get(#, 1), "hostname") != null && get(get(#, 1), "hostname") != ""
           ),
           [
             (get(get(#, 1), "local") != null && get(get(#, 1), "local") != "" ? get(get(#, 1), "local") : get(#, 0)),

--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -30,13 +30,7 @@ config:
           "registry-1.docker.io": { "remote": "https://registry-1.docker.io", "local": "docker.io" },
           "registry.k8s.io": { "remote": "https://registry.k8s.io" }
         })}
-      registry_count: >-
-        ${(workstation.services.registries ?? true) == false
-          ? 0
-          : len(docker.registries ?? {
-              "gcr.io": {}, "ghcr.io": {}, "quay.io": {},
-              "registry-1.docker.io": {}, "registry.k8s.io": {}
-            })}
+      registry_count: "${(workstation.services.registries ?? true) == false ? 0 : len(workstation_registries.registries ?? {})}"
 
   # Registry mirrors: built from workstation TF output "registries"; only entries with remote are included (Talos mirrors upstream remotes).
   # config: empty for HTTP mirrors—Talos errors "TLS config specified for non-HTTPS registry" if tls is set for http:// endpoints.
@@ -120,9 +114,9 @@ terraform:
     domain_name: ${dns.domain}
     network_name: windsor-${context}
     network_cidr: ${network.cidr_block}
-    dns_forward_target: "${cidrhost(network.cidr_block, 4 + int(workstation_registries.registry_count ?? 0)) + \":30053\"}"
-    webhook_host: "${cidrhost(network.cidr_block, 4 + int(workstation_registries.registry_count ?? 0))}"
-    primary_node_ip: "${cidrhost(network.cidr_block, 4 + int(workstation_registries.registry_count ?? 0))}"
+    dns_forward_target: "${cidrhost(network.cidr_block, 4 + len(workstation_registries.registries ?? {})) + \":30053\"}"
+    webhook_host: "${cidrhost(network.cidr_block, 4 + len(workstation_registries.registries ?? {}))}"
+    primary_node_ip: "${cidrhost(network.cidr_block, 4 + len(workstation_registries.registries ?? {}))}"
     enable_dns: ${workstation.services.dns ?? true}
     enable_git: ${workstation.services.git ?? true}
     registries: ${workstation_registries.registries ?? {}}

--- a/contexts/_template/facets/provider-base.yaml
+++ b/contexts/_template/facets/provider-base.yaml
@@ -4,9 +4,11 @@ metadata:
   name: provider-base
   description: "Base infrastructure components for all providers"
 
-when: platform != 'none'
+when: (platform ?? provider) != 'none'
 
 config:
+- name: platform
+  value: "${platform ?? provider ?? 'none'}"
 - name: workstation
   value:
     runtime: "${workstation.runtime ?? vm.driver ?? ''}"

--- a/contexts/_template/facets/provider-base.yaml
+++ b/contexts/_template/facets/provider-base.yaml
@@ -4,11 +4,9 @@ metadata:
   name: provider-base
   description: "Base infrastructure components for all providers"
 
-when: (platform ?? provider) != 'none'
+when: platform != 'none'
 
 config:
-- name: platform
-  value: "${platform ?? provider ?? 'none'}"
 - name: workstation
   value:
     runtime: "${workstation.runtime ?? vm.driver ?? ''}"

--- a/contexts/_template/facets/provider-docker.yaml
+++ b/contexts/_template/facets/provider-docker.yaml
@@ -21,28 +21,6 @@ config:
             ? "https://" + split(values(cluster.controlplanes.nodes ?? {})[0].endpoint, ":")[0] + ":6443"
             : "https://localhost:6443"))}
 
-# No compute: node TLS cert must include localhost (and 127.0.0.1 only for docker-desktop) so host→container verifies.
-# talos_common_docker only runs when compute runs; no-compute path (docker-desktop) needs these certSANs.
-- name: docker_desktop_common_patches
-  when: len(terraform_output("compute", "controlplanes") ?? []) == 0
-  value:
-    common_config_patches: >-
-      cluster:
-        apiServer:
-          certSANs:
-            - localhost
-      ${workstation.runtime == "docker-desktop" ? "\n            - 127.0.0.1" : ""}
-        allowSchedulingOnControlPlanes: ${cluster.controlplanes.schedulable ?? ((cluster.workers.count ?? 0) == 0)}
-        extraManifests:
-          - "https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml"
-      machine:
-        certSANs:
-            - localhost
-      ${workstation.runtime == "docker-desktop" ? "\n            - 127.0.0.1" : ""}
-        kubelet:
-          extraArgs:
-            rotate-server-certificates: "true"
-
 terraform:
 # Run cluster/talos: secrets, config apply, bootstrap, kubeconfig. Inputs from compute output or context;
 # hostname stripped for containers (Talos 1.12 rejects setting hostname when runtime already set it).
@@ -59,17 +37,25 @@ terraform:
     talos_version: ${talos.talos_version}
     # When compute output exists, strip hostname from each node (Docker sets it; Talos 1.12 rejects override).
     # When no compute, rewrite endpoint/node to 127.0.0.1:(50000+i) so host can bootstrap/apply.
+    # docker-desktop: each control plane gets per-node config_patches (machine.certSANs = node + hostname + localhost + 127.0.0.1) so Talos API cert works from host.
     controlplanes: >-
-      ${(len(terraform_output("compute", "controlplanes") ?? []) > 0
-        ? map(terraform_output("compute", "controlplanes"), fromPairs(concat(filter(toPairs(#), get(#, 0) != "hostname"), [["hostname", null]])))
-        : reduce(
-            take(values(cluster.controlplanes.nodes ?? {}), int(cluster.controlplanes.count ?? 1)),
-            concat(#acc, [fromPairs(concat(
-              filter(toPairs(#), get(#, 0) != "hostname" && get(#, 0) != "endpoint" && get(#, 0) != "node"),
-              [["hostname", null], ["endpoint", "127.0.0.1:" + string(50000 + len(#acc))], ["node", "127.0.0.1"]]
-            ))]),
-            []
-          ))}
+      ${map(
+        len(terraform_output("compute", "controlplanes") ?? []) > 0
+          ? terraform_output("compute", "controlplanes")
+          : reduce(
+              take(values(cluster.controlplanes.nodes ?? {}), int(cluster.controlplanes.count ?? 1)),
+              concat(#acc, [fromPairs(concat(
+                filter(toPairs(#), get(#, 0) != "hostname" && get(#, 0) != "endpoint" && get(#, 0) != "node"),
+                [["hostname", null], ["endpoint", "127.0.0.1:" + string(50000 + len(#acc))], ["node", "127.0.0.1"]]
+              ))]),
+              []
+            ),
+        fromPairs(concat(
+          filter(toPairs(#), get(#, 0) != "hostname"),
+          [["hostname", null]],
+          workstation.runtime == 'docker-desktop' ? [["config_patches", "machine:\n  certSANs:\n  - " + (get(#, "node") != null && get(#, "node") != "" ? get(#, "node") : split(get(#, "endpoint"), ":")[0]) + (get(#, "hostname") != null && get(#, "hostname") != "" ? "\n  - " + get(#, "hostname") : "") + "\n  - localhost\n  - 127.0.0.1"]] : []
+        ))
+      )}
     workers: >-
       ${(len(terraform_output("compute", "controlplanes") ?? []) > 0
         ? map(terraform_output("compute", "workers") ?? [], fromPairs(concat(filter(toPairs(#), get(#, 0) != "hostname"), [["hostname", null]])))
@@ -83,14 +69,9 @@ terraform:
           )))}
     controlplane_disks: ${cluster.controlplanes.disks ?? []}
     worker_disks: ${cluster.workers.disks ?? []}
-    common_config_patches: >-
-      ${len(terraform_output("compute", "controlplanes") ?? []) == 0
-        ? docker_desktop_common_patches.common_config_patches
-        : (talos_common_docker.common_config_patches ?? talos_common.common_config_patches)}
-    controlplane_config_patches: >-
-      ${len(terraform_output("compute", "controlplanes") ?? []) == 0 ? "" : (talos_common_docker.controlplane_config_patches ?? "")}
-    worker_config_patches: >-
-      ${len(terraform_output("compute", "controlplanes") ?? []) == 0 ? "" : (talos_common_docker.worker_config_patches ?? "")}
+    common_config_patches: ${talos_common.common_config_patches}
+    controlplane_config_patches: "${talos_common_docker.controlplane_config_patches ?? \"\"}"
+    worker_config_patches: "${talos_common_docker.worker_config_patches ?? \"\"}"
     controlplane_volumes: ${talos_common.controlplane_volumes ?? []}
     worker_volumes: ${talos_common.worker_volumes ?? []}
 
@@ -99,7 +80,7 @@ kustomize:
 # MetalLB base (colima, incus, docker driver). Not used for docker-desktop (no node IPs to load-balance).
 - name: lb-base
   path: lb/base
-  when: workstation.runtime == 'colima' || workstation.runtime == 'colima-incus' || workstation.runtime == 'docker'
+  when: workstation.runtime == 'colima' || workstation.runtime == 'docker'
   dependsOn:
     - policy-resources
   components:
@@ -110,7 +91,7 @@ kustomize:
 # MetalLB resources and mode (e.g. metallb/arp). Depends on lb-base.
 - name: lb-resources
   path: lb/resources
-  when: workstation.runtime == 'colima' || workstation.runtime == 'colima-incus' || workstation.runtime == 'docker'
+  when: workstation.runtime == 'colima' || workstation.runtime == 'docker'
   dependsOn:
     - lb-base
   components:

--- a/contexts/_template/schema.yaml
+++ b/contexts/_template/schema.yaml
@@ -125,7 +125,7 @@ properties:
       - incus
       - metal
       - docker
-    description: Alias for provider; when set overrides provider. Facets use effective_provider (platform ?? provider).
+    description: Alias for provider; when set overrides provider.
 
   # Development mode
   dev:
@@ -236,15 +236,15 @@ properties:
           properties:
             remote:
               type: string
-              description: Upstream registry URL (e.g. https://gcr.io). Proxy supports remoteurl, username, password, ttl.
+              description: Upstream registry URL (e.g. https://gcr.io).
             local:
               type: string
-              description: Client-facing registry host for mirror key (e.g. docker.io). When set, used as the mirror name so pulls to this host use the proxy. Omit to use the registry map key.
+              description: Client-facing registry host for mirror key (e.g. docker.io). Omit to use the registry map key.
             hostname:
               type: string
-              description: Hostname for registry mirror config (e.g. registry.test)
+              description: Hostname for the mirror endpoint (e.g. registry.test).
           additionalProperties: false
-        description: Registry mirror config keyed by registry host (e.g. gcr.io, ghcr.io). Used by workstation proxy registries and cluster machine config.
+        description: Registry mirror config keyed by registry host (e.g. gcr.io, ghcr.io). Used by workstation proxy/DNS and by Talos cluster mirrors.
     additionalProperties: false
 
   # High availability mode
@@ -422,6 +422,9 @@ properties:
           - docker
           - incus
         description: Container/VM runtime
+      address:
+        type: string
+        description: Deprecated. Use workstation.address. VM/workstation host address (e.g. Colima VM IP).
     additionalProperties: false
 
   # Workstation (DNS, registries, git livereload)

--- a/contexts/_template/tests/option-ingress.test.yaml
+++ b/contexts/_template/tests/option-ingress.test.yaml
@@ -85,6 +85,15 @@ cases:
         runtime: docker-desktop
       network: *default-network
       cluster: *default-cluster
+    terraformOutputs:
+      compute:
+        controlplanes:
+          - endpoint: 10.5.0.10:6443
+            node: 10.5.0.10
+            hostname: controlplane-1
+        workers: []
+      workstation:
+        registries: {}
     expect:
       kustomize:
         - name: ingress
@@ -110,6 +119,15 @@ cases:
         runtime: colima
       network: *default-network
       cluster: *default-cluster
+    terraformOutputs:
+      compute:
+        controlplanes:
+          - endpoint: 10.5.0.10:6443
+            node: 10.5.0.10
+            hostname: controlplane-1
+        workers: []
+      workstation:
+        registries: {}
     expect:
       kustomize:
         - name: ingress

--- a/contexts/_template/tests/option-workstation.test.yaml
+++ b/contexts/_template/tests/option-workstation.test.yaml
@@ -1,6 +1,7 @@
 # option-workstation.yaml facet tests
-# Tests workstation stack (workstation/docker, compute/docker, cluster/talos) when workstation.enabled and provider docker.
-# Facet contributes config (certSANs_from_compute, common_patch_docker, talos_common_docker) and terraform chain.
+# Tests workstation stack (workstation/docker or incus, compute, cluster/talos) when workstation.enabled.
+# Asserts cluster common_config_patches: cert_rotation (extraManifests + kubelet.extraArgs) and registries.mirrors
+# so changes to config-talos or option-workstation patch logic are caught.
 
 x-defaults:
   network: &default-network
@@ -39,7 +40,7 @@ x-defaults:
     driver: nginx
 
 cases:
-  # Minimal: workstation enabled, docker, minimal cluster/network/dns → cluster and gitops (option-workstation + provider-docker)
+  # Minimal: workstation enabled, docker (colima), minimal cluster → cluster and gitops. No certSANs (colima; only docker-desktop sets them).
   - name: minimal workstation creates terraform chain and talos config
     values:
       provider: docker
@@ -58,6 +59,18 @@ cases:
           path: cluster/talos
           inputs:
             cluster_name: talos
+            common_config_patches: |-
+              cluster:
+                allowSchedulingOnControlPlanes: true
+                extraManifests:
+                - https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml
+              machine:
+                kubelet:
+                  extraArgs:
+                    rotate-server-certificates: "true"
+                registries:
+                  config: {}
+                  mirrors: {}
         - name: gitops
           path: gitops/flux
           destroy: false
@@ -172,7 +185,8 @@ cases:
           path: gitops/flux
           destroy: false
 
-  # Incus with workstation enabled: option-workstation contributes workstation/incus, compute/incus, cluster/talos
+  # Incus with workstation enabled: option-workstation contributes workstation/incus, compute/incus, cluster/talos.
+  # Asserts cluster common_config_patches: cert_rotation + registries.mirrors; no certSANs (incus path uses common_patch_with_registries only).
   - name: incus with workstation enabled creates workstation/incus compute cluster chain
     values:
       provider: incus
@@ -222,6 +236,19 @@ cases:
           path: cluster/talos
           dependsOn:
             - compute
+          inputs:
+            common_config_patches: |-
+              cluster:
+                allowSchedulingOnControlPlanes: false
+                extraManifests:
+                - https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml
+              machine:
+                kubelet:
+                  extraArgs:
+                    rotate-server-certificates: "true"
+                registries:
+                  config: {}
+                  mirrors: {}
 
   # Edge: vm.driver docker-desktop — no lb kustomize components
   - name: docker-desktop workstation has node hostport dns and no lb

--- a/contexts/_template/tests/option-workstation.test.yaml
+++ b/contexts/_template/tests/option-workstation.test.yaml
@@ -250,7 +250,7 @@ cases:
                   config: {}
                   mirrors: {}
 
-  # Edge: vm.driver docker-desktop — no lb kustomize components. Asserts workstation inputs use 4+registry_count for IPs (validates registry_count = len(workstation_registries.registries)).
+  # Edge: vm.driver docker-desktop — no lb kustomize components. Asserts workstation inputs use 4+len(registries) for IPs.
   - name: docker-desktop workstation has node hostport dns and no lb
     values:
       provider: docker

--- a/contexts/_template/tests/option-workstation.test.yaml
+++ b/contexts/_template/tests/option-workstation.test.yaml
@@ -250,7 +250,7 @@ cases:
                   config: {}
                   mirrors: {}
 
-  # Edge: vm.driver docker-desktop — no lb kustomize components
+  # Edge: vm.driver docker-desktop — no lb kustomize components. Asserts workstation inputs use 4+registry_count for IPs (validates registry_count = len(workstation_registries.registries)).
   - name: docker-desktop workstation has node hostport dns and no lb
     values:
       provider: docker
@@ -265,6 +265,10 @@ cases:
     terraformOutputs: *default-terraform-outputs
     expect:
       terraform:
+        - name: workstation
+          path: workstation/docker
+          inputs:
+            webhook_host: "10.5.0.9"
         - name: cluster
           path: cluster/talos
         - name: gitops

--- a/contexts/_template/tests/provider-docker.test.yaml
+++ b/contexts/_template/tests/provider-docker.test.yaml
@@ -177,7 +177,7 @@ cases:
   # Registry mirrors: when terraform_output("workstation", "registries") has hostname, common_config_patches must include non-empty mirrors. Colima: no certSANs.
   - name: cluster common_config_patches includes registry mirrors when docker.registries have hostname
     values:
-      provider: docker
+      platform: docker
       workstation:
         enabled: true
       vm:

--- a/contexts/_template/tests/provider-docker.test.yaml
+++ b/contexts/_template/tests/provider-docker.test.yaml
@@ -38,6 +38,20 @@ x-defaults:
           hostname: controlplane-1
       workers: []
 
+  # Workstation registries with hostname so common_config_patches gets non-empty mirrors (mirror key -> endpoint).
+  terraform-outputs-with-workstation-registries: &terraform-outputs-with-workstation-registries
+    compute:
+      controlplanes:
+        - endpoint: 10.5.0.10:6443
+          node: 10.5.0.10
+          hostname: controlplane-1
+      workers: []
+    workstation:
+      registries:
+        gcr.io:
+          remote: "https://gcr.io"
+          hostname: "gcr.test"
+
   ingress-disabled: &ingress-disabled
     enabled: false
     driver: nginx
@@ -159,6 +173,45 @@ cases:
             local_volume_path: /var/mnt/local
           timeout: 20m
           interval: 5m
+
+  # Registry mirrors: when terraform_output("workstation", "registries") has hostname, common_config_patches must include non-empty mirrors. Colima: no certSANs.
+  - name: cluster common_config_patches includes registry mirrors when docker.registries have hostname
+    values:
+      provider: docker
+      workstation:
+        enabled: true
+      vm:
+        driver: colima
+      dns: *default-dns
+      ingress: *ingress-disabled
+      network: *default-network
+      cluster: *default-cluster
+      docker:
+        registries:
+          gcr.io:
+            remote: "https://gcr.io"
+            hostname: "gcr.test"
+    terraformOutputs: *terraform-outputs-with-workstation-registries
+    expect:
+      terraform:
+        - name: cluster
+          path: cluster/talos
+          inputs:
+            common_config_patches: |-
+              cluster:
+                allowSchedulingOnControlPlanes: true
+                extraManifests:
+                - https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml
+              machine:
+                kubelet:
+                  extraArgs:
+                    rotate-server-certificates: "true"
+                registries:
+                  config: {}
+                  mirrors:
+                    gcr.io:
+                      endpoints:
+                      - http://gcr.test:5000
 
   # Full: workstation path with fully populated cluster, ingress, volumes
   - name: full config creates workstation compute cluster chain with all options
@@ -318,6 +371,12 @@ cases:
       network: *default-network
       cluster: *default-cluster
     terraformOutputs: *default-terraform-outputs
+    expect:
+      terraform:
+        - name: cluster
+          path: cluster/talos
+          inputs:
+            cluster_endpoint: https://10.5.0.10:6443
     exclude:
       kustomize:
         - name: lb-base

--- a/terraform/cluster/talos/modules/machine/main.tf
+++ b/terraform/cluster/talos/modules/machine/main.tf
@@ -104,12 +104,11 @@ resource "local_sensitive_file" "kubeconfig" {
 
 locals {
   # Always use Talos API; during bootstrap also check Kubernetes API
-  # Use IP address for health check to avoid DNS resolution issues
-  # If node is already an IP, use it; otherwise extract IP from endpoint (endpoint may include port)
-  # Hostnames may not be resolvable during initial setup, but IP addresses always work
-  # Extract IP by: removing protocol, taking first path segment (host:port or host), then extracting IP before port
+  # Use the endpoint's host for health check so the host (where the provisioner runs) can reach the Talos API.
+  # In docker-desktop, endpoint is 127.0.0.1:50000 while node is the container IP (10.5.0.10); the host must use 127.0.0.1.
+  # Extract host by: removing optional protocol, taking host from host:port or path, then stripping port
   endpoint_ip          = can(regex("^https?://", var.endpoint)) ? split(":", split("/", split("://", var.endpoint)[1])[0])[0] : split(":", var.endpoint)[0]
-  health_check_node    = can(regex("^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+", var.node)) ? var.node : local.endpoint_ip
+  health_check_node    = local.endpoint_ip
   health_check_command = var.bootstrap ? "windsor check node-health --nodes ${local.health_check_node} --timeout 5m --k8s-endpoint --skip-services dashboard" : "windsor check node-health --nodes ${local.health_check_node} --timeout 5m --skip-services dashboard"
 }
 

--- a/terraform/cluster/talos/modules/machine/test.tftest.hcl
+++ b/terraform/cluster/talos/modules/machine/test.tftest.hcl
@@ -212,7 +212,7 @@ run "health_check_command_bootstrap_mode" {
 
   assert {
     condition     = strcontains(local.health_check_command, "192.168.1.10")
-    error_message = "Should use IP address (var.node when it's an IP, otherwise var.endpoint) instead of hostname for health check to avoid DNS resolution issues"
+    error_message = "Should use endpoint host for health check so the host can reach the Talos API (e.g. 127.0.0.1 in docker-desktop)"
   }
 }
 
@@ -236,7 +236,7 @@ run "health_check_command_non_bootstrap_mode" {
 
   assert {
     condition     = strcontains(local.health_check_command, "192.168.1.20")
-    error_message = "Should use IP address (var.node when it's an IP, otherwise var.endpoint) instead of hostname for health check to avoid DNS resolution issues"
+    error_message = "Should use endpoint host for health check so the host can reach the Talos API"
   }
 }
 
@@ -250,7 +250,7 @@ run "health_check_command_uses_node_address" {
 
   assert {
     condition     = strcontains(local.health_check_command, "dummy")
-    error_message = "Should use node address in health check"
+    error_message = "Should use endpoint host (dummy) in health check"
   }
 }
 

--- a/terraform/workstation/docker/main.tf
+++ b/terraform/workstation/docker/main.tf
@@ -47,10 +47,14 @@ locals {
   dns_ip               = cidrhost(var.network_cidr, 2)
   git_ip               = cidrhost(var.network_cidr, 3)
   registry_keys_sorted = sort(keys(local.registries))
-  # Hostname prefix = key with TLD stripped (e.g. gcr.io -> gcr) so endpoint is gcr.domain not gcr.io.domain
+  # Hostname prefix: when key matches remote URL host, strip last dot-segment (TLD); else use key (e.g. local-only registry).
   registry_host_prefix = {
-    for k in keys(local.registries) : k => (
-      length(split(".", k)) > 1 ? join(".", slice(split(".", k), 0, length(split(".", k)) - 1)) : k
+    for k, v in local.registries : k => (
+      v.remote != null
+      && split(":", split("/", trimprefix(trimprefix(v.remote, "https://"), "http://"))[0])[0] == k
+      && length(split(".", k)) > 1
+      ? join(".", slice(split(".", k), 0, length(split(".", k)) - 1))
+      : k
     )
   }
   registry_ips = {

--- a/terraform/workstation/docker/main.tf
+++ b/terraform/workstation/docker/main.tf
@@ -40,11 +40,19 @@ locals {
     { label = "context", value = var.context },
     { label = "managed_by", value = "terraform" }
   ]
+  # Registries: blueprint may pass null when workstation_registries is missing; treat as empty map.
+  registries = coalesce(var.registries, {})
   # Sequential from lowest block: 1=gateway (not a container), 2=dns, 3=git, 4+=registries
   gateway              = cidrhost(var.network_cidr, 1)
   dns_ip               = cidrhost(var.network_cidr, 2)
   git_ip               = cidrhost(var.network_cidr, 3)
-  registry_keys_sorted = sort(keys(var.registries))
+  registry_keys_sorted = sort(keys(local.registries))
+  # Hostname prefix = key with TLD stripped (e.g. gcr.io -> gcr) so endpoint is gcr.domain not gcr.io.domain
+  registry_host_prefix = {
+    for k in keys(local.registries) : k => (
+      length(split(".", k)) > 1 ? join(".", slice(split(".", k), 0, length(split(".", k)) - 1)) : k
+    )
+  }
   registry_ips = {
     for i, k in local.registry_keys_sorted : k => cidrhost(var.network_cidr, 4 + i)
   }
@@ -58,7 +66,7 @@ locals {
   # Corefile hosts: localhost mode uses 127.0.0.1 (host via published ports), else CIDR-derived IPs
   corefile_host_entries = concat(
     var.enable_dns ? ["${local.use_localhost_networking ? "127.0.0.1" : local.dns_ip} dns.${local.domain_name}"] : [],
-    [for k in local.registry_keys_sorted : "${local.use_localhost_networking ? "127.0.0.1" : local.registry_ips[k]} ${k}.${local.domain_name}"],
+    [for k in local.registry_keys_sorted : "${local.use_localhost_networking ? "127.0.0.1" : local.registry_ips[k]} ${local.registry_host_prefix[k]}.${local.domain_name}"],
     var.enable_git ? ["${local.use_localhost_networking ? "127.0.0.1" : local.git_ip} git.${local.domain_name}"] : []
   )
   corefile_content = var.enable_dns ? templatefile("${path.module}/templates/Corefile.tpl", {
@@ -177,13 +185,13 @@ resource "docker_container" "dns" {
 # =============================================================================
 
 resource "docker_image" "registry" {
-  count = length(var.registries) > 0 ? 1 : 0
+  count = length(local.registries) > 0 ? 1 : 0
   name  = "registry:3.0.0"
 }
 
 resource "docker_container" "registry" {
-  for_each = var.registries
-  name     = "${each.key}.${local.domain_name}"
+  for_each = local.registries
+  name     = "${local.registry_host_prefix[each.key]}.${local.domain_name}"
   image    = docker_image.registry[0].image_id
   restart  = "always"
   dynamic "labels" {

--- a/terraform/workstation/docker/main.tf
+++ b/terraform/workstation/docker/main.tf
@@ -47,7 +47,7 @@ locals {
   dns_ip               = cidrhost(var.network_cidr, 2)
   git_ip               = cidrhost(var.network_cidr, 3)
   registry_keys_sorted = sort(keys(local.registries))
-  # Hostname prefix: when key matches remote URL host, strip last dot-segment (TLD); else use key (e.g. local-only registry).
+  # Keep in sync with workstation/incus registry_hostname_base (same stripping logic).
   registry_host_prefix = {
     for k, v in local.registries : k => (
       v.remote != null

--- a/terraform/workstation/docker/outputs.tf
+++ b/terraform/workstation/docker/outputs.tf
@@ -28,8 +28,8 @@ output "next_ip" {
 }
 
 output "dns_ip" {
-  description = "IPv4 address reserved for the DNS container (cidrhost(network_cidr, 2)). Present in service_ips.dns when enable_dns is true."
-  value       = local.dns_ip
+  description = "Host-facing IP for the DNS container. For docker-desktop runtime, 127.0.0.1 (ports published to localhost); otherwise cidrhost(network_cidr, 2)."
+  value       = local.use_localhost_networking ? "127.0.0.1" : local.dns_ip
 }
 
 output "domain_name" {
@@ -64,5 +64,17 @@ output "containers" {
       { dns = try(docker_container.dns[0].name, null), git = try(docker_container.git[0].name, null) },
       { for rk, rv in docker_container.registry : rk => rv.name }
     ) : k => v if v != null
+  }
+}
+
+output "registries" {
+  description = "Registry config with computed hostname per entry. Merges var.registries with hostname (e.g. gcr.domain_name) for cluster Talos mirrors and other consumers."
+  value = {
+    for k in keys(local.registries) : k => {
+      remote   = try(local.registries[k].remote, null)
+      local    = try(trimprefix(trimprefix(local.registries[k].local, "https://"), "http://"), null)
+      hostport = try(local.registries[k].hostport, null)
+      hostname = "${local.registry_host_prefix[k]}.${local.domain_name}"
+    }
   }
 }

--- a/terraform/workstation/docker/test.tftest.hcl
+++ b/terraform/workstation/docker/test.tftest.hcl
@@ -76,8 +76,8 @@ run "full_configuration" {
     enable_dns   = true
     enable_git   = true
     registries = {
-      gcr  = { remote = "https://gcr.io" }
-      ghcr = { remote = "https://ghcr.io" }
+      "gcr.io"  = { remote = "https://gcr.io" }
+      "ghcr.io" = { remote = "https://ghcr.io" }
     }
   }
 
@@ -117,7 +117,7 @@ run "full_configuration" {
   }
 
   assert {
-    condition     = local.service_ips["gcr"] == "10.20.0.4" && local.service_ips["ghcr"] == "10.20.0.5"
+    condition     = local.service_ips["gcr.io"] == "10.20.0.4" && local.service_ips["ghcr.io"] == "10.20.0.5"
     error_message = "Sequential IPs: first two registries at 4 and 5"
   }
 

--- a/terraform/workstation/docker/test.tftest.hcl
+++ b/terraform/workstation/docker/test.tftest.hcl
@@ -239,6 +239,28 @@ run "webhook_host_docker_desktop_derived" {
   }
 }
 
+# Null registries: blueprint may pass registries = null; module coalesces to {} so no registry containers.
+run "registries_null" {
+  command = plan
+
+  variables {
+    project_root = "/tmp/windsor-test"
+    context      = "test"
+    runtime      = "colima"
+    registries   = null
+  }
+
+  assert {
+    condition     = length(local.registries) == 0
+    error_message = "local.registries should be empty when var.registries is null"
+  }
+
+  assert {
+    condition     = length(docker_container.registry) == 0
+    error_message = "No registry containers when registries is null"
+  }
+}
+
 # Negative: invalid runtime rejected.
 run "invalid_runtime" {
   command         = plan

--- a/terraform/workstation/docker/variables.tf
+++ b/terraform/workstation/docker/variables.tf
@@ -77,27 +77,27 @@ variable "enable_git" {
 }
 
 variable "registries" {
-  description = "Map of registry configs (aligned with windsor docker.registries). Key is hostname prefix (e.g. gcr, registry.k8s). Each entry: remote (proxy upstream URL; Distribution supports only remoteurl, username, password, ttl), hostport (publish port on host, optional). Omit remote for local-only registry. Null is coalesced to empty in the module."
+  description = "Map of registry configs (aligned with windsor docker.registries). Key is registry host (e.g. gcr.io, registry.k8s.io). Each entry: remote (proxy upstream URL; Distribution supports only remoteurl, username, password, ttl), hostport (publish port on host, optional). Omit remote for local-only registry. Null is coalesced to empty in the module."
   type = map(object({
     remote   = optional(string)
     local    = optional(string)
     hostport = optional(number)
   }))
   default = {
-    gcr = {
+    "gcr.io" = {
       remote = "https://gcr.io"
     }
-    ghcr = {
+    "ghcr.io" = {
       remote = "https://ghcr.io"
     }
-    quay = {
+    "quay.io" = {
       remote = "https://quay.io"
     }
-    "registry-1.docker" = {
+    "registry-1.docker.io" = {
       remote = "https://registry-1.docker.io"
       local  = "docker.io"
     }
-    "registry.k8s" = {
+    "registry.k8s.io" = {
       remote = "https://registry.k8s.io"
     }
     registry = {

--- a/terraform/workstation/docker/variables.tf
+++ b/terraform/workstation/docker/variables.tf
@@ -77,7 +77,7 @@ variable "enable_git" {
 }
 
 variable "registries" {
-  description = "Map of registry configs (aligned with windsor docker.registries). Key is hostname prefix (e.g. gcr, registry.k8s). Each entry: remote (proxy upstream URL; Distribution supports only remoteurl, username, password, ttl), hostport (publish port on host, optional). Omit remote for local-only registry."
+  description = "Map of registry configs (aligned with windsor docker.registries). Key is hostname prefix (e.g. gcr, registry.k8s). Each entry: remote (proxy upstream URL; Distribution supports only remoteurl, username, password, ttl), hostport (publish port on host, optional). Omit remote for local-only registry. Null is coalesced to empty in the module."
   type = map(object({
     remote   = optional(string)
     local    = optional(string)
@@ -95,7 +95,7 @@ variable "registries" {
     }
     "registry-1.docker" = {
       remote = "https://registry-1.docker.io"
-      local  = "https://docker.io"
+      local  = "docker.io"
     }
     "registry.k8s" = {
       remote = "https://registry.k8s.io"
@@ -104,6 +104,7 @@ variable "registries" {
       hostport = 5001
     }
   }
+  nullable = true
 }
 
 variable "webhook_token" {

--- a/terraform/workstation/incus/main.tf
+++ b/terraform/workstation/incus/main.tf
@@ -58,7 +58,7 @@ locals {
   registry_ips = {
     for i, k in local.registry_keys_sorted : k => cidrhost(var.network_cidr, 4 + i)
   }
-  # Hostname prefix: when key matches remote URL host, strip last dot-segment (TLD); else use key (e.g. local-only registry).
+  # Keep in sync with workstation/docker registry_host_prefix (same stripping logic).
   registry_hostname_base = {
     for k, v in var.registries : k => (
       v.remote != null

--- a/terraform/workstation/incus/main.tf
+++ b/terraform/workstation/incus/main.tf
@@ -58,11 +58,12 @@ locals {
   registry_ips = {
     for i, k in local.registry_keys_sorted : k => cidrhost(var.network_cidr, 4 + i)
   }
-  # Strip trailing TLD from registry key so hostname is registry.k8s.test not registry.k8s.io.test
-  registry_hostname_tlds = toset(["io", "com", "test", "dev", "org", "net"])
+  # Hostname prefix: when key matches remote URL host, strip last dot-segment (TLD); else use key (e.g. local-only registry).
   registry_hostname_base = {
-    for k in local.registry_keys_sorted : k => (
-      length(split(".", k)) > 1 && contains(local.registry_hostname_tlds, element(split(".", k), length(split(".", k)) - 1))
+    for k, v in var.registries : k => (
+      v.remote != null
+      && split(":", split("/", trimprefix(trimprefix(v.remote, "https://"), "http://"))[0])[0] == k
+      && length(split(".", k)) > 1
       ? join(".", slice(split(".", k), 0, length(split(".", k)) - 1))
       : k
     )
@@ -157,16 +158,14 @@ resource "incus_instance" "dns" {
 
 # =============================================================================
 # Registry cache dirs (Incus requires disk source path to exist before create)
+# Use local_file so the resource is only "created" after the path exists; provisioners
+# run after resource creation so depends_on would not wait for mkdir.
 # =============================================================================
 
-resource "terraform_data" "registry_cache_dirs" {
+resource "local_file" "registry_cache_dir" {
   for_each = var.registries
-  triggers_replace = {
-    path = "${var.project_root}/.windsor/cache/docker/registries/${each.key}"
-  }
-  provisioner "local-exec" {
-    command = "mkdir -p '${var.project_root}/.windsor/cache/docker/registries/${each.key}'"
-  }
+  content  = ""
+  filename = "${var.project_root}/.windsor/cache/docker/registries/${each.key}/.keep"
 }
 
 # =============================================================================
@@ -179,7 +178,7 @@ resource "incus_instance" "registry" {
   type     = "container"
   # renovate: datasource=docker depName=library/registry package=library/registry
   image      = "docker:library/registry:3.0.0"
-  depends_on = [incus_network.main, terraform_data.registry_cache_dirs]
+  depends_on = [incus_network.main, local_file.registry_cache_dir]
   config = each.value.remote != null ? {
     "environment.REGISTRY_PROXY_REMOTEURL" = each.value.remote
   } : {}

--- a/terraform/workstation/incus/outputs.tf
+++ b/terraform/workstation/incus/outputs.tf
@@ -61,3 +61,15 @@ output "containers" {
     ) : k => v if v != null
   }
 }
+
+output "registries" {
+  description = "Registry config with computed hostname per entry. Same shape as workstation/docker for cluster Talos mirrors."
+  value = {
+    for k in keys(var.registries) : k => {
+      remote   = try(var.registries[k].remote, null)
+      local    = try(trimprefix(trimprefix(var.registries[k].local, "https://"), "http://"), null)
+      hostport = try(var.registries[k].hostport, null)
+      hostname = local.registry_hostname[k]
+    }
+  }
+}

--- a/terraform/workstation/incus/test.tftest.hcl
+++ b/terraform/workstation/incus/test.tftest.hcl
@@ -221,9 +221,9 @@ run "registry_hostname_normalization" {
     project_root = "/tmp/windsor-test"
     context      = "test"
     registries = {
-      "gcr.io"         = { remote = "https://gcr.io" }
+      "gcr.io"          = { remote = "https://gcr.io" }
       "registry.k8s.io" = { remote = "https://registry.k8s.io" }
-      registry         = { hostport = 5001 }
+      registry          = { hostport = 5001 }
     }
   }
 

--- a/terraform/workstation/incus/test.tftest.hcl
+++ b/terraform/workstation/incus/test.tftest.hcl
@@ -71,8 +71,8 @@ run "full_configuration" {
     enable_dns   = true
     enable_git   = true
     registries = {
-      gcr  = { remote = "https://gcr.io" }
-      ghcr = { remote = "https://ghcr.io" }
+      "gcr.io"  = { remote = "https://gcr.io" }
+      "ghcr.io" = { remote = "https://ghcr.io" }
     }
   }
 
@@ -102,7 +102,7 @@ run "full_configuration" {
   }
 
   assert {
-    condition     = local.service_ips["gcr"] == "10.20.0.4" && local.service_ips["ghcr"] == "10.20.0.5"
+    condition     = local.service_ips["gcr.io"] == "10.20.0.4" && local.service_ips["ghcr.io"] == "10.20.0.5"
     error_message = "Sequential IPs: first two registries at 4 and 5"
   }
 
@@ -213,7 +213,7 @@ run "create_network_false_uses_existing_network" {
   }
 }
 
-# Registry hostname normalization: keys with trailing TLD (e.g. gcr.io, registry.k8s.io) get single .test.
+# Registry hostname normalization: when key matches remote URL host, strip last dot-segment (TLD); local-only key used as-is.
 run "registry_hostname_normalization" {
   command = plan
 
@@ -221,19 +221,19 @@ run "registry_hostname_normalization" {
     project_root = "/tmp/windsor-test"
     context      = "test"
     registries = {
-      "gcr.io"          = { remote = "https://gcr.io" }
+      "gcr.io"         = { remote = "https://gcr.io" }
       "registry.k8s.io" = { remote = "https://registry.k8s.io" }
-      "registry.test"   = { hostport = 5001 }
+      registry         = { hostport = 5001 }
     }
   }
 
   assert {
-    condition     = local.registry_hostname["gcr.io"] == "gcr.test" && local.registry_hostname["registry.k8s.io"] == "registry.k8s.test" && local.registry_hostname["registry.test"] == "registry.test"
-    error_message = "Trailing TLD stripped from registry key so hostname has single domain: gcr.test, registry.k8s.test, registry.test"
+    condition     = local.registry_hostname["gcr.io"] == "gcr.test" && local.registry_hostname["registry.k8s.io"] == "registry.k8s.test" && local.registry_hostname["registry"] == "registry.test"
+    error_message = "Remote-match keys get TLD stripped (gcr.test, registry.k8s.test); local-only key used as-is (registry.test)"
   }
 
   assert {
-    condition     = incus_instance.registry["gcr.io"].name == "gcr-test" && incus_instance.registry["registry.k8s.io"].name == "registry-k8s-test" && incus_instance.registry["registry.test"].name == "registry-test"
+    condition     = incus_instance.registry["gcr.io"].name == "gcr-test" && incus_instance.registry["registry.k8s.io"].name == "registry-k8s-test" && incus_instance.registry["registry"].name == "registry-test"
     error_message = "Incus instance names are sanitized (dots to hyphens) from normalized hostname"
   }
 }

--- a/terraform/workstation/incus/variables.tf
+++ b/terraform/workstation/incus/variables.tf
@@ -73,27 +73,27 @@ variable "enable_git" {
 }
 
 variable "registries" {
-  description = "Map of registry configs (aligned with windsor docker.registries). Key is hostname prefix (e.g. gcr, registry.k8s). Each entry: remote (proxy upstream URL), hostport (unused for Incus; kept for API compatibility), local. Omit remote for local-only registry."
+  description = "Map of registry configs (aligned with windsor docker.registries). Key is registry host (e.g. gcr.io, registry.k8s.io). Each entry: remote (proxy upstream URL), hostport (unused for Incus; kept for API compatibility), local. Omit remote for local-only registry."
   type = map(object({
     remote   = optional(string)
     local    = optional(string)
     hostport = optional(number)
   }))
   default = {
-    gcr = {
+    "gcr.io" = {
       remote = "https://gcr.io"
     }
-    ghcr = {
+    "ghcr.io" = {
       remote = "https://ghcr.io"
     }
-    quay = {
+    "quay.io" = {
       remote = "https://quay.io"
     }
-    "registry-1.docker" = {
+    "registry-1.docker.io" = {
       remote = "https://registry-1.docker.io"
-      local  = "https://docker.io"
+      local  = "docker.io"
     }
-    "registry.k8s" = {
+    "registry.k8s.io" = {
       remote = "https://registry.k8s.io"
     }
     registry = {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches local-cluster bootstrap/config patch composition (Talos mirrors, cert SANs, health checks), so miswiring could break docker/colima/docker-desktop dev environments despite good test coverage.
> 
> **Overview**
> Improves local *workstation → compute → Talos cluster* wiring by **deriving Talos registry mirrors from workstation Terraform outputs** and normalizing registry hostnames/keys across Docker and Incus (including new `workstation.*` `registries` outputs and null-safe handling).
> 
> Refactors Talos common patch composition: cert rotation settings are centralized under `talos_common.cert_rotation`, registry mirror patches are merged via `option-workstation`, and docker-desktop behavior is tightened (per-node `certSANs` patches for Talos API access, endpoint-host health checks, and updated lb gating/IP calculations). Blueprint and Terraform tests are updated/expanded to assert these composed patches and docker-desktop/colima differences.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b285d14dc16b1145452a3d2a25ab95b34cb88d1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->