### PR TITLE
fix(workstation): Re-enable webhook

### DIFF
--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -100,7 +100,7 @@ terraform:
       ))}
     git_username: ${workstation.git.username ?? "local"}
     git_password: ${workstation.git.password ?? "local"}
-    webhook_token: ${workstation.git.webhook_token ?? "abcdef123456"}
+    webhook_token: ${gitops.webhook.token ?? "abcdef123456"}
 
 # Workstation stack for docker-desktop: DNS, registries, git livereload. No loadbalancer; DNS forwards to
 # first node. Use container port 30053 (not host 8053) so the DNS container on the same network can reach the node.
@@ -113,12 +113,12 @@ terraform:
     domain_name: ${dns.private_domain}
     network_name: windsor-${context}
     network_cidr: ${network.cidr_block}
-    dns_forward_target: "${cidrhost(network.cidr_block, 10) + \":30053\"}"
-    webhook_host: "${cidrhost(network.cidr_block, 10)}"
+    dns_forward_target: "${cidrhost(network.cidr_block, 4 + len(workstation_registries.registries ?? {})) + \":30053\"}"
+    webhook_host: "${cidrhost(network.cidr_block, 4 + len(workstation_registries.registries ?? {}))}"
     webhook_port: 30292
     webhook_enabled: ${gitops.webhook.enabled ?? true}
-    webhook_token: ${workstation.git.webhook_token ?? "abcdef123456"}
-    primary_node_ip: "${cidrhost(network.cidr_block, 10)}"
+    webhook_token: ${gitops.webhook.token ?? "abcdef123456"}
+    primary_node_ip: "${cidrhost(network.cidr_block, 4 + len(workstation_registries.registries ?? {}))}"
     enable_dns: ${workstation.services.dns ?? true}
     enable_git: ${workstation.services.git ?? true}
     registries: ${workstation_registries.registries ?? {}}
@@ -138,7 +138,7 @@ terraform:
     webhook_host: ${network.loadbalancer_ips.start}
     webhook_port: 9292
     webhook_enabled: ${gitops.webhook.enabled ?? true}
-    webhook_token: ${workstation.git.webhook_token ?? "abcdef123456"}
+    webhook_token: ${gitops.webhook.token ?? "abcdef123456"}
     primary_node_ip: ${network.loadbalancer_ips.start}
     enable_dns: ${workstation.services.dns ?? true}
     enable_git: ${workstation.services.git ?? true}
@@ -162,7 +162,7 @@ terraform:
     enable_dns: ${workstation.services.dns ?? true}
     enable_git: ${workstation.services.git ?? true}
     registries: ${workstation_registries.registries ?? {}}
-    webhook_token: ${workstation.git.webhook_token ?? "abcdef123456"}
+    webhook_token: ${gitops.webhook.token ?? "abcdef123456"}
     git_username: ${workstation.git.username ?? "local"}
     git_password: ${workstation.git.password ?? "local"}
 

--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -83,7 +83,7 @@ config:
       worker_config_patches: ""
 
 terraform:
-# GitOps/flux with livereload credentials and webhook token. Runs when workstation + cluster enabled (depends on cluster).
+# GitOps/flux with git livereload credentials and webhook token. Runs when workstation + cluster enabled (depends on cluster).
 - name: gitops
   when: (cluster.enabled ?? true)
   path: gitops/flux
@@ -98,9 +98,9 @@ terraform:
         floor((cluster.controlplanes.memory ?? 4) / 2),
         10
       ))}
-    git_username: ${git.livereload.username ?? "local"}
-    git_password: ${git.livereload.password ?? "local"}
-    webhook_token: ${git.livereload.webhook_token ?? "abcdef123456"}
+    git_username: ${workstation.git.username ?? "local"}
+    git_password: ${workstation.git.password ?? "local"}
+    webhook_token: ${workstation.git.webhook_token ?? "abcdef123456"}
 
 # Workstation stack for docker-desktop: DNS, registries, git livereload. No loadbalancer; DNS forwards to
 # first node. Use container port 30053 (not host 8053) so the DNS container on the same network can reach the node.
