### PR TITLE
fix(kustomize/gateway): Ensure use of local DNS for docker-desktop mode

### DIFF
--- a/contexts/_template/facets/option-gateway.yaml
+++ b/contexts/_template/facets/option-gateway.yaml
@@ -60,6 +60,7 @@ kustomize:
     - "${gateway_effective.driver != 'cilium' && (addons.private_dns.enabled ?? (dev == true)) == true ? 'dns' : ''}"
   substitutions:
     gateway_class_name: ${gateway_effective.driver}
+    gateway_dns_target: ${network.loadbalancer_ips.start ?? ''}
     external_domain: ${dns.private_domain}
     loadbalancer_start_ip: ${network.loadbalancer_ips.start ?? ''}
   timeout: 10m

--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -114,6 +114,13 @@ terraform:
     git_password: ${workstation.git.password ?? "local"}
     webhook_token: ${gitops.webhook.token ?? "abcdef123456"}
 
+# On docker-desktop the LB IP is cluster-internal; override gateway_dns_target so external-dns
+# advertises 127.0.0.1 (reached via host-port mapping) instead of the unreachable LB IP.
+- name: gateway-resources
+  when: "platform == 'docker' && workstation.runtime == 'docker-desktop' && gateway_effective.enabled == true"
+  substitutions:
+    gateway_dns_target: "127.0.0.1"
+
 # Workstation stack for docker-desktop: DNS, registries, git livereload. No loadbalancer; DNS forwards to
 # first node. Use container port 30053 (not host 8053) so the DNS container on the same network can reach the node.
 # 30053 = NodePort for DNS set in kustomize/ingress/nginx/coredns/patches/helm-release.yaml; cluster.*.hostports must use same container port (e.g. 8053:30053/udp).

--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -114,13 +114,6 @@ terraform:
     git_password: ${workstation.git.password ?? "local"}
     webhook_token: ${gitops.webhook.token ?? "abcdef123456"}
 
-# On docker-desktop the LB IP is cluster-internal; override gateway_dns_target so external-dns
-# advertises 127.0.0.1 (reached via host-port mapping) instead of the unreachable LB IP.
-- name: gateway-resources
-  when: "platform == 'docker' && workstation.runtime == 'docker-desktop' && gateway_effective.enabled == true"
-  substitutions:
-    gateway_dns_target: "127.0.0.1"
-
 # Workstation stack for docker-desktop: DNS, registries, git livereload. No loadbalancer; DNS forwards to
 # first node. Use container port 30053 (not host 8053) so the DNS container on the same network can reach the node.
 # 30053 = NodePort for DNS set in kustomize/ingress/nginx/coredns/patches/helm-release.yaml; cluster.*.hostports must use same container port (e.g. 8053:30053/udp).
@@ -301,3 +294,12 @@ terraform:
   when: "cluster.enabled == true && platform == 'docker'"
   dependsOn:
     - compute
+
+kustomize:
+
+# On docker-desktop the LB IP is cluster-internal; override gateway_dns_target so external-dns
+# advertises 127.0.0.1 (reached via host-port mapping) instead of the unreachable LB IP.
+- name: gateway-resources
+  when: "platform == 'docker' && workstation.runtime == 'docker-desktop' && gateway_effective.enabled == true"
+  substitutions:
+    gateway_dns_target: "127.0.0.1"

--- a/kustomize/gateway/resources/dns/kustomization.yaml
+++ b/kustomize/gateway/resources/dns/kustomization.yaml
@@ -2,3 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 patches:
   - path: patches/gateway.yaml
+  - path: patches/listeners.yaml
+    target:
+      group: gateway.networking.k8s.io
+      version: v1
+      kind: Gateway
+      name: external
+      namespace: system-gateway

--- a/kustomize/gateway/resources/dns/kustomization.yaml
+++ b/kustomize/gateway/resources/dns/kustomization.yaml
@@ -2,8 +2,3 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 patches:
   - path: patches/gateway.yaml
