### PR TITLE
fix(workstation): Add null safe fix for registries

### DIFF
--- a/terraform/workstation/docker/main.tf
+++ b/terraform/workstation/docker/main.tf
@@ -48,10 +48,15 @@ locals {
   git_ip               = cidrhost(var.network_cidr, 3)
   registry_keys_sorted = sort(keys(local.registries))
   # Keep in sync with workstation/incus registry_hostname_base (same stripping logic).
+  registry_remote_host = {
+    for k, v in local.registries : k => try(
+      split(":", split("/", trimprefix(trimprefix(v.remote, "https://"), "http://"))[0])[0],
+      null
+    )
+  }
   registry_host_prefix = {
     for k, v in local.registries : k => (
-      v.remote != null
-      && split(":", split("/", trimprefix(trimprefix(v.remote, "https://"), "http://"))[0])[0] == k
+      local.registry_remote_host[k] == k
       && length(split(".", k)) > 1
       ? join(".", slice(split(".", k), 0, length(split(".", k)) - 1))
       : k

--- a/terraform/workstation/incus/main.tf
+++ b/terraform/workstation/incus/main.tf
@@ -59,10 +59,15 @@ locals {
     for i, k in local.registry_keys_sorted : k => cidrhost(var.network_cidr, 4 + i)
   }
   # Keep in sync with workstation/docker registry_host_prefix (same stripping logic).
+  registry_remote_host = {
+    for k, v in var.registries : k => try(
+      split(":", split("/", trimprefix(trimprefix(v.remote, "https://"), "http://"))[0])[0],
+      null
+    )
+  }
   registry_hostname_base = {
     for k, v in var.registries : k => (
-      v.remote != null
-      && split(":", split("/", trimprefix(trimprefix(v.remote, "https://"), "http://"))[0])[0] == k
+      local.registry_remote_host[k] == k
       && length(split(".", k)) > 1
       ? join(".", slice(split(".", k), 0, length(split(".", k)) - 1))
       : k


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk Terraform change that only affects how registry hostnames/prefixes are derived when `registries[*].remote` is null or unparsable; potential impact is limited to registry DNS/container naming.
> 
> **Overview**
> Prevents workstation Terraform from failing when a registry entry has a null (or otherwise unparsable) `remote` URL.
> 
> Both `workstation/docker` and `workstation/incus` now precompute `registry_remote_host` with `try(...)` and base `registry_host_prefix`/`registry_hostname_base` decisions on that value, keeping hostname derivation consistent across runtimes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ebc32e7bafd07baafdbbb3f8b8d7725411197c6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->