@@ -117,7 +117,7 @@ terraform:
     webhook_host: "${cidrhost(network.cidr_block, 10)}"
     webhook_port: 30292
     webhook_enabled: ${gitops.webhook.enabled ?? true}
-    webhook_token: ${git.livereload.webhook_token ?? "abcdef123456"}
+    webhook_token: ${workstation.git.webhook_token ?? "abcdef123456"}
     primary_node_ip: "${cidrhost(network.cidr_block, 10)}"
     enable_dns: ${workstation.services.dns ?? true}
     enable_git: ${workstation.services.git ?? true}
@@ -138,6 +138,7 @@ terraform:
     webhook_host: ${network.loadbalancer_ips.start}
     webhook_port: 9292
     webhook_enabled: ${gitops.webhook.enabled ?? true}
+    webhook_token: ${workstation.git.webhook_token ?? "abcdef123456"}
     primary_node_ip: ${network.loadbalancer_ips.start}
     enable_dns: ${workstation.services.dns ?? true}
     enable_git: ${workstation.services.git ?? true}
@@ -161,9 +162,9 @@ terraform:
     enable_dns: ${workstation.services.dns ?? true}
     enable_git: ${workstation.services.git ?? true}
     registries: ${workstation_registries.registries ?? {}}
-    webhook_token: ${git.livereload.webhook_token ?? "abcdef123456"}
-    git_username: ${git.livereload.username ?? "local"}
-    git_password: ${git.livereload.password ?? "local"}
+    webhook_token: ${workstation.git.webhook_token ?? "abcdef123456"}
+    git_username: ${workstation.git.username ?? "local"}
+    git_password: ${workstation.git.password ?? "local"}
 
 - name: compute
   when: "platform == 'incus' && (cluster.enabled ?? true)"
@@ -266,14 +267,14 @@ terraform:
         image: ${cluster.controlplanes.image ?? talos.docker_image}
         cpu: ${cluster.controlplanes.cpu ?? 2}
         memory: ${cluster.controlplanes.memory ?? 2}
-        hostports: "${workstation.runtime == \"docker-desktop\" ? (cluster.controlplanes.hostports ?? []) : []}"
+        hostports: "${workstation.runtime == \"docker-desktop\" ? (cluster.controlplanes.hostports ?? [\"8080:30080/tcp\", \"8443:30443/tcp\"]) : []}"
         volumes: ${cluster.controlplanes.volumes ?? []}
       workers:
         count: ${cluster.workers.count ?? 0}
         image: ${cluster.workers.image ?? talos.docker_image}
         cpu: ${cluster.workers.cpu ?? 4}
         memory: ${cluster.workers.memory ?? 4}
-        hostports: "${workstation.runtime == \"docker-desktop\" ? (cluster.workers.hostports ?? []) : []}"
+        hostports: "${workstation.runtime == \"docker-desktop\" ? (cluster.workers.hostports ?? [\"8080:30080/tcp\", \"8443:30443/tcp\"]) : []}"
         volumes: ${cluster.workers.volumes ?? []}
 
 # cluster/talos: run after compute so it gets controlplanes/workers from compute output. Only when docker + workstation.

--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -113,9 +113,12 @@ terraform:
     domain_name: ${dns.private_domain}
     network_name: windsor-${context}
     network_cidr: ${network.cidr_block}