-    target:
-      group: gateway.networking.k8s.io
-      kind: Gateway
-      name: external
-      namespace: system-gateway

--- a/kustomize/gateway/resources/dns/patches/gateway.yaml
+++ b/kustomize/gateway/resources/dns/patches/gateway.yaml
@@ -1,25 +1,25 @@
-- op: add
-  path: /metadata/annotations/external-dns.alpha.kubernetes.io~1target
-  value: "${gateway_dns_target}"
-- op: add
-  path: /spec/listeners/-
-  value:
-    name: dns-udp
-    protocol: UDP
-    port: 53
-    allowedRoutes:
-      namespaces:
-        from: All
-      kinds:
-        - kind: UDPRoute
-- op: add
-  path: /spec/listeners/-
-  value:
-    name: dns-tcp
-    protocol: TCP
-    port: 53
-    allowedRoutes:
-      namespaces:
-        from: All
-      kinds:
-        - kind: TCPRoute
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: external
+  namespace: system-gateway
+  annotations:
+    external-dns.alpha.kubernetes.io/target: "${gateway_dns_target}"
+spec:
+  listeners:
+    - name: dns-udp
+      protocol: UDP
+      port: 53
+      allowedRoutes:
+        namespaces:
+          from: All
+        kinds:
+          - kind: UDPRoute
+    - name: dns-tcp
+      protocol: TCP
+      port: 53
+      allowedRoutes:
+        namespaces:
+          from: All
+        kinds:
+          - kind: TCPRoute

--- a/kustomize/gateway/resources/dns/patches/gateway.yaml
+++ b/kustomize/gateway/resources/dns/patches/gateway.yaml
@@ -5,21 +5,3 @@ metadata:
   namespace: system-gateway
   annotations:
     external-dns.alpha.kubernetes.io/target: "${gateway_dns_target}"
-spec:
-  listeners:
-    - name: dns-udp
-      protocol: UDP
-      port: 53
-      allowedRoutes:
-        namespaces:
-          from: All
-        kinds:
-          - kind: UDPRoute
-    - name: dns-tcp
-      protocol: TCP
-      port: 53
-      allowedRoutes:
-        namespaces:
-          from: All
-        kinds:
-          - kind: TCPRoute

--- a/kustomize/gateway/resources/dns/patches/gateway.yaml
+++ b/kustomize/gateway/resources/dns/patches/gateway.yaml
@@ -1,4 +1,7 @@
 - op: add
+  path: /metadata/annotations/external-dns.alpha.kubernetes.io~1target
+  value: "${gateway_dns_target}"
+- op: add
   path: /spec/listeners/-
   value:
     name: dns-udp

--- a/kustomize/gateway/resources/dns/patches/listeners.yaml
+++ b/kustomize/gateway/resources/dns/patches/listeners.yaml
@@ -1,0 +1,22 @@
+- op: add
+  path: /spec/listeners/-
+  value:
+    name: dns-udp
+    protocol: UDP
+    port: 53
+    allowedRoutes:
+      namespaces:
+        from: All
+      kinds:
+        - kind: UDPRoute
+- op: add
+  path: /spec/listeners/-
+  value:
+    name: dns-tcp
+    protocol: TCP
+    port: 53
+    allowedRoutes:
+      namespaces:
+        from: All
+      kinds:
+        - kind: TCPRoute


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how `external-dns` determines the Gateway target IP and adds a docker-desktop override, which can impact DNS routing and reachability in dev clusters.
> 
> **Overview**
> Makes the Gateway DNS integration set `external-dns.alpha.kubernetes.io/target` from a new `gateway_dns_target` substitution, defaulting to the load balancer start IP.
> 
> For `docker-desktop`, overrides `gateway_dns_target` to `127.0.0.1` so DNS records point at the host (via port mappings) instead of the cluster-internal LB IP, and splits the DNS Gateway patches so listener additions live in a dedicated `patches/listeners.yaml` targeting `gateway.networking.k8s.io/v1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e1a44baecc06bb8726a941d7d0ba36a77da3142. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->