### PR TITLE
chore(deps): Pin image refs and repair renovate

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -27,3 +27,6 @@ Descriptions (schema, docs, UI copy) state what something is or does; they do no
 
 ## BLUEPRINT DEBUGGING
 For facet/blueprint issues use: `windsor test` (blueprint tests) and `windsor show blueprint` (composed blueprint output) to inspect config and Terraform inputs. `windsor test` uses mocked terraformOutputs and does not run real composition—it can pass even when `windsor show blueprint` fails.
+
+## KUBERNETES DEBUGGING CONTEXT
+For live cluster diagnostics in local environments, run Kubernetes commands through Windsor context execution: `windsor exec -- kubectl ...` rather than direct `kubectl ...` to ensure the active Windsor context and kubeconfig are used consistently.

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -148,15 +148,33 @@
         "/^.*\\.tf$/",
         "/^.*\\.tfvars$/"
       ],
+      "description": "Parse helm annotations with explicit helmRepo",
       "matchStrings": [
-        "\\s*#\\s*renovate:\\s*datasource=(?<datasource>[^\\s]+)\\s*depName=(?<depName>[^\\s]+)\\s*package=(?<package>[^\\s]+)(\\s+helmRepo=(?<helmRepo>[^\\s]+))?[^\\n]*\\n[^\\n]*[:\\s](?<currentValue>v?\\d+\\.\\d+\\.\\d+(-[a-zA-Z0-9]+)?)(?:@(?<currentDigest>sha256:[a-f0-9]{64})|[\\s@]|$)",
-        "\\s*#\\s*renovate:\\s*datasource=(?<datasource>[^\\s]+)\\s*depName=(?<depName>[^\\s]+)\\s*package=(?<package>[^\\s]+)(\\s+helmRepo=(?<helmRepo>[^\\s]+))?[^\\n]*\\n[^\\n]*[:\\s](?<currentValue>v?\\d+\\.\\d+)(?:@(?<currentDigest>sha256:[a-f0-9]{64})|[\\s@]|$)"
+        "\\s*#\\s*renovate:\\s*datasource=(?<datasource>[^\\s]+)\\s*depName=(?<depName>[^\\s]+)\\s*package=(?<package>[^\\s]+)\\s+helmRepo=(?<helmRepo>[^\\s]+)[^\\n]*\\n[^\\n]*[:\\s][\"']?(?<currentValue>v?\\d+\\.\\d+\\.\\d+(-[a-zA-Z0-9]+)?)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?(?:[\\s\"']|$)",
+        "\\s*#\\s*renovate:\\s*datasource=(?<datasource>[^\\s]+)\\s*depName=(?<depName>[^\\s]+)\\s*package=(?<package>[^\\s]+)\\s+helmRepo=(?<helmRepo>[^\\s]+)[^\\n]*\\n[^\\n]*[:\\s][\"']?(?<currentValue>v?\\d+\\.\\d+)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?(?:[\\s\"']|$)"
       ],
       "versioningTemplate": "semver",
       "datasourceTemplate": "{{datasource}}",
       "packageNameTemplate": "{{package}}",
       "depNameTemplate": "{{depName}}",
       "registryUrlTemplate": "{{helmRepo}}"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^.*\\.ya?ml$/",
+        "/^.*\\.tf$/",
+        "/^.*\\.tfvars$/"
+      ],
+      "description": "Parse non-helm renovate annotations",
+      "matchStrings": [
+        "\\s*#\\s*renovate:\\s*datasource=(?<datasource>[^\\s]+)\\s*depName=(?<depName>[^\\s]+)\\s*package=(?<package>[^\\s]+)\\s*\\n[^\\n]*[:\\s][\"']?(?<currentValue>v?\\d+\\.\\d+\\.\\d+(-[a-zA-Z0-9]+)?)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?(?:[\\s\"']|$)",
+        "\\s*#\\s*renovate:\\s*datasource=(?<datasource>[^\\s]+)\\s*depName=(?<depName>[^\\s]+)\\s*package=(?<package>[^\\s]+)\\s*\\n[^\\n]*[:\\s][\"']?(?<currentValue>v?\\d+\\.\\d+)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?(?:[\\s\"']|$)"
+      ],
+      "versioningTemplate": "semver",
+      "datasourceTemplate": "{{datasource}}",
+      "packageNameTemplate": "{{package}}",
+      "depNameTemplate": "{{depName}}"
     },
     {
       "description": "Handle date-based Docker image tags (e.g., trust-pkg-debian-bookworm)",
@@ -188,6 +206,9 @@
     }
   ],
   "platformAutomerge": true,