-    dns_forward_target: "${cidrhost(network.cidr_block, 4 + len(workstation_registries.registries ?? {})) + \":30053\"}"
-    webhook_host: "${cidrhost(network.cidr_block, 4 + len(workstation_registries.registries ?? {}))}"
-    primary_node_ip: "${cidrhost(network.cidr_block, 4 + len(workstation_registries.registries ?? {}))}"
+    dns_forward_target: "${cidrhost(network.cidr_block, 10) + \":30053\"}"
+    webhook_host: "${cidrhost(network.cidr_block, 10)}"
+    webhook_port: 30292
+    webhook_enabled: ${gitops.webhook.enabled ?? true}
+    webhook_token: ${git.livereload.webhook_token ?? "abcdef123456"}
+    primary_node_ip: "${cidrhost(network.cidr_block, 10)}"
     enable_dns: ${workstation.services.dns ?? true}
     enable_git: ${workstation.services.git ?? true}
     registries: ${workstation_registries.registries ?? {}}
@@ -133,6 +136,8 @@ terraform:
     network_cidr: ${network.cidr_block}
     dns_forward_target: ${network.loadbalancer_ips.start}
     webhook_host: ${network.loadbalancer_ips.start}
+    webhook_port: 9292
+    webhook_enabled: ${gitops.webhook.enabled ?? true}
     primary_node_ip: ${network.loadbalancer_ips.start}
     enable_dns: ${workstation.services.dns ?? true}
     enable_git: ${workstation.services.git ?? true}
@@ -150,6 +155,8 @@ terraform:
     loadbalancer_start_ip: ${network.loadbalancer_ips.start}
     dns_forward_target: ${network.loadbalancer_ips.start}
     webhook_host: ${network.loadbalancer_ips.start}
+    webhook_port: 9292
+    webhook_enabled: ${gitops.webhook.enabled ?? true}
     primary_node_ip: ${network.loadbalancer_ips.start}
     enable_dns: ${workstation.services.dns ?? true}
     enable_git: ${workstation.services.git ?? true}

--- a/contexts/_template/facets/provider-base.yaml
+++ b/contexts/_template/facets/provider-base.yaml
@@ -104,3 +104,12 @@ kustomize:
     - "${log_level != 'trace' ? 'fluentd/filters/log-level/' + (log_level ?? 'info') : ''}"
   timeout: 15m
   interval: 10m
+
+# Flux webhook receiver for immediate source reconciliation.
+- name: gitops
+  path: gitops/flux
+  when: (gitops.webhook.enabled ?? true) == true
+  components:
+    - webhook
+  substitutions:
+    git_repository_name: ${gitops.repository.name ?? "local"}

--- a/contexts/_template/schema.yaml
+++ b/contexts/_template/schema.yaml
@@ -385,6 +385,27 @@ properties:
         description: Private DNS zone (e.g. in-cluster CoreDNS, workstation resolver)
     additionalProperties: false
 
+  # GitOps configuration
+  gitops:
+    type: object
+    properties:
+      repository:
+        type: object
+        properties:
+          name:
+            type: string
+            default: local
+            description: Flux GitRepository name used as the primary source for reconciliations
+        additionalProperties: false
+      webhook:
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: true
+            description: Enable webhook-triggered Flux source reconciliation
+        additionalProperties: false
+    additionalProperties: false
   # Ingress configuration
   ingress:
     type: object

--- a/contexts/_template/schema.yaml
+++ b/contexts/_template/schema.yaml
@@ -404,6 +404,10 @@ properties:
             type: boolean
             default: true
             description: Enable webhook-triggered Flux source reconciliation
+          token:
+            type: string
+            sensitive: true
+            description: Token for the Flux Receiver secret. Defaults to a placeholder in workstation mode; set explicitly for production.
         additionalProperties: false
     additionalProperties: false
   # Ingress configuration

--- a/contexts/_template/schema.yaml
+++ b/contexts/_template/schema.yaml
@@ -507,6 +507,19 @@ properties:
             description: Create registry proxy containers (from docker.registries when true)
         additionalProperties: false
         description: Toggle workstation services
+      git:
+        type: object
+        properties:
+          username:
+            type: string
+            default: local
+            description: Username for git livereload HTTP auth
+          password:
+            type: string
+            default: local
+            description: Password for git livereload HTTP auth
+        additionalProperties: false
+        description: Git livereload credentials
     additionalProperties: false
 
   # Optional addons

