### PR TITLE
feat(facets): Refactor network IPs

### DIFF
--- a/contexts/_template/facets/addon-private-dns.yaml
+++ b/contexts/_template/facets/addon-private-dns.yaml
@@ -31,4 +31,4 @@ kustomize:
     - "${workstation.runtime == 'docker-desktop' ? 'external-dns/localhost' : ''}"
   substitutions:
     external_domain: ${dns.private_domain}
-    loadbalancer_start_ip: ${network.loadbalancer_ips.start}
+    loadbalancer_start_ip: ${network_effective.loadbalancer_ips.start}

--- a/contexts/_template/facets/option-cni.yaml
+++ b/contexts/_template/facets/option-cni.yaml
@@ -75,8 +75,8 @@ kustomize:
     - cilium/l2
   substitutions:
     k8s_service_host: ${talos_common.k8s_service_host}
-    loadbalancer_start_ip: ${network.loadbalancer_ips.start}
-    loadbalancer_end_ip: ${network.loadbalancer_ips.end}
+    loadbalancer_start_ip: ${network_effective.loadbalancer_ips.start}
+    loadbalancer_end_ip: ${network_effective.loadbalancer_ips.end}
   timeout: 15m
   interval: 5m
 

--- a/contexts/_template/facets/option-gateway.yaml
+++ b/contexts/_template/facets/option-gateway.yaml
@@ -58,10 +58,11 @@ kustomize:
   components:
     - "${gateway_effective.driver == 'cilium' ? 'cilium' : ''}"
     - "${gateway_effective.driver != 'cilium' && (addons.private_dns.enabled ?? (dev == true)) == true ? 'dns' : ''}"
+    - "${lb_effective.enabled == true ? 'lb-address' : ''}"
   substitutions:
     gateway_class_name: ${gateway_effective.driver}
-    gateway_dns_target: ${network.loadbalancer_ips.start ?? ''}
+    gateway_dns_target: ${network_effective.loadbalancer_ips.start}
     external_domain: ${dns.private_domain}
-    loadbalancer_start_ip: ${network.loadbalancer_ips.start ?? ''}
+    loadbalancer_start_ip: ${network_effective.loadbalancer_ips.start}
   timeout: 10m
   interval: 5m

--- a/contexts/_template/facets/option-gateway.yaml
+++ b/contexts/_template/facets/option-gateway.yaml
@@ -61,8 +61,8 @@ kustomize:
     - "${lb_effective.enabled == true ? 'lb-address' : ''}"
   substitutions:
     gateway_class_name: ${gateway_effective.driver}
-    gateway_dns_target: ${network_effective.loadbalancer_ips.start}
+    gateway_dns_target: "${lb_effective.enabled == true ? network_effective.loadbalancer_ips.start : ''}"
     external_domain: ${dns.private_domain}
-    loadbalancer_start_ip: ${network_effective.loadbalancer_ips.start}
+    loadbalancer_start_ip: "${lb_effective.enabled == true ? network_effective.loadbalancer_ips.start : ''}"
   timeout: 10m
   interval: 5m

--- a/contexts/_template/facets/option-gateway.yaml
+++ b/contexts/_template/facets/option-gateway.yaml
@@ -63,6 +63,6 @@ kustomize:
     gateway_class_name: ${gateway_effective.driver}
     gateway_dns_target: "${lb_effective.enabled == true ? network_effective.loadbalancer_ips.start : ''}"
     external_domain: ${dns.private_domain}
-    loadbalancer_start_ip: "${lb_effective.enabled == true ? network_effective.loadbalancer_ips.start : ''}"
+    loadbalancer_start_ip: "${network_effective.loadbalancer_ips.start ?? ''}"
   timeout: 10m
   interval: 5m

--- a/contexts/_template/facets/option-gateway.yaml
+++ b/contexts/_template/facets/option-gateway.yaml
@@ -63,6 +63,6 @@ kustomize:
     gateway_class_name: ${gateway_effective.driver}
     gateway_dns_target: "${lb_effective.enabled == true ? network_effective.loadbalancer_ips.start : ''}"
     external_domain: ${dns.private_domain}
-    loadbalancer_start_ip: "${network_effective.loadbalancer_ips.start ?? ''}"
+    loadbalancer_start_ip: ${network_effective.loadbalancer_ips.start}
   timeout: 10m
   interval: 5m