+  "addLabels": [
+    "dependencies"
+  ],
   "labels": [
     "dependencies"
   ]

--- a/kustomize/policy/base/kyverno/helm-release.yaml
+++ b/kustomize/policy/base/kyverno/helm-release.yaml
@@ -16,27 +16,45 @@ spec:
         name: kyverno
         namespace: system-gitops
   values:
-    image:
-      # renovate: datasource=docker depName=ghcr.io/kyverno/kyverno package=ghcr.io/kyverno/kyverno
-      tag: v3.6.0@sha256:89a052af62c612d0e05d2596f03edba77d7d904c4478b387a5dc6305821fe0a1
+    crds:
+      migration:
+        image:
+          # renovate: datasource=docker depName=reg.kyverno.io/kyverno/kyverno-cli package=reg.kyverno.io/kyverno/kyverno-cli
+          tag: v1.16.2@sha256:f1a4dd586f118ca24d1fb768b8791a506231748d41cb490dfff04b66b2738079
     # Disable ANSI color codes in logs
     admissionController:
+      initContainer:
+        image:
+          # renovate: datasource=docker depName=reg.kyverno.io/kyverno/kyvernopre package=reg.kyverno.io/kyverno/kyvernopre
+          tag: v1.16.2@sha256:ba3a31b25a9e1c6f993d7555158396d87790445ddc785426c249e8320b94b02a
       container:
+        image:
+          # renovate: datasource=docker depName=reg.kyverno.io/kyverno/kyverno package=reg.kyverno.io/kyverno/kyverno
+          tag: v1.16.2@sha256:b0c123d62a1b8e21da707450ef44c4616832434f919d1cd19cfdbe2836277699
         extraEnvVars:
         - name: NO_COLOR
           value: "1"
     backgroundController:
       container:
+        image:
+          # renovate: datasource=docker depName=reg.kyverno.io/kyverno/background-controller package=reg.kyverno.io/kyverno/background-controller
+          tag: v1.16.2@sha256:736c5da855863a3b15ee0e272f5b9e72c3c1b2f221f8345664354f57a5dc0f25
         extraEnvVars:
         - name: NO_COLOR
           value: "1"
     cleanupController:
       container:
+        image:
+          # renovate: datasource=docker depName=reg.kyverno.io/kyverno/cleanup-controller package=reg.kyverno.io/kyverno/cleanup-controller
+          tag: v1.16.2@sha256:1bf6d0501d7f16aa5d36821f907287d8653564c642866c4b597f2e6abc527390
         extraEnvVars:
         - name: NO_COLOR
           value: "1"
     reportsController:
       container:
+        image:
+          # renovate: datasource=docker depName=reg.kyverno.io/kyverno/reports-controller package=reg.kyverno.io/kyverno/reports-controller
+          tag: v1.16.2@sha256:88d0dfc245a689e9bf3e258159b539f3a1b1a5a89f82b6a07c12762527bb7793
         extraEnvVars:
         - name: NO_COLOR
           value: "1"