--- a/contexts/_template/tests/option-workstation.test.yaml
+++ b/contexts/_template/tests/option-workstation.test.yaml
@@ -253,7 +253,7 @@ cases:
         - name: workstation
           path: workstation/docker
           inputs:
-            webhook_host: "10.5.0.10"
+            webhook_host: "10.5.0.9"
         - name: cluster
           path: cluster/talos
         - name: gitops
@@ -263,6 +263,101 @@ cases:
       kustomize:
         - name: lb-base
         - name: lb-resources
+
+  # Edge: custom webhook token propagates to all three workstation variants and gitops/flux so the sha256 hash matches.
+  - name: custom webhook token propagates to docker-desktop workstation and gitops
+    values:
+      provider: docker
+      workstation:
+        runtime: docker-desktop
+      gitops:
+        webhook:
+          token: mysecrettoken
+      dns: *default-dns
+      ingress: *ingress-disabled
+      network: *default-network
+      cluster: *default-cluster
+    terraformOutputs: *default-terraform-outputs
+    expect:
+      terraform:
+        - name: workstation
+          path: workstation/docker
+          inputs:
+            webhook_token: mysecrettoken
+        - name: gitops
+          path: gitops/flux
+          inputs:
+            webhook_token: mysecrettoken
+
+  - name: custom webhook token propagates to colima workstation and gitops
+    values:
+      provider: docker
+      workstation:
+        runtime: colima
+      gitops:
+        webhook:
+          token: mysecrettoken
+      dns: *default-dns
+      ingress: *ingress-disabled
+      network: *default-network
+      cluster: *default-cluster
+    terraformOutputs: *default-terraform-outputs
+    expect:
+      terraform:
+        - name: workstation
+          path: workstation/docker
+          inputs:
+            webhook_token: mysecrettoken
+        - name: gitops
+          path: gitops/flux
+          inputs:
+            webhook_token: mysecrettoken
+
+  - name: custom webhook token propagates to incus workstation and gitops
+    values:
+      provider: incus
+      workstation:
+        runtime: colima
+      gitops:
+        webhook:
+          token: mysecrettoken
+      dns: *default-dns
+      ingress: *ingress-disabled
+      network: *default-network
+      cluster:
+        driver: talos
+        controlplanes:
+          nodes:
+            controlplane-1: *cp1-node
+        workers:
+          count: 1
+          volumes:
+            - /var/mnt/local
+          nodes:
+            worker-1:
+              endpoint: 10.5.0.20:50000
+              node: 10.5.0.20
+              hostname: worker-1
+    terraformOutputs:
+      compute:
+        controlplanes:
+          - endpoint: 10.5.0.10:6443
+            node: 10.5.0.10
+            hostname: controlplane-1
+        workers:
+          - endpoint: 10.5.0.20:50000
+            node: 10.5.0.20
+            hostname: worker-1
+    expect:
+      terraform:
+        - name: workstation
+          path: workstation/incus
+          inputs:
+            webhook_token: mysecrettoken
+        - name: gitops
+          path: gitops/flux
+          inputs:
+            webhook_token: mysecrettoken
 
   # Edge: gitops webhook settings are top-level and propagate to both gitops/flux and workstation modules.
   - name: gitops webhook feature flag disables receiver component

--- a/contexts/_template/tests/option-workstation.test.yaml
+++ b/contexts/_template/tests/option-workstation.test.yaml
@@ -253,7 +253,7 @@ cases:
         - name: workstation
           path: workstation/docker
           inputs:
-            webhook_host: "10.5.0.9"
+            webhook_host: "10.5.0.10"
         - name: cluster
           path: cluster/talos
         - name: gitops
@@ -263,3 +263,33 @@ cases:
       kustomize:
         - name: lb-base
         - name: lb-resources