--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -124,13 +124,13 @@ terraform:
     runtime: 'docker-desktop'
     domain_name: ${dns.private_domain}
     network_name: windsor-${context}
-    network_cidr: ${network.cidr_block}
-    dns_forward_target: "${cidrhost(network.cidr_block, 10) + \":30053\"}"
-    webhook_host: "${cidrhost(network.cidr_block, 10)}"
+    network_cidr: ${network_effective.cidr_block}
+    dns_forward_target: "${cidrhost(network_effective.cidr_block, 10) + \":30053\"}"
+    webhook_host: "${cidrhost(network_effective.cidr_block, 10)}"
     webhook_port: 30292
     webhook_enabled: ${gitops.webhook.enabled ?? true}
     webhook_token: ${gitops.webhook.token ?? "abcdef123456"}
-    primary_node_ip: "${cidrhost(network.cidr_block, 10)}"
+    primary_node_ip: "${cidrhost(network_effective.cidr_block, 10)}"
     enable_dns: ${workstation.services.dns ?? true}
     enable_git: ${workstation.services.git ?? true}
     registries: ${workstation_registries.registries ?? {}}
@@ -145,13 +145,13 @@ terraform:
       ${workstation.runtime == "docker" ? "linux" : (workstation.runtime ?? "linux")}
     domain_name: ${dns.private_domain}
     network_name: windsor-${context}
-    network_cidr: ${network.cidr_block}
-    dns_forward_target: ${network.loadbalancer_ips.start}
-    webhook_host: ${network.loadbalancer_ips.start}
+    network_cidr: ${network_effective.cidr_block}
+    dns_forward_target: ${network_effective.loadbalancer_ips.start}
+    webhook_host: ${network_effective.loadbalancer_ips.start}
     webhook_port: "${gateway_effective.enabled == true ? 80 : 9292}"
     webhook_enabled: ${gitops.webhook.enabled ?? true}
     webhook_token: ${gitops.webhook.token ?? "abcdef123456"}
-    primary_node_ip: ${network.loadbalancer_ips.start}
+    primary_node_ip: ${network_effective.loadbalancer_ips.start}
     enable_dns: ${workstation.services.dns ?? true}
     enable_git: ${workstation.services.git ?? true}
     registries: ${workstation_registries.registries ?? {}}
@@ -164,13 +164,13 @@ terraform:
     domain_name: ${dns.private_domain}
     network_name: "${(workstation.runtime ?? '') == 'colima' ? 'incusbr0' : ''}"
     create_network: "${(workstation.runtime ?? '') != 'colima'}"
-    network_cidr: ${network.cidr_block}
-    loadbalancer_start_ip: ${network.loadbalancer_ips.start}
-    dns_forward_target: ${network.loadbalancer_ips.start}
-    webhook_host: ${network.loadbalancer_ips.start}
+    network_cidr: ${network_effective.cidr_block}
+    loadbalancer_start_ip: ${network_effective.loadbalancer_ips.start}
+    dns_forward_target: ${network_effective.loadbalancer_ips.start}
+    webhook_host: ${network_effective.loadbalancer_ips.start}
     webhook_port: 9292
     webhook_enabled: ${gitops.webhook.enabled ?? true}
-    primary_node_ip: ${network.loadbalancer_ips.start}
+    primary_node_ip: ${network_effective.loadbalancer_ips.start}
     enable_dns: ${workstation.services.dns ?? true}
     enable_git: ${workstation.services.git ?? true}
     registries: ${workstation_registries.registries ?? {}}
@@ -195,7 +195,7 @@ terraform:
       - name: controlplane
         role: controlplane
         count: ${cluster.controlplanes.count ?? 1}
-        ipv4: ${cidrhost(network.cidr_block, 10)}
+        ipv4: ${cidrhost(network_effective.cidr_block, 10)}
         image: ${cluster.controlplanes.image ?? talos.incus_image}
         type: virtual-machine
         description: Talos control plane node
@@ -212,7 +212,7 @@ terraform:
       - name: worker
         role: worker
         count: ${cluster.workers.count ?? 0}
-        ipv4: ${cidrhost(network.cidr_block, 20)}
+        ipv4: ${cidrhost(network_effective.cidr_block, 20)}
         image: ${cluster.workers.image ?? talos.incus_image}
         type: virtual-machine
         description: Talos worker node