--- a/terraform/gitops/flux/main.tf
+++ b/terraform/gitops/flux/main.tf
@@ -55,7 +55,20 @@ resource "helm_release" "flux_system" {
   create_namespace = false
   wait             = true
   values = [yamlencode({
+    imageAutomationController = {
+      image = "ghcr.io/fluxcd/image-automation-controller"
+      # renovate: datasource=docker depName=ghcr.io/fluxcd/image-automation-controller package=ghcr.io/fluxcd/image-automation-controller
+      tag = "v1.0.2@sha256:a28eccd31409191131377ecf888a168c59e9a72578e71139b81b146d813c8335"
+    }
+    imageReflectionController = {
+      image = "ghcr.io/fluxcd/image-reflector-controller"
+      # renovate: datasource=docker depName=ghcr.io/fluxcd/image-reflector-controller package=ghcr.io/fluxcd/image-reflector-controller
+      tag = "v1.0.2@sha256:a2dba78aa10c1a3905652f6cea39c4fc9c9688755e63dc1f38a0a0306bda54ce"
+    }
     kustomizeController = {
+      image = "ghcr.io/fluxcd/kustomize-controller"
+      # renovate: datasource=docker depName=ghcr.io/fluxcd/kustomize-controller package=ghcr.io/fluxcd/kustomize-controller
+      tag = "v1.7.1@sha256:2b51e7a48594263ece5d86636a9b95381b19fc3091e7341a88802f4557b35a53"
       container = {
         additionalArgs = [
           "--concurrent=${var.concurrency}",
@@ -69,6 +82,9 @@ resource "helm_release" "flux_system" {
       }
     }
     helmController = {
+      image = "ghcr.io/fluxcd/helm-controller"
+      # renovate: datasource=docker depName=ghcr.io/fluxcd/helm-controller package=ghcr.io/fluxcd/helm-controller
+      tag = "v1.4.2@sha256:32dd3ec7a138245ff4cd755439099c544f4ce3a55f95aa69a97106c05a661def"
       container = {
         additionalArgs = [
           "--concurrent=${max(2, var.concurrency - 1)}",
@@ -76,12 +92,20 @@ resource "helm_release" "flux_system" {
         ]
       }
     }
+    notificationController = {
+      image = "ghcr.io/fluxcd/notification-controller"
+      # renovate: datasource=docker depName=ghcr.io/fluxcd/notification-controller package=ghcr.io/fluxcd/notification-controller
+      tag = "v1.7.3@sha256:55813e89e49509e5a312682759b7a4d5235ecc2e13a1eb70f917faf769596b07"
+    }
     sourceController = {
+      image = "ghcr.io/fluxcd/source-controller"
+      # renovate: datasource=docker depName=ghcr.io/fluxcd/source-controller package=ghcr.io/fluxcd/source-controller
+      tag = "v1.7.2@sha256:030e258b636fede22a41bcaea3ea4542035cc280b0c740f641c4c5efb904b980"
       container = {
         additionalArgs = [
           "--concurrent=${var.concurrency}",
           "--requeue-dependency=${local.requeue_interval}",
-          "--helm-cache-max-size=10",
+          "--helm-cache-max-size=200",
           "--helm-cache-ttl=60m",
           "--helm-cache-purge-interval=5m"
         ]

--- a/terraform/workstation/docker/main.tf
+++ b/terraform/workstation/docker/main.tf
@@ -197,7 +197,8 @@ resource "docker_container" "dns" {
 
 resource "docker_image" "registry" {
   count = length(local.registries) > 0 ? 1 : 0
-  name  = "registry:3.0.0"
+  # renovate: datasource=docker depName=ghcr.io/distribution/distribution package=ghcr.io/distribution/distribution
+  name = "ghcr.io/distribution/distribution:3.0.0"
 }
 
 resource "docker_container" "registry" {

--- a/terraform/workstation/docker/main.tf
+++ b/terraform/workstation/docker/main.tf
@@ -198,7 +198,7 @@ resource "docker_container" "dns" {
 resource "docker_image" "registry" {
   count = length(local.registries) > 0 ? 1 : 0
   # renovate: datasource=docker depName=ghcr.io/distribution/distribution package=ghcr.io/distribution/distribution
-  name = "ghcr.io/distribution/distribution:3.0.0"
+  name = "ghcr.io/distribution/distribution:3.0.0@sha256:4ba3adf47f5c866e9a29288c758c5328ef03396cb8f5f6454463655fa8bc83e2"
 }
 
 resource "docker_container" "registry" {

--- a/terraform/workstation/incus/main.tf
+++ b/terraform/workstation/incus/main.tf
@@ -35,6 +35,12 @@ provider "incus" {
     protocol = "oci"
     public   = true
   }
+  remote {
+    name     = "registryk8s"
+    address  = "https://registry.k8s.io"
+    protocol = "oci"
+    public   = true
+  }
 }
 
 # =============================================================================
@@ -128,8 +134,8 @@ resource "incus_instance" "dns" {
   count = var.enable_dns ? 1 : 0
   name  = replace("dns.${local.domain_name}", ".", "-")
   type  = "container"
-  # renovate: datasource=docker depName=coredns/coredns package=coredns/coredns
-  image = "docker:coredns/coredns:1.14.1"
+  # renovate: datasource=docker depName=registry.k8s.io/coredns/coredns package=registry.k8s.io/coredns/coredns
+  image = "registryk8s:coredns/coredns:v1.14.1"
   config = {
     "raw.lxc"        = "lxc.apparmor.profile=unconfined"
     "oci.entrypoint" = "/coredns -conf /etc/coredns/Corefile"
@@ -181,8 +187,8 @@ resource "incus_instance" "registry" {
   for_each = var.registries
   name     = replace(local.registry_hostname[each.key], ".", "-")
   type     = "container"
-  # renovate: datasource=docker depName=library/registry package=library/registry
-  image      = "docker:library/registry:3.0.0"
+  # renovate: datasource=docker depName=ghcr.io/distribution/distribution package=ghcr.io/distribution/distribution
+  image      = "ghcr:distribution/distribution:3.0.0"
   depends_on = [incus_network.main, local_file.registry_cache_dir]
   config = each.value.remote != null ? {
     "environment.REGISTRY_PROXY_REMOTEURL" = each.value.remote

--- a/terraform/workstation/incus/main.tf
+++ b/terraform/workstation/incus/main.tf
@@ -188,7 +188,7 @@ resource "incus_instance" "registry" {
   name     = replace(local.registry_hostname[each.key], ".", "-")
   type     = "container"
   # renovate: datasource=docker depName=ghcr.io/distribution/distribution package=ghcr.io/distribution/distribution
-  image      = "ghcr:distribution/distribution:3.0.0"
+  image      = "ghcr:distribution/distribution:3.0.0@sha256:4ba3adf47f5c866e9a29288c758c5328ef03396cb8f5f6454463655fa8bc83e2"
   depends_on = [incus_network.main, local_file.registry_cache_dir]
   config = each.value.remote != null ? {
     "environment.REGISTRY_PROXY_REMOTEURL" = each.value.remote


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes pinned container images/digests for core cluster components (Flux, Kyverno) and adjusts workstation registry/DNS image sources, which can affect runtime behavior if tags/digests or registries are incorrect.
> 
> **Overview**
> **Pins and standardizes container image references** across GitOps and local workstation modules, switching several components to explicit `image` + digest-pinned `tag` values (notably Flux controllers and Kyverno images) and increasing Flux `source-controller` helm cache size.
> 
> **Repairs Renovate extraction** by tightening the regex manager to require `helmRepo` for Helm annotations, adding a separate manager for non-Helm annotations, and ensuring dependency PRs are consistently labeled `dependencies`.
> 
> **Workstation image source updates** switch registry images from `library/registry`/`registry:3.0.0` to `ghcr.io/distribution/distribution` with a pinned digest, and update Incus to pull CoreDNS from `registry.k8s.io` via a new `registryk8s` remote.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9171054bbe919976b69094d170ce536bb2b30153. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->