+
+  # Edge: gitops webhook settings are top-level and propagate to both gitops/flux and workstation modules.
+  - name: gitops webhook feature flag disables receiver component
+    values:
+      provider: docker
+      workstation:
+        runtime: docker-desktop
+      gitops:
+        repository:
+          name: flux-primary
+        webhook:
+          enabled: false
+      dns: *default-dns
+      ingress: *ingress-disabled
+      network: *default-network
+      cluster: *default-cluster
+    terraformOutputs: *default-terraform-outputs
+    expect:
+      terraform:
+        - name: workstation
+          path: workstation/docker
+          inputs:
+            webhook_enabled: false
+        - name: gitops
+          path: gitops/flux
+          destroy: false
+    exclude:
+      kustomize:
+        - name: gitops
+          path: gitops/flux

--- a/kustomize/gateway/resources/envoy/flux-webhook/kustomization.yaml
+++ b/kustomize/gateway/resources/envoy/flux-webhook/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - tcproute.yaml
+patches:
+  - target:
+      group: gateway.networking.k8s.io
+      version: v1
+      kind: Gateway
+      name: edge
+      namespace: system-gateway
+    path: patches/gateway.yaml

--- a/kustomize/gateway/resources/envoy/flux-webhook/patches/gateway.yaml
+++ b/kustomize/gateway/resources/envoy/flux-webhook/patches/gateway.yaml
@@ -1,0 +1,11 @@
+- op: add
+  path: /spec/listeners/-
+  value:
+    name: flux-webhook
+    protocol: TCP
+    port: 9292
+    allowedRoutes:
+      namespaces:
+        from: All
+      kinds:
+        - kind: TCPRoute

--- a/kustomize/gateway/resources/envoy/flux-webhook/tcproute.yaml
+++ b/kustomize/gateway/resources/envoy/flux-webhook/tcproute.yaml
@@ -1,0 +1,14 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: flux-webhook
+  namespace: system-gitops
+spec:
+  parentRefs:
+    - name: edge
+      namespace: system-gateway
+      sectionName: flux-webhook
+  rules:
+    - backendRefs:
+        - name: webhook-receiver
+          port: 80

--- a/kustomize/gitops/flux/webhook/kustomization.yaml
+++ b/kustomize/gitops/flux/webhook/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources:
-- receiver.yaml
+  - receiver.yaml

--- a/kustomize/gitops/flux/webhook/receiver.yaml
+++ b/kustomize/gitops/flux/webhook/receiver.yaml
@@ -1,14 +1,14 @@
-  apiVersion: notification.toolkit.fluxcd.io/v1
-  kind: Receiver
-  metadata:
-    name: flux-webhook
-    namespace: system-gitops
-  spec:
-    type: generic
-    events: []
-    secretRef:
-      name: webhook-token
-    resources:
-      - apiVersion: source.toolkit.fluxcd.io/v1
-        kind: GitRepository
-        name: ${CONTEXT}
+apiVersion: notification.toolkit.fluxcd.io/v1
+kind: Receiver
+metadata:
+  name: flux-webhook
+  namespace: system-gitops
+spec:
+  type: generic
+  events: []
+  secretRef:
+    name: webhook-token
+  resources:
+    - apiVersion: source.toolkit.fluxcd.io/v1
+      kind: GitRepository
+      name: ${git_repository_name}

