### PR TITLE
chore(deps): Upgrade to aks 1.33

### DIFF
--- a/terraform/cluster/azure-aks/README.md
+++ b/terraform/cluster/azure-aks/README.md
@@ -99,7 +99,7 @@ No modules.
 | <a name="input_image_cleaner_interval_hours"></a> [image\_cleaner\_interval\_hours](#input\_image\_cleaner\_interval\_hours) | Interval in hours for Image Cleaner to run | `number` | `48` | no |
 | <a name="input_key_vault_key_id"></a> [key\_vault\_key\_id](#input\_key\_vault\_key\_id) | The ID of an existing Key Vault key to use for disk encryption. If null, a new key will be created. | `string` | `null` | no |
 | <a name="input_kubelogin_mode"></a> [kubelogin\_mode](#input\_kubelogin\_mode) | Login mode for kubelogin convert-kubeconfig. If set, converts the kubeconfig to use this login mode. Valid values: devicecode, interactive, spn, ropc, msi, azurecli, azd, workloadidentity, azurepipelines. Leave empty to skip conversion and use the default devicecode mode from Azure. | `string` | `""` | no |
-| <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Version of Kubernetes to use | `string` | `"1.32"` | no |
+| <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Version of Kubernetes to use | `string` | `"1.33"` | no |
 | <a name="input_local_account_disabled"></a> [local\_account\_disabled](#input\_local\_account\_disabled) | Whether to disable local accounts for the AKS cluster | `bool` | `true` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the resource | `string` | `"cluster"` | no |
 | <a name="input_network_acls_default_action"></a> [network\_acls\_default\_action](#input\_network\_acls\_default\_action) | The default action for the AKS cluster's network ACLs | `string` | `"Allow"` | no |

--- a/terraform/cluster/azure-aks/README.md
+++ b/terraform/cluster/azure-aks/README.md
@@ -99,7 +99,7 @@ No modules.
 | <a name="input_image_cleaner_interval_hours"></a> [image\_cleaner\_interval\_hours](#input\_image\_cleaner\_interval\_hours) | Interval in hours for Image Cleaner to run | `number` | `48` | no |
 | <a name="input_key_vault_key_id"></a> [key\_vault\_key\_id](#input\_key\_vault\_key\_id) | The ID of an existing Key Vault key to use for disk encryption. If null, a new key will be created. | `string` | `null` | no |
 | <a name="input_kubelogin_mode"></a> [kubelogin\_mode](#input\_kubelogin\_mode) | Login mode for kubelogin convert-kubeconfig. If set, converts the kubeconfig to use this login mode. Valid values: devicecode, interactive, spn, ropc, msi, azurecli, azd, workloadidentity, azurepipelines. Leave empty to skip conversion and use the default devicecode mode from Azure. | `string` | `""` | no |
-| <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Version of Kubernetes to use | `string` | `"1.33"` | no |
+| <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Version of Kubernetes to use | `string` | `"1.34"` | no |
 | <a name="input_local_account_disabled"></a> [local\_account\_disabled](#input\_local\_account\_disabled) | Whether to disable local accounts for the AKS cluster | `bool` | `true` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the resource | `string` | `"cluster"` | no |
 | <a name="input_network_acls_default_action"></a> [network\_acls\_default\_action](#input\_network\_acls\_default\_action) | The default action for the AKS cluster's network ACLs | `string` | `"Allow"` | no |

--- a/terraform/cluster/azure-aks/test.tftest.hcl
+++ b/terraform/cluster/azure-aks/test.tftest.hcl
@@ -38,7 +38,7 @@ run "minimal_configuration" {
   variables {
     context_id         = "test"
     name               = "windsor-aks"
-    kubernetes_version = "1.32"
+    kubernetes_version = "1.33"
   }
 
   assert {
@@ -187,7 +187,7 @@ run "full_configuration" {
     name                      = "windsor-aks"
     cluster_name              = "test-cluster"
     resource_group_name       = "test-rg"
-    kubernetes_version        = "1.32"
+    kubernetes_version        = "1.33"
     oidc_issuer_enabled       = true
     workload_identity_enabled = true
     default_node_pool = {
@@ -426,7 +426,7 @@ run "private_cluster" {
     name                    = "windsor-aks"
     cluster_name            = "test-cluster"
     private_cluster_enabled = true
-    kubernetes_version      = "1.32"
+    kubernetes_version      = "1.33"
   }
 
   assert {
@@ -482,7 +482,7 @@ run "authorized_ip_ranges" {
     context_id           = "test"
     name                 = "windsor-aks"
     cluster_name         = "test-cluster"
-    kubernetes_version   = "1.32"
+    kubernetes_version   = "1.33"
     authorized_ip_ranges = ["10.0.0.0/8", "192.168.0.0/16"]
   }
 
@@ -512,7 +512,7 @@ run "azure_rbac_with_admin_object_ids" {
     context_id             = "test"
     name                   = "windsor-aks"
     cluster_name           = "test-cluster"
-    kubernetes_version     = "1.32"
+    kubernetes_version     = "1.33"
     local_account_disabled = true
     admin_object_ids       = ["33333333-3333-3333-3333-333333333333", "44444444-4444-4444-4444-444444444444"]
   }
@@ -566,7 +566,7 @@ run "multiple_invalid_inputs" {
   ]
   variables {
     context_id         = "test"
-    kubernetes_version = "v1.32"
+    kubernetes_version = "v1.33"
     outbound_type      = "invalid"
   }
 }
@@ -579,7 +579,7 @@ run "disk_encryption_with_provided_key" {
   variables {
     context_id              = "test"
     name                    = "windsor-aks"
-    kubernetes_version      = "1.32"
+    kubernetes_version      = "1.33"
     disk_encryption_enabled = true
     key_vault_key_id        = "https://test-kv.vault.azure.net/keys/test-key/abc123"
   }
@@ -608,7 +608,7 @@ run "volume_snapshots_disabled" {
   variables {
     context_id              = "test"
     name                    = "windsor-aks"
-    kubernetes_version      = "1.32"
+    kubernetes_version      = "1.33"
     enable_volume_snapshots = false
   }
 

--- a/terraform/cluster/azure-aks/test.tftest.hcl
+++ b/terraform/cluster/azure-aks/test.tftest.hcl
@@ -38,7 +38,7 @@ run "minimal_configuration" {
   variables {
     context_id         = "test"
     name               = "windsor-aks"
-    kubernetes_version = "1.33"
+    kubernetes_version = "1.34"
   }
 
   assert {
@@ -187,7 +187,7 @@ run "full_configuration" {
     name                      = "windsor-aks"
     cluster_name              = "test-cluster"
     resource_group_name       = "test-rg"
-    kubernetes_version        = "1.33"
+    kubernetes_version        = "1.34"
     oidc_issuer_enabled       = true
     workload_identity_enabled = true
     default_node_pool = {
@@ -426,7 +426,7 @@ run "private_cluster" {
     name                    = "windsor-aks"
     cluster_name            = "test-cluster"
     private_cluster_enabled = true
-    kubernetes_version      = "1.33"
+    kubernetes_version      = "1.34"
   }
 
   assert {
@@ -482,7 +482,7 @@ run "authorized_ip_ranges" {
     context_id           = "test"
     name                 = "windsor-aks"
     cluster_name         = "test-cluster"
-    kubernetes_version   = "1.33"
+    kubernetes_version   = "1.34"
     authorized_ip_ranges = ["10.0.0.0/8", "192.168.0.0/16"]
   }
 
@@ -512,7 +512,7 @@ run "azure_rbac_with_admin_object_ids" {
     context_id             = "test"
     name                   = "windsor-aks"
     cluster_name           = "test-cluster"
-    kubernetes_version     = "1.33"
+    kubernetes_version     = "1.34"
     local_account_disabled = true
     admin_object_ids       = ["33333333-3333-3333-3333-333333333333", "44444444-4444-4444-4444-444444444444"]
   }
@@ -566,7 +566,7 @@ run "multiple_invalid_inputs" {
   ]
   variables {
     context_id         = "test"
-    kubernetes_version = "v1.33"
+    kubernetes_version = "v1.34"
     outbound_type      = "invalid"
   }
 }
@@ -579,7 +579,7 @@ run "disk_encryption_with_provided_key" {
   variables {
     context_id              = "test"
     name                    = "windsor-aks"
-    kubernetes_version      = "1.33"
+    kubernetes_version      = "1.34"
     disk_encryption_enabled = true
     key_vault_key_id        = "https://test-kv.vault.azure.net/keys/test-key/abc123"
   }
@@ -608,7 +608,7 @@ run "volume_snapshots_disabled" {
   variables {
     context_id              = "test"
     name                    = "windsor-aks"
-    kubernetes_version      = "1.33"
+    kubernetes_version      = "1.34"
     enable_volume_snapshots = false
   }
 

--- a/terraform/cluster/azure-aks/variables.tf
+++ b/terraform/cluster/azure-aks/variables.tf
@@ -60,10 +60,10 @@ variable "kubernetes_version" {
   description = "Version of Kubernetes to use"
   type        = string
   # renovate: datasource=github-tags depName=aks-kubernetes package=windsorcli/k8s-versions
-  default = "1.33"
+  default = "1.34"
   validation {
     condition     = can(regex("^1\\.\\d+$", var.kubernetes_version))
-    error_message = "The Kubernetes version should be in version format like '1.33'."
+    error_message = "The Kubernetes version should be in version format like '1.34'."
   }
 }
 

--- a/terraform/cluster/azure-aks/variables.tf
+++ b/terraform/cluster/azure-aks/variables.tf
@@ -60,10 +60,10 @@ variable "kubernetes_version" {
   description = "Version of Kubernetes to use"
   type        = string
   # renovate: datasource=github-tags depName=aks-kubernetes package=windsorcli/k8s-versions
-  default = "1.32"
+  default = "1.33"
   validation {
     condition     = can(regex("^1\\.\\d+$", var.kubernetes_version))
-    error_message = "The Kubernetes version should be in version format like '1.32'."
+    error_message = "The Kubernetes version should be in version format like '1.33'."
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changing the default AKS Kubernetes version can trigger cluster upgrades or compatibility issues for consumers that rely on module defaults. The code changes are small but affect core infrastructure behavior.
> 
> **Overview**
> Updates the Azure AKS Terraform module to default `kubernetes_version` to `1.34` (from `1.32`).
> 
> Refreshes the generated README input docs and the Terraform module tests to use `1.34` consistently, including the version validation error example.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6be171f75ef23bfac6ab07d75db7e2c7485ac04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->