### PR TITLE
chore(config): Fully replace vm.driver with workstation.runtime

### DIFF
--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -4,13 +4,13 @@ metadata:
   name: workstation
   description: Workstation stack for local development and cluster infrastructure.
 
-# Docker: facet applies when workstation not disabled (default on). Incus: facet applies only when workstation enabled (default off). Workstation stack blocks are gated per block.
-when: "(platform == 'docker' && (workstation.enabled ?? true)) || (platform == 'incus' && (workstation.enabled ?? false))"
+# Facet applies when workstation.runtime is set (docker-desktop, colima, docker).
+when: "workstation.runtime != null && workstation.runtime != ''"
 
 config:
   - name: workstation
     value:
-      runtime: "${workstation.runtime ?? vm.driver ?? \"colima\"}"
+      runtime: "${workstation.runtime ?? ''}"
       arch: "${workstation.arch ?? 'amd64'}"
 
   # Talos image refs for workstation compute (docker/incus). Only relevant when workstation stack runs; providers use talos_version fallback when not.

--- a/contexts/_template/facets/provider-docker.yaml
+++ b/contexts/_template/facets/provider-docker.yaml
@@ -26,7 +26,7 @@ terraform:
 # hostname stripped for containers (Talos 1.12 rejects setting hostname when runtime already set it).
 # When workstation enabled and cluster enabled, cluster must wait for compute (workstation → compute → cluster). Omit when cluster disabled (no compute).
 - name: cluster
-  when: workstation.enabled == true && (cluster.enabled ?? true)
+  when: workstation.runtime != null && workstation.runtime != '' && (cluster.enabled ?? true)
   path: cluster/talos
   dependsOn:
     - compute

--- a/contexts/_template/facets/provider-incus.yaml
+++ b/contexts/_template/facets/provider-incus.yaml
@@ -23,12 +23,12 @@ terraform:
   when: "workstation.runtime == null || workstation.runtime == ''"
   path: compute/incus
   inputs:
-    network_name: "${(workstation.runtime ?? '') == 'colima' ? 'incusbr0' : ''}"
-    create_network: "${(workstation.runtime ?? '') != 'colima'}"
+    network_name: ""
+    create_network: true
     network_cidr: ${network.cidr_block}
     storage_pools:
       local:
-        driver: "${(workstation.runtime ?? '') == 'colima' ? 'dir' : null}"
+        driver: null
     instances:
       - name: controlplane
         role: controlplane
@@ -37,7 +37,7 @@ terraform:
         image: ${cluster.controlplanes.image ?? ("windsor:talos/v" + talos.talos_version + "/amd64")}
         type: virtual-machine
         description: Talos control plane node
-        storage_pool: "${(workstation.runtime ?? '') == 'colima' ? 'local' : 'default'}"
+        storage_pool: "default"
         root_disk_size: ${string(cluster.controlplanes.root_disk_size ?? 30) + "GB"}
         limits:
           cpu: ${string(cluster.controlplanes.cpu ?? 2)}

--- a/contexts/_template/facets/provider-incus.yaml
+++ b/contexts/_template/facets/provider-incus.yaml
@@ -20,7 +20,7 @@ config:
 terraform:
 
 - name: compute
-  when: "(workstation.enabled != true)"
+  when: "workstation.runtime == null || workstation.runtime == ''"
   path: compute/incus
   inputs:
     network_name: "${(workstation.runtime ?? '') == 'colima' ? 'incusbr0' : ''}"
@@ -66,7 +66,7 @@ terraform:
           raw.qemu: -boot order=c,menu=off
 
 - name: cluster
-  when: "(workstation.enabled != true)"
+  when: "workstation.runtime == null || workstation.runtime == ''"
   path: cluster/talos
   dependsOn:
   - compute

--- a/contexts/_template/schema.yaml
+++ b/contexts/_template/schema.yaml
@@ -376,13 +376,13 @@ properties:
     properties:
       domain:
         type: string
-        description: Single domain for local/private DNS (used by workstation, addons when set)
+        description: Base domain; used as fallback when public_domain or private_domain are not set
       public_domain:
         type: string
-        description: Public domain name
+        description: Public DNS zone (e.g. Route53 hosted zone)
       private_domain:
         type: string
-        description: Private domain name
+        description: Private DNS zone (e.g. in-cluster CoreDNS, workstation resolver)
     additionalProperties: false
 
   # Ingress configuration
@@ -452,6 +452,19 @@ properties:
           - docker-desktop
           - docker
         description: Host runtime for local clusters. VM-backed (colima, docker-desktop) or plain engine (docker). When unset, falls back to vm.driver.
