### PR TITLE
feat(dns): Improve resilience and performance of coredns/etcd/external-dns

### DIFF
--- a/contexts/_template/facets/addon-private-dns.yaml
+++ b/contexts/_template/facets/addon-private-dns.yaml
@@ -18,8 +18,10 @@ kustomize:
   components:
     - coredns
     - coredns/etcd
+    - "${(ha ?? false) ? 'coredns/ha' : ''}"
     - external-dns
     - external-dns/coredns
+    - "${(ha ?? false) ? 'external-dns/ha' : ''}"
     # Component name remains "ingress" for compatibility, but it configures
     # both ingress and Gateway API HTTPRoute sources in external-dns.
     - external-dns/ingress

--- a/kustomize/dns/coredns/etcd/statefulset.yaml
+++ b/kustomize/dns/coredns/etcd/statefulset.yaml
@@ -99,16 +99,10 @@ spec:
         - name: tmp
           mountPath: /tmp
       volumes:
+      - name: etcd-data
+        emptyDir: {}
       - name: etcd-tls
         secret:
           secretName: etcd-server-tls
       - name: tmp
         emptyDir: {}
-  volumeClaimTemplates:
-  - metadata:
-      name: etcd-data
-    spec:
-      accessModes: ["ReadWriteOnce"]
-      resources:
-        requests:
-          storage: 1Gi

--- a/kustomize/dns/coredns/ha/kustomization.yaml
+++ b/kustomize/dns/coredns/ha/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: patches/helm-release.yaml
+    target:
+      group: helm.toolkit.fluxcd.io
+      version: v2
+      kind: HelmRelease
+      name: coredns
+      namespace: system-dns

--- a/kustomize/dns/coredns/ha/patches/helm-release.yaml
+++ b/kustomize/dns/coredns/ha/patches/helm-release.yaml
@@ -1,0 +1,14 @@
+- op: add
+  path: /spec/values/replicaCount
+  value: 3
+- op: add
+  path: /spec/values/affinity
+  value:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: coredns
+            topologyKey: kubernetes.io/hostname

--- a/kustomize/dns/external-dns/coredns/patches/helm-release.yaml
+++ b/kustomize/dns/external-dns/coredns/patches/helm-release.yaml
@@ -1,4 +1,9 @@
 - op: add
+  path: /spec/dependsOn/-
+  value:
+    name: coredns
+    namespace: system-dns
+- op: add
   path: /spec/values/provider
   value:
     name: coredns

--- a/kustomize/dns/external-dns/ha/kustomization.yaml
+++ b/kustomize/dns/external-dns/ha/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: patches/helm-release.yaml
+    target:
+      group: helm.toolkit.fluxcd.io
+      version: v2
+      kind: HelmRelease
+      name: external-dns
+      namespace: system-dns

--- a/kustomize/dns/external-dns/ha/patches/helm-release.yaml
+++ b/kustomize/dns/external-dns/ha/patches/helm-release.yaml
@@ -1,0 +1,7 @@
+- op: add
+  path: /spec/values/replicaCount
+  value: 2
+- op: add
+  path: /spec/values/extraArgs
+  value:
+    - --leader-election

--- a/kustomize/dns/external-dns/ha/patches/helm-release.yaml
+++ b/kustomize/dns/external-dns/ha/patches/helm-release.yaml
@@ -4,4 +4,4 @@
 - op: add
   path: /spec/values/extraArgs
   value:
-    - --leader-election
+    - --enable-leader-election


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> High risk because it changes cluster DNS control-plane behavior and removes persistent storage for etcd, which can cause record loss or DNS outages on pod restart. It also alters deployment ordering and replica scheduling for CoreDNS/external-dns.
> 
> **Overview**
> Adds an `ha`-gated path in the private DNS facet to optionally enable new `coredns/ha` and `external-dns/ha` components.
> 
> Introduces HA patches that scale `coredns` to 3 replicas with pod anti-affinity and scale `external-dns` to 2 replicas with leader election enabled.
> 
> Switches the CoreDNS etcd `StatefulSet` from a PVC-backed `volumeClaimTemplates` to an `emptyDir` data volume (ephemeral), and makes `external-dns` explicitly `dependsOn` `coredns` in its HelmRelease patch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d054e1639575ee4fe3e73dc2bc70eb3dcf7e94f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->