### PR TITLE
fix(workstation): Generate correct local repo name

### DIFF
--- a/terraform/workstation/docker/main.tf
+++ b/terraform/workstation/docker/main.tf
@@ -22,6 +22,7 @@ terraform {
 
 locals {
   domain_name           = coalesce(var.domain_name, var.context)
+  git_repo_name         = basename(var.project_root)
   compose_project       = "workstation-windsor-${var.context}"
   network_name_resolved = coalesce(var.network_name, "windsor-${var.context}")
   # Runtime: docker-desktop => localhost-only networking; colima/linux => advanced networking. Standardized with compute/docker.
@@ -279,6 +280,6 @@ resource "docker_container" "git" {
   }
   volumes {
     host_path      = var.project_root
-    container_path = "/repos/mount/core"
+    container_path = "/repos/mount/${local.git_repo_name}"
   }
 }

--- a/terraform/workstation/docker/test.tftest.hcl
+++ b/terraform/workstation/docker/test.tftest.hcl
@@ -60,6 +60,11 @@ run "minimal_configuration" {
     condition     = docker_container.dns[0].name == "dns.test"
     error_message = "DNS container name should use domain_name (dns.test when domain_name defaults to context)"
   }
+
+  assert {
+    condition     = local.git_repo_name == "windsor-test" && one(docker_container.git[0].volumes).container_path == "/repos/mount/windsor-test"
+    error_message = "Git mount path should use basename(project_root) for repo naming"
+  }
 }
 
 # Full: all optional variables set; asserts custom network, domain_name, compose_project, custom registries, sequential IPs, runtime logic.
@@ -144,6 +149,11 @@ run "full_configuration" {
   assert {
     condition     = length(docker_container.dns) == 1 && length(docker_container.git) == 1
     error_message = "DNS and git containers should be created when enabled"
+  }
+
+  assert {
+    condition     = local.git_repo_name == "repo" && one(docker_container.git[0].volumes).container_path == "/repos/mount/repo"
+    error_message = "Git mount path should follow basename(project_root) in full configuration"
   }
 }
 

--- a/terraform/workstation/incus/main.tf
+++ b/terraform/workstation/incus/main.tf
@@ -49,6 +49,7 @@ provider "incus" {
 
 locals {
   domain_name           = coalesce(var.domain_name, var.context)
+  git_repo_name         = basename(var.project_root)
   network_name_resolved = coalesce(var.network_name, "windsor-${var.context}")
   compose_project       = "workstation-windsor-${var.context}"
   # Incus: bridge networking only; no localhost/port-publish mode like docker-desktop (docker uses loadbalancer_cidr for that)
@@ -248,7 +249,7 @@ resource "incus_instance" "git" {
     type = "disk"
     properties = {
       source = var.project_root
-      path   = "/repos/mount/core"
+      path   = "/repos/mount/${local.git_repo_name}"
     }
   }
 }

--- a/terraform/workstation/incus/test.tftest.hcl
+++ b/terraform/workstation/incus/test.tftest.hcl
@@ -56,6 +56,11 @@ run "minimal_configuration" {
     condition     = incus_instance.dns[0].name == "dns-test"
     error_message = "DNS instance name should use domain_name (dns.test when domain_name defaults to context)"
   }
+
+  assert {
+    condition     = local.git_repo_name == "windsor-test"
+    error_message = "Git repo name should use basename(project_root)"
+  }
 }
 
 # Full: all optional variables set; asserts custom network, domain_name, compose_project, custom registries, sequential IPs.
@@ -119,6 +124,11 @@ run "full_configuration" {
   assert {
     condition     = length(incus_instance.dns) == 1 && length(incus_instance.git) == 1
     error_message = "DNS and git instances should be created when enabled"
+  }
+
+  assert {
+    condition     = local.git_repo_name == "repo"
+    error_message = "Git repo name should follow basename(project_root) in full configuration"
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the on-disk mount location inside the git container/instance, which could break tooling that assumed the previous fixed `/repos/mount/core` path. Scope is limited to workstation Docker/Incus modules and covered by updated tests.
> 
> **Overview**
> **Workstation git mounts now use the repo’s actual directory name.** Both `workstation/docker` and `workstation/incus` derive `git_repo_name` via `basename(var.project_root)` and mount the project root at `/repos/mount/${git_repo_name}` instead of the hardcoded `/repos/mount/core`.
> 
> Tests were updated/added to assert the new `git_repo_name` local and the resulting mount path in minimal and full configurations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a732d48de5594fdcb236e2c70032f5d5f592edd5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->