--- a/contexts/_template/facets/provider-aws.yaml
+++ b/contexts/_template/facets/provider-aws.yaml
@@ -10,7 +10,7 @@ terraform:
 - name: network
   path: network/aws-vpc
   inputs:
-    cidr_block: ${network.cidr_block}
+    cidr_block: ${network_effective.cidr_block}
     domain_name: ${dns.public_domain ?? ""}
 - name: cluster
   path: cluster/aws-eks

--- a/contexts/_template/facets/provider-azure.yaml
+++ b/contexts/_template/facets/provider-azure.yaml
@@ -10,7 +10,7 @@ terraform:
 - name: network
   path: network/azure-vnet
   inputs:
-    vnet_cidr: ${network.cidr_block}
+    vnet_cidr: ${network_effective.cidr_block}
 - name: cluster
   path: cluster/azure-aks
   dependsOn:

--- a/contexts/_template/facets/provider-base.yaml
+++ b/contexts/_template/facets/provider-base.yaml
@@ -18,8 +18,11 @@ config:
     driver: "${cluster.cni.driver ?? (cluster.driver == 'talos' ? 'cilium' : '')}"
 - name: lb_effective
   value:
-    # Cilium provides built-in L2/BGP load balancing; external LB (e.g. MetalLB) is only needed for other CNIs.
-    enabled: "${cni_effective.driver != 'cilium'}"
+    # In-cluster LB is only needed when a loadbalancer_driver is explicitly configured (local platforms).
+    # Cloud platforms (AWS, Azure) use cloud-managed LBs and do not set loadbalancer_driver.
+    # Cilium provides built-in L2/BGP LB so no external driver is needed even on local platforms.
+    enabled: "${cni_effective.driver != 'cilium' && (network.loadbalancer_driver ?? '') != ''}"
+    driver: "${network.loadbalancer_driver ?? 'kube-vip'}"
     # NodePort on docker-desktop (no loadbalancer available); loadbalancer everywhere else.
     mode: loadbalancer
 - name: dns
@@ -33,6 +36,12 @@ config:
   value: "${cluster.driver == 'talos' && (cluster.enabled ?? true)}"
 - name: talos_provisioned
   value: "${cluster.driver == 'talos' && cluster_provisioned}"
+- name: network_effective
+  value:
+    cidr_block: "${network.cidr_block ?? '10.5.0.0/16'}"
+    loadbalancer_ips:
+      start: "${network.loadbalancer_ips.start ?? cidrhost(network.cidr_block ?? '10.5.0.0/16', 266)}"
+      end: "${network.loadbalancer_ips.end ?? cidrhost(network.cidr_block ?? '10.5.0.0/16', 356)}"
 - name: telemetry_effective
   value:
     logs_driver: "${telemetry.logs.driver ?? 'fluentd'}"

--- a/contexts/_template/facets/provider-base.yaml
+++ b/contexts/_template/facets/provider-base.yaml
@@ -36,12 +36,14 @@ config:
   value: "${cluster.driver == 'talos' && (cluster.enabled ?? true)}"
 - name: talos_provisioned
   value: "${cluster.driver == 'talos' && cluster_provisioned}"
+- name: network_cidr_effective
+  value: "${network.cidr_block ?? '10.5.0.0/16'}"
 - name: network_effective
   value:
-    cidr_block: "${network.cidr_block ?? '10.5.0.0/16'}"
+    cidr_block: "${network_cidr_effective}"
     loadbalancer_ips:
-      start: "${network.loadbalancer_ips.start ?? cidrhost(network.cidr_block ?? '10.5.0.0/16', 266)}"
-      end: "${network.loadbalancer_ips.end ?? cidrhost(network.cidr_block ?? '10.5.0.0/16', 356)}"
+      start: "${network.loadbalancer_ips.start ?? cidrhost(network_cidr_effective, 266)}"
+      end: "${network.loadbalancer_ips.end ?? cidrhost(network_cidr_effective, 356)}"
 - name: telemetry_effective
   value:
     logs_driver: "${telemetry.logs.driver ?? 'fluentd'}"

--- a/contexts/_template/facets/provider-docker.yaml
+++ b/contexts/_template/facets/provider-docker.yaml
@@ -11,7 +11,7 @@ config:
   value:
     # Docker compute assigns the first controlplane a fixed IP at offset 10 in the network CIDR
     # (workstation services occupy offsets 2–9). Mirrors the incus provider convention.