+      dns:
+        type: object
+        description: Workstation-specific DNS state (server address, forwarders)
+        properties:
+          address:
+            type: string
+            description: DNS server address resolved from workstation infrastructure
+          forward:
+            type: array
+            items:
+              type: string
+            description: Forward DNS servers
+        additionalProperties: false
       services:
         type: object
         properties:

--- a/contexts/_template/tests/addon-object-store.test.yaml
+++ b/contexts/_template/tests/addon-object-store.test.yaml
@@ -32,8 +32,8 @@ cases:
   - name: full config creates MinIO object store with ingress dependency
     values:
       provider: metal
-      vm:
-        driver: colima
+      workstation:
+        runtime: colima
       ingress:
         enabled: true
         driver: nginx
@@ -72,8 +72,8 @@ cases:
   - name: fails when MinIO enabled without ingress
     values:
       provider: metal
-      vm:
-        driver: docker-desktop
+      workstation:
+        runtime: docker-desktop
       ingress: *ingress-disabled
       network: *default-network
       cluster: *default-cluster

--- a/contexts/_template/tests/addon-observability.test.yaml
+++ b/contexts/_template/tests/addon-observability.test.yaml
@@ -234,8 +234,8 @@ cases:
   - name: fails when elasticsearch selected without ingress
     values:
       provider: metal
-      vm:
-        driver: docker-desktop
+      workstation:
+        runtime: docker-desktop
       ingress: *ingress-disabled
       network: *default-network
       cluster: *default-cluster

--- a/contexts/_template/tests/addon-private-dns.test.yaml
+++ b/contexts/_template/tests/addon-private-dns.test.yaml
@@ -55,8 +55,8 @@ cases:
     values:
       provider: metal
       dev: true
-      vm:
-        driver: docker-desktop
+      workstation:
+        runtime: docker-desktop
       ingress:
         enabled: true
         driver: nginx

--- a/contexts/_template/tests/option-workstation.test.yaml
+++ b/contexts/_template/tests/option-workstation.test.yaml
@@ -45,9 +45,7 @@ cases:
     values:
       provider: docker
       workstation:
-        enabled: true
-      vm:
-        driver: colima
+        runtime: colima
       dns: *default-dns
       ingress: *ingress-disabled
       network: *default-network
@@ -75,14 +73,12 @@ cases:
           path: gitops/flux
           destroy: false
 
-  # Full: fully populated cluster, vm.driver, dns, volumes
+  # Full: fully populated cluster, dns, volumes
   - name: full workstation with cluster options and colima
     values:
       provider: docker
       workstation:
-        enabled: true
-      vm:
-        driver: colima
+        runtime: colima
       dns: *default-dns
       ingress: *ingress-disabled
       network: *default-network
@@ -115,9 +111,7 @@ cases:
     values:
       provider: docker
       workstation:
-        enabled: true
-      vm:
-        driver: colima
+        runtime: colima
       dns: *default-dns
       ingress: *ingress-disabled
       network: *default-network
@@ -135,15 +129,13 @@ cases:
         - name: workstation
           path: workstation/docker
 
-  # Edge: workstation.runtime set explicitly overrides vm.driver (config merge); runtime docker → loadbalancer present
-  - name: workstation runtime override uses explicit runtime not vm.driver
+  # Edge: workstation.runtime docker → loadbalancer present
+  - name: workstation runtime docker yields loadbalancer
     values:
       provider: docker
       workstation:
         enabled: true
         runtime: docker
-      vm:
-        driver: colima
       dns: *default-dns
       ingress: *ingress-disabled
       network: *default-network
@@ -167,11 +159,9 @@ cases:
     values:
       provider: docker
       workstation:
-        enabled: true
+        runtime: colima
         services:
           registries: false
-      vm:
-        driver: colima
       dns: *default-dns
       ingress: *ingress-disabled
       network: *default-network
@@ -191,9 +181,7 @@ cases:
     values:
       provider: incus
       workstation:
-        enabled: true
-      vm:
-        driver: colima
+        runtime: colima
       dns: *default-dns
       ingress: *ingress-disabled
       network: *default-network
@@ -250,14 +238,12 @@ cases:
                   config: {}
                   mirrors: {}
 
-  # Edge: vm.driver docker-desktop — no lb kustomize components. Asserts workstation inputs use 4+len(registries) for IPs.
+  # Edge: docker-desktop — no lb kustomize components. Asserts workstation inputs use 4+len(registries) for IPs.
   - name: docker-desktop workstation has node hostport dns and no lb
     values:
       provider: docker
       workstation:
-        enabled: true
-      vm:
-        driver: docker-desktop
+        runtime: docker-desktop
       dns: *default-dns
       ingress: *ingress-disabled
       network: *default-network

