### PR TITLE
fix(workstation): Bind dns 127.0.0.1

### DIFF
--- a/terraform/workstation/docker/main.tf
+++ b/terraform/workstation/docker/main.tf
@@ -163,6 +163,7 @@ resource "docker_container" "dns" {
     content {
       internal = 53
       external = 53
+      ip       = "127.0.0.1"
       protocol = "tcp"
     }
   }
@@ -171,6 +172,7 @@ resource "docker_container" "dns" {
     content {
       internal = 53
       external = 53
+      ip       = "127.0.0.1"
       protocol = "udp"
     }
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk Terraform change that only restricts the DNS container's published port exposure to localhost; main potential impact is on users who previously relied on accessing DNS from outside the host.
> 
> **Overview**
> When `publish_ports` is enabled, the DNS container’s TCP/UDP port `53` bindings are now explicitly published to `127.0.0.1` instead of all interfaces, reducing unintended network exposure on developer machines.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac29ef73357d7b39fc771ef20e071010ac867121. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->