-    k8s_service_host: "${cidrhost(network.cidr_block, 10)}"
+    k8s_service_host: "${cidrhost(network_effective.cidr_block, 10)}"
 
 # Fallback cluster API endpoint: compute first cp host; else no compute → localhost:6443 (docker-desktop); else colima/linux from context.
 # With provider docker, no compute implies host→container so use localhost. Referenced by cluster_endpoint input.
@@ -90,7 +90,7 @@ kustomize:
   dependsOn:
     - policy-resources
   components:
-    - "${network.loadbalancer_driver == 'metallb' ? 'metallb' : ''}"
+    - "${lb_effective.driver == 'metallb' ? 'metallb' : ''}"
   timeout: 5m
   interval: 5m
 
@@ -101,9 +101,9 @@ kustomize:
   dependsOn:
     - lb-base
   components:
-    - ${network.loadbalancer_driver}
-    - "${network.loadbalancer_driver}/${network.loadbalancer_mode}"
+    - ${lb_effective.driver}
+    - "${lb_effective.driver}/${network.loadbalancer_mode ?? 'arp'}"
   substitutions:
-    loadbalancer_ip_range: ${network.loadbalancer_ips.start + '-' + network.loadbalancer_ips.end}
+    loadbalancer_ip_range: ${network_effective.loadbalancer_ips.start + '-' + network_effective.loadbalancer_ips.end}
   timeout: 5m
   interval: 5m

--- a/contexts/_template/facets/provider-incus.yaml
+++ b/contexts/_template/facets/provider-incus.yaml
@@ -16,7 +16,7 @@ config:
       - name: longhorn
         size: 30
     # Incus assigns the controlplane a fixed IP at offset 10 in the network CIDR.
-    k8s_service_host: "${cidrhost(network.cidr_block, 10)}"
+    k8s_service_host: "${cidrhost(network_effective.cidr_block, 10)}"
 
 # colima-incus: use flannel (no cilium overhead) — this setup is primarily for testing storage drivers.
 - name: cni_effective
@@ -42,7 +42,7 @@ terraform:
   inputs:
     network_name: ""
     create_network: true
-    network_cidr: ${network.cidr_block}
+    network_cidr: ${network_effective.cidr_block}
     storage_pools:
       local:
         driver: null
@@ -50,7 +50,7 @@ terraform:
       - name: controlplane
         role: controlplane
         count: ${cluster.controlplanes.count ?? 1}
-        ipv4: ${cidrhost(network.cidr_block, 10)}
+        ipv4: ${cidrhost(network_effective.cidr_block, 10)}
         image: ${cluster.controlplanes.image ?? ("windsor:talos/v" + talos.talos_version + "/amd64")}
         type: virtual-machine
         description: Talos control plane node
@@ -67,7 +67,7 @@ terraform:
       - name: worker
         role: worker
         count: ${cluster.workers.count ?? 0}
-        ipv4: ${cidrhost(network.cidr_block, 20)}
+        ipv4: ${cidrhost(network_effective.cidr_block, 20)}
         image: ${cluster.workers.image ?? ("windsor:talos/v" + talos.talos_version + "/amd64")}
         type: virtual-machine
         description: Talos worker node
@@ -118,7 +118,7 @@ kustomize:
   dependsOn:
     - policy-resources
   components:
-    - "${network.loadbalancer_driver == 'metallb' ? 'metallb' : ''}"
+    - "${lb_effective.driver == 'metallb' ? 'metallb' : ''}"
   timeout: 5m
   interval: 5m
 
@@ -128,9 +128,9 @@ kustomize:
   dependsOn:
     - lb-base
   components:
-    - ${network.loadbalancer_driver}
-    - "${network.loadbalancer_driver}/${network.loadbalancer_mode}"
+    - ${lb_effective.driver}
+    - "${lb_effective.driver}/${network.loadbalancer_mode ?? 'arp'}"
   substitutions:
-    loadbalancer_ip_range: "${network.loadbalancer_ips.start + '-' + network.loadbalancer_ips.end}"
+    loadbalancer_ip_range: "${network_effective.loadbalancer_ips.start + '-' + network_effective.loadbalancer_ips.end}"
   timeout: 5m
   interval: 5m

