### PR TITLE
fix(workstation): Pin registry mirror to 3.0.0 to avoid bug

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,11 +7,6 @@
   ],
   "packageRules": [
     {
-      "description": "Pin ghcr.io/distribution/distribution at 3.0.0 - bug in 3.1.0",
-      "matchPackageNames": ["ghcr.io/distribution/distribution"],
-      "enabled": false
-    },
-    {
       "description": "Pin GitHub Actions to specific commit SHAs",
       "matchManagers": [
         "github-actions"
@@ -104,6 +99,11 @@
       "automergeType": "pr",
       "automergeStrategy": "squash",
       "labels": ["dependencies"]
+    },
+    {
+      "description": "Pin ghcr.io/distribution/distribution at 3.0.0 - bug in 3.1.0",
+      "matchPackageNames": ["ghcr.io/distribution/distribution"],
+      "enabled": false
     }
   ],
   "customManagers": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,11 @@
   ],
   "packageRules": [
     {
+      "description": "Pin ghcr.io/distribution/distribution at 3.0.0 - bug in 3.1.0",
+      "matchPackageNames": ["ghcr.io/distribution/distribution"],
+      "enabled": false
+    },
+    {
       "description": "Pin GitHub Actions to specific commit SHAs",
       "matchManagers": [
         "github-actions"

--- a/terraform/workstation/docker/main.tf
+++ b/terraform/workstation/docker/main.tf
@@ -199,7 +199,7 @@ resource "docker_container" "dns" {
 resource "docker_image" "registry" {
   count = length(local.registries) > 0 ? 1 : 0
   # renovate: datasource=docker depName=ghcr.io/distribution/distribution package=ghcr.io/distribution/distribution
-  name = "ghcr.io/distribution/distribution:3.1.0@sha256:4fdc7c11dd6b58fd06e386971bf29929eebd831a074197ad1457a1aefeacf3da"
+  name = "ghcr.io/distribution/distribution:3.0.0@sha256:4ba3adf47f5c866e9a29288c758c5328ef03396cb8f5f6454463655fa8bc83e2"
 }
 
 resource "docker_container" "registry" {

--- a/terraform/workstation/incus/main.tf
+++ b/terraform/workstation/incus/main.tf
@@ -189,7 +189,7 @@ resource "incus_instance" "registry" {
   name     = replace(local.registry_hostname[each.key], ".", "-")
   type     = "container"
   # renovate: datasource=docker depName=ghcr.io/distribution/distribution package=ghcr.io/distribution/distribution
-  image      = "ghcr:distribution/distribution:3.1.0@sha256:4fdc7c11dd6b58fd06e386971bf29929eebd831a074197ad1457a1aefeacf3da"
+  image      = "ghcr:distribution/distribution:3.0.0@sha256:4ba3adf47f5c866e9a29288c758c5328ef03396cb8f5f6454463655fa8bc83e2"
   depends_on = [incus_network.main, local_file.registry_cache_dir]
   config = each.value.remote != null ? {
     "environment.REGISTRY_PROXY_REMOTEURL" = each.value.remote


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the pinned `ghcr.io/distribution/distribution` image version/digest used by workstation registry mirrors, which can impact local dev registry behavior. Low code complexity, but image downgrades can have runtime compatibility implications.
> 
> **Overview**
> Pins the workstation registry mirror container image (`ghcr.io/distribution/distribution`) to **3.0.0** (with a new sha256 digest) for both the Docker and Incus Terraform modules, replacing the previous **3.1.0** pin.
> 
> Adds a Renovate package rule to effectively *hold* `ghcr.io/distribution/distribution` at this version (rule added with `enabled: false`) to avoid automatically upgrading to the known-bad release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2e54b45db3cb22eff5e846c4350522bf264c5e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->