--- a/terraform/workstation/docker/main.tf
+++ b/terraform/workstation/docker/main.tf
@@ -36,7 +36,7 @@ locals {
   # Webhook host: explicit, or primary node IP, or primary LB (localhost mode=host 10 in same /24, else loadbalancer_start_ip)
   webhook_host_derived = local.use_localhost_networking ? cidrhost(local.loadbalancer_cidr, 10) : local.loadbalancer_start_ip
   webhook_host         = coalesce(var.webhook_host, var.primary_node_ip, local.webhook_host_derived)
-  webhook_url          = "http://${local.webhook_host}:9292/hook/${var.webhook_token}"
+  webhook_url          = var.webhook_enabled ? "http://${local.webhook_host}:${var.webhook_port}/hook/${sha256("${var.webhook_token}${var.receiver_name}${var.receiver_namespace}")}" : null
   common_labels = [
     { label = "context", value = var.context },
     { label = "managed_by", value = "terraform" }
@@ -249,15 +249,17 @@ resource "docker_container" "git" {
   count = var.enable_git ? 1 : 0
   name  = "git.${local.domain_name}"
   image = docker_image.git_livereload[0].image_id
-  env = [
-    "GIT_PASSWORD=${var.git_password}",
-    "GIT_USERNAME=${var.git_username}",
-    "RSYNC_EXCLUDE=${var.git_rsync_exclude}",
-    "RSYNC_INCLUDE=${var.git_rsync_include}",
-    "RSYNC_PROTECT=${var.git_rsync_protect}",
-    "VERIFY_SSL=false",
-    "WEBHOOK_URL=${local.webhook_url}"
-  ]
+  env = concat(
+    [
+      "GIT_PASSWORD=${var.git_password}",
+      "GIT_USERNAME=${var.git_username}",
+      "RSYNC_EXCLUDE=${var.git_rsync_exclude}",
+      "RSYNC_INCLUDE=${var.git_rsync_include}",
+      "RSYNC_PROTECT=${var.git_rsync_protect}",
+      "VERIFY_SSL=false"
+    ],
+    var.webhook_enabled ? ["WEBHOOK_URL=${local.webhook_url}"] : []
+  )
   restart = "always"
   dynamic "labels" {
     for_each = local.common_labels

--- a/terraform/workstation/docker/variables.tf
+++ b/terraform/workstation/docker/variables.tf
@@ -52,6 +52,18 @@ variable "webhook_host" {
   default     = null
 }
 
+variable "webhook_port" {
+  description = "Port for the git livereload webhook URL. Use NodePort in docker-desktop mode when gateway is exposed via NodePort."
+  type        = number
+  default     = 9292
+}
+
+variable "webhook_enabled" {
+  description = "Enable git livereload webhook notifications."
+  type        = bool
+  default     = true
+}
+
 variable "primary_node_ip" {
   description = "IP of the primary developing node (controlplane or worker) for NodePort webhook. If set and webhook_host is null, used as webhook host."
   type        = string
@@ -108,10 +120,22 @@ variable "registries" {
 }
 
 variable "webhook_token" {
-  description = "Token for the git livereload webhook URL. If not set, a placeholder is used (caller should replace or provide via env)."
+  description = "Raw token for the Flux Receiver secret. The webhook URL is derived by hashing this with the receiver name and namespace."
   type        = string
-  default     = "5dc88e45e809fb0872b749c0969067e2c1fd142e17aed07573fad20553cc0c59"
+  default     = "abcdef123456"
   sensitive   = true
+}
+
+variable "receiver_name" {
+  description = "Name of the Flux Receiver resource used to compute the webhook URL path."
+  type        = string
+  default     = "flux-webhook"
+}
+
+variable "receiver_namespace" {
+  description = "Namespace of the Flux Receiver resource used to compute the webhook URL path."
+  type        = string
+  default     = "system-gitops"
 }
 
 variable "git_username" {

--- a/terraform/workstation/incus/main.tf
+++ b/terraform/workstation/incus/main.tf
@@ -56,7 +56,7 @@ locals {
   loadbalancer_start_ip = coalesce(var.loadbalancer_start_ip, cidrhost(cidrsubnet(var.network_cidr, 8, 1), 1))
   webhook_host_derived  = local.loadbalancer_start_ip
   webhook_host          = coalesce(var.webhook_host, var.primary_node_ip, local.webhook_host_derived)
-  webhook_url           = "http://${local.webhook_host}:9292/hook/${var.webhook_token}"
+  webhook_url           = var.webhook_enabled ? "http://${local.webhook_host}:${var.webhook_port}/hook/${sha256("${var.webhook_token}${var.receiver_name}${var.receiver_namespace}")}" : null
   gateway               = cidrhost(var.network_cidr, 1)
   dns_ip                = cidrhost(var.network_cidr, 2)
   attached_network      = var.create_network ? local.network_name_resolved : var.network_name
@@ -225,15 +225,17 @@ resource "incus_instance" "git" {
   type       = "container"
   # renovate: datasource=github-releases depName=windsorcli/git-livereload
   image = "ghcr:windsorcli/git-livereload:v0.2.1"
-  config = {
-    "environment.GIT_PASSWORD"  = var.git_password
-    "environment.GIT_USERNAME"  = var.git_username
-    "environment.RSYNC_EXCLUDE" = var.git_rsync_exclude
-    "environment.RSYNC_INCLUDE" = var.git_rsync_include
-    "environment.RSYNC_PROTECT" = var.git_rsync_protect
-    "environment.VERIFY_SSL"    = "false"
-    "environment.WEBHOOK_URL"   = local.webhook_url
-  }
+  config = merge(
+    {
+      "environment.GIT_PASSWORD"  = var.git_password
+      "environment.GIT_USERNAME"  = var.git_username
+      "environment.RSYNC_EXCLUDE" = var.git_rsync_exclude
+      "environment.RSYNC_INCLUDE" = var.git_rsync_include
+      "environment.RSYNC_PROTECT" = var.git_rsync_protect
+      "environment.VERIFY_SSL"    = "false"
+    },
+    var.webhook_enabled ? { "environment.WEBHOOK_URL" = local.webhook_url } : {}
+  )
 
   device {
     name = "eth0"

--- a/terraform/workstation/incus/variables.tf
+++ b/terraform/workstation/incus/variables.tf
@@ -48,6 +48,18 @@ variable "webhook_host" {
   default     = null
 }
 
+variable "webhook_port" {
+  description = "Port for the git livereload webhook URL."
+  type        = number
+  default     = 9292
+}
+
+variable "webhook_enabled" {
+  description = "Enable git livereload webhook notifications."
+  type        = bool
+  default     = true
+}
+
 variable "primary_node_ip" {
   description = "IP of the primary developing node (controlplane or worker) for NodePort webhook. If set and webhook_host is null, used as webhook host."
   type        = string
@@ -103,10 +115,22 @@ variable "registries" {
 }
 
 variable "webhook_token" {
-  description = "Token for the git livereload webhook URL. If not set, a placeholder is used (caller should replace or provide via env)."
+  description = "Raw token for the Flux Receiver secret. The webhook URL is derived by hashing this with the receiver name and namespace."
   type        = string
-  default     = "5dc88e45e809fb0872b749c0969067e2c1fd142e17aed07573fad20553cc0c59"
+  default     = "abcdef123456"
   sensitive   = true
+}
+
+variable "receiver_name" {
+  description = "Name of the Flux Receiver resource used to compute the webhook URL path."
+  type        = string
+  default     = "flux-webhook"
+}
+
+variable "receiver_namespace" {
+  description = "Namespace of the Flux Receiver resource used to compute the webhook URL path."
+  type        = string
+  default     = "system-gitops"
 }
 
 variable "git_username" {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes Flux webhook wiring and token derivation across Terraform and Kustomize; misconfiguration could break GitOps reconciliation triggers or expose an unexpected listener/port in dev environments.
> 
> **Overview**
> Re-enables immediate Flux source reconciliation by adding a `gitops.webhook` feature flag/token to the blueprint schema and wiring a `gitops/flux` Kustomize component that installs the Flux `Receiver` (with configurable `git_repository_name`).
> 
> Updates workstation Terraform modules (Docker and Incus) to optionally emit webhook notifications: the `WEBHOOK_URL` is now derived from a hash of `webhook_token` + receiver identity, supports configurable `webhook_port`, and can be disabled entirely. Workstation facet inputs are updated to use the new top-level `gitops` settings and to default Docker Desktop Talos node `hostports` to expose common NodePorts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0891271d10d9b9f3b59e86feb42d4971863500e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->