--- a/contexts/_template/facets/provider-metal.yaml
+++ b/contexts/_template/facets/provider-metal.yaml
@@ -44,7 +44,7 @@ kustomize:
   dependsOn:
     - policy-resources
   components:
-    - "${network.loadbalancer_driver == 'metallb' ? 'metallb' : ''}"
+    - "${lb_effective.driver == 'metallb' ? 'metallb' : ''}"
   timeout: 5m
   interval: 5m
 
@@ -54,9 +54,9 @@ kustomize:
   dependsOn:
     - lb-base
   components:
-    - ${network.loadbalancer_driver}
-    - "${network.loadbalancer_driver}/${network.loadbalancer_mode}"
+    - ${lb_effective.driver}
+    - "${lb_effective.driver}/${network.loadbalancer_mode ?? 'arp'}"
   substitutions:
-    loadbalancer_ip_range: ${network.loadbalancer_ips.start + '-' + network.loadbalancer_ips.end}
+    loadbalancer_ip_range: ${network_effective.loadbalancer_ips.start + '-' + network_effective.loadbalancer_ips.end}
   timeout: 5m
   interval: 5m

--- a/contexts/_template/schema.yaml
+++ b/contexts/_template/schema.yaml
@@ -285,7 +285,6 @@ properties:
       cidr_block:
         type: string
         pattern: "^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"
-        default: "10.5.0.0/16"
         description: Primary network CIDR block
       loadbalancer_ips:
         type: object
@@ -293,12 +292,10 @@ properties:
           start:
             type: string
             pattern: "^([0-9]{1,3}\\.){3}[0-9]{1,3}$"
-            default: "10.5.1.10"
             description: Load balancer IP pool start
           end:
             type: string
             pattern: "^([0-9]{1,3}\\.){3}[0-9]{1,3}$"
-            default: "10.5.1.100"
             description: Load balancer IP pool end
         additionalProperties: false
       loadbalancer_driver:
@@ -306,13 +303,11 @@ properties:
         enum:
           - metallb
           - kube-vip
-        default: kube-vip
         description: In-cluster load balancer driver
       loadbalancer_mode:
         type: string
         enum:
           - arp
-        default: arp
         description: Load balancer mode (only 'arp' is currently supported; use for flat L2 networks with ARP broadcasts)
     additionalProperties: false
 

--- a/contexts/_template/tests/option-cni.test.yaml
+++ b/contexts/_template/tests/option-cni.test.yaml
@@ -230,6 +230,32 @@ cases:
             - gateway-base
             - cni
 
+  # network_effective: loadbalancer IPs derived from CIDR when not explicitly set (workstation layer active).
+  - name: loadbalancer IPs derived from cidr_block when not set
+    values:
+      provider: docker
+      workstation:
+        runtime: colima
+      gateway:
+        enabled: false
+      network:
+        cidr_block: 10.5.0.0/16
+        loadbalancer_driver: kube-vip
+        loadbalancer_mode: arp
+      cluster: *default-cluster
+    expect:
+      kustomize:
+        - <<: *cni-base
+          components:
+            - cilium
+            - cilium/talos
+            - cilium/prometheus
+            - cilium/hubble
+            - cilium/l2
+          substitutions:
+            loadbalancer_start_ip: "10.5.1.10"
+            loadbalancer_end_ip: "10.5.1.100"
+
   # Cilium: gitops terraform depends on cni when cilium is selected.
   - name: cilium driver makes gitops terraform depend on cni
     values:

--- a/contexts/_template/tests/option-gateway.test.yaml
+++ b/contexts/_template/tests/option-gateway.test.yaml
@@ -79,6 +79,7 @@ x-defaults:
       - cni
     substitutions:
       gateway_class_name: cilium
+      loadbalancer_start_ip: "10.5.1.10"
     timeout: 10m
     interval: 5m
 

--- a/contexts/_template/tests/option-gateway.test.yaml
+++ b/contexts/_template/tests/option-gateway.test.yaml
@@ -310,9 +310,10 @@ cases:
             gateway_class_name: envoy
             loadbalancer_start_ip: "10.5.1.10"
 