--- a/contexts/_template/tests/option-workstation.test.yaml
+++ b/contexts/_template/tests/option-workstation.test.yaml
@@ -134,7 +134,6 @@ cases:
     values:
       provider: docker
       workstation:
-        enabled: true
         runtime: docker
       dns: *default-dns
       ingress: *ingress-disabled

--- a/contexts/_template/tests/provider-docker.test.yaml
+++ b/contexts/_template/tests/provider-docker.test.yaml
@@ -62,9 +62,7 @@ cases:
     values:
       provider: docker
       workstation:
-        enabled: true
-      vm:
-        driver: colima
+        runtime: colima
       dns: *default-dns
       ingress: *ingress-disabled
       network: *default-network
@@ -179,9 +177,7 @@ cases:
     values:
       platform: docker
       workstation:
-        enabled: true
-      vm:
-        driver: colima
+        runtime: colima
       dns: *default-dns
       ingress: *ingress-disabled
       network: *default-network
@@ -218,9 +214,7 @@ cases:
     values:
       provider: docker
       workstation:
-        enabled: true
-      vm:
-        driver: colima
+        runtime: colima
       dns: *default-dns
       ingress:
         enabled: true
@@ -348,10 +342,6 @@ cases:
   - name: docker without workstation has no cluster terraform
     values:
       provider: docker
-      workstation:
-        enabled: false
-      vm:
-        driver: colima
       ingress: *ingress-disabled
       network: *default-network
       cluster: *default-cluster
@@ -363,9 +353,7 @@ cases:
     values:
       provider: docker
       workstation:
-        enabled: true
-      vm:
-        driver: docker-desktop
+        runtime: docker-desktop
       dns: *default-dns
       ingress: *ingress-disabled
       network: *default-network

--- a/contexts/_template/tests/provider-incus.test.yaml
+++ b/contexts/_template/tests/provider-incus.test.yaml
@@ -51,8 +51,6 @@ cases:
   - name: minimal config creates compute and cluster terraform chain with defaults
     values:
       provider: incus
-      vm:
-        driver: ""
       ingress: *ingress-disabled
       network: *default-network
       cluster: *default-cluster
@@ -110,8 +108,6 @@ cases:
   - name: full config with custom network, MetalLB, ingress, and all cluster options
     values:
       provider: incus
-      vm:
-        driver: ""
       ingress:
         enabled: true
         driver: nginx
@@ -227,8 +223,6 @@ cases:
   - name: colima-incus uses compute/incus not docker stack
     values:
       provider: incus
-      vm:
-        driver: colima-incus
       ingress: *ingress-disabled
       network: *default-network
       cluster: *default-cluster
@@ -244,20 +238,20 @@ cases:
         - name: workstation
         - path: compute/docker
 
-  # Edge case: Colima uses existing network
+  # Edge case: Colima uses existing incusbr0 network (workstation path sets network_name directly)
   - name: Colima uses existing incusbr0 network
     values:
       provider: incus
-      vm:
-        driver: colima
+      workstation:
+        runtime: colima
       ingress: *ingress-disabled
       network: *default-network
       cluster: *default-cluster
     terraformOutputs: *default-terraform-outputs
     expect:
       terraform:
-        - name: compute
-          path: compute/incus
+        - name: workstation
+          path: workstation/incus
           inputs:
             network_name: incusbr0
             create_network: false

--- a/contexts/_template/tests/provider-metal.test.yaml
+++ b/contexts/_template/tests/provider-metal.test.yaml
@@ -139,8 +139,8 @@ cases:
   - name: full config with MetalLB, custom resources, ingress, and custom worker volume
     values:
       provider: metal
-      vm:
-        driver: colima
+      workstation:
+        runtime: colima
       ingress:
         enabled: true
         driver: nginx


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the gating conditions for running workstation/compute/cluster Terraform stacks (Docker and Incus) and alters Incus networking defaults, which could change when infrastructure is created in existing configs.
> 
> **Overview**
> Shifts local-dev stack activation from `workstation.enabled`/`vm.driver` to explicit `workstation.runtime`, with the workstation facet only applying when `workstation.runtime` is non-empty and the Docker provider’s `cluster` Terraform run gated on the same condition.
> 
> Adjusts the Incus provider so its standalone `compute`/`cluster` stacks run only when `workstation.runtime` is unset, and simplifies Incus compute inputs (always create a network, default storage pool, no Colima-specific overrides). Updates the config schema to add `workstation.dns` state and refreshes DNS field descriptions, and rewrites all affected facet tests to use `workstation.runtime` instead of `vm.driver`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c668210825c5bf3ceeef377e0c078bafd5fa900. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->