### PR TITLE
chore(ci): Allow Claude diagnosis on renovate PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -231,6 +231,7 @@ jobs:
           windsor show blueprint
 
       - name: Windsor Up
+        id: windsor_up
         run: windsor up --verbose --wait
 
       - name: Collect Windsor State
@@ -269,7 +270,7 @@ jobs:
           retention-days: 30
 
       - name: Investigate cluster failure with Claude
-        if: failure()
+        if: always() && steps.windsor_up.outcome == 'failure'
         uses: anthropics/claude-code-action@5fb899572b81d2bb648d4d187173a2f423a9677c # v1.0.96
         env:
           GH_REPO: ${{ github.repository }}
@@ -281,6 +282,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_bots: "renovate"
           prompt: |
             The integration test job just failed. The local Windsor cluster
             is still running on this runner and has NOT been torn down yet.


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> This change is fully contained within a single CI workflow step and has no effect on production code or shipped artifacts.
>
> **Overview**
>
> The PR tightens when the cluster-failure diagnosis action fires and extends that diagnosis to Renovate dependency-bump PRs. The previous condition, `failure()`, would trigger the Claude inspection step whenever any job step failed; the new `always() && steps.windsor_up.outcome == 'failure'` ensures the live-cluster inspection only runs when the cluster setup itself fails — the one scenario where a running cluster is still available to inspect. The `allowed_bots: "renovate"` addition removes the guard that was silently preventing Renovate-authored PRs from receiving automated diagnosis.
>
> Because Renovate can open many PRs across active dependency ranges, each `windsor_up` failure on a Renovate PR will now consume an Anthropic API call. This is worth monitoring if cluster setup is intermittently flaky, but is not a correctness concern.
>
> Reviewed by Claude for commit `d88e610`.

<!-- /claude-code-review:summary -->