-  # AWS: gateway-resources renders without loadbalancer_ips (cloud LB, no IP pool).
-  # gateway_dns_target and loadbalancer_start_ip evaluate to empty string and are omitted from output.
-  - name: aws envoy gateway-resources renders with empty loadbalancer_start_ip and gateway_dns_target
+  # AWS: no network.loadbalancer_ips configured, so loadbalancer_start_ip falls back to the
+  # cidrhost default (10.5.1.10 from the default /16). gateway_dns_target evaluates to "" and
+  # is omitted from output because lb_effective.enabled is false on AWS (cloud-managed LB).
+  - name: aws envoy gateway-resources uses cidr-derived loadbalancer_start_ip
     values:
       provider: aws
       gateway:
@@ -326,5 +327,6 @@ cases:
             - gateway-base
           substitutions:
             gateway_class_name: envoy
+            loadbalancer_start_ip: "10.5.1.10"
           timeout: 10m
           interval: 5m

--- a/contexts/_template/tests/option-gateway.test.yaml
+++ b/contexts/_template/tests/option-gateway.test.yaml
@@ -309,8 +309,9 @@ cases:
             gateway_class_name: envoy
             loadbalancer_start_ip: "10.5.1.10"
 
-  # AWS: gateway-resources renders without loadbalancer_ips (cloud LB, no IP pool)
-  - name: aws envoy gateway-resources renders with empty loadbalancer_start_ip
+  # AWS: gateway-resources renders without loadbalancer_ips (cloud LB, no IP pool).
+  # gateway_dns_target and loadbalancer_start_ip evaluate to empty string and are omitted from output.
+  - name: aws envoy gateway-resources renders with empty loadbalancer_start_ip and gateway_dns_target
     values:
       provider: aws
       gateway:

--- a/contexts/_template/tests/option-gateway.test.yaml
+++ b/contexts/_template/tests/option-gateway.test.yaml
@@ -287,6 +287,28 @@ cases:
             - webhook
             - webhook/gateway
 
+  # lb-address: included when lb_effective.enabled (non-Cilium CNI + loadbalancer_driver set); IP pinned in gateway spec
+  - name: local envoy gateway-resources includes lb-address when loadbalancer IP configured
+    values:
+      provider: metal
+      gateway:
+        enabled: true
+        driver: envoy
+      network: *default-network
+      cluster:
+        <<: *default-cluster
+        cni:
+          driver: flannel
+    expect:
+      kustomize:
+        - name: gateway-resources
+          path: gateway/resources
+          components:
+            - lb-address
+          substitutions:
+            gateway_class_name: envoy
+            loadbalancer_start_ip: "10.5.1.10"
+
   # AWS: gateway-resources renders without loadbalancer_ips (cloud LB, no IP pool)
   - name: aws envoy gateway-resources renders with empty loadbalancer_start_ip
     values:

--- a/kustomize/gateway/resources/lb-address/kustomization.yaml
+++ b/kustomize/gateway/resources/lb-address/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: patches/gateway.yaml
+    target:
+      group: gateway.networking.k8s.io
+      version: v1
+      kind: Gateway
+      name: external
+      namespace: system-gateway

--- a/kustomize/gateway/resources/lb-address/patches/gateway.yaml
+++ b/kustomize/gateway/resources/lb-address/patches/gateway.yaml
@@ -1,0 +1,5 @@
+- op: add
+  path: /spec/addresses
+  value:
+    - type: IPAddress
+      value: ${loadbalancer_start_ip}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core networking defaults and load balancer/gateway rendering across multiple providers, which can change IP assignments and service reachability if assumptions differ between environments.
> 
> **Overview**
> Centralizes network defaults by introducing `network_effective` (CIDR + derived `loadbalancer_ips`) and updating facets/providers to consume these effective values instead of requiring explicit `network.*` settings.
> 
> Refines load balancer behavior via `lb_effective`: it now only enables an in-cluster LB when `network.loadbalancer_driver` is explicitly set (and CNI isn’t Cilium), and provider kustomizations now reference `lb_effective.driver` and the effective IP range.
> 
> For non-Cilium gateways on local platforms, `gateway-resources` can now include a new `lb-address` kustomize component that patches the `Gateway` to use `spec.addresses` with `loadbalancer_start_ip`; schema defaults for network/LB fields were removed and tests were updated/added to cover CIDR-derived IPs and the new gateway behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c58ab32d31a0200469d6e2c4cda14858c1ddc3b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->