### PR TITLE
feat(mirror): Support for docker and helm mirrors

### DIFF
--- a/contexts/_template/facets/config-talos.yaml
+++ b/contexts/_template/facets/config-talos.yaml
@@ -20,6 +20,32 @@ when: cluster.driver == 'talos'
 config:
 
   # ---------------------------------------------------------------------------
+  # Default registries
+  # ---------------------------------------------------------------------------
+  #
+  # Canonical list of upstream registries. User-supplied docker.registries
+  # entries are merged on top (augment, not replace) so adding a private
+  # registry doesn't lose the defaults.
+  #
+  # Referenced by config-talos (mirror mode) and option-workstation
+  # (pull-through mode + local mirror mode).
+  #
+  - name: default_registries
+    value:
+      registries: >-
+        ${fromPairs(concat(
+          toPairs({
+            "gcr.io": { "remote": "https://gcr.io" },
+            "ghcr.io": { "remote": "https://ghcr.io" },
+            "quay.io": { "remote": "https://quay.io" },
+            "reg.kyverno.io": { "remote": "https://reg.kyverno.io" },
+            "registry-1.docker.io": { "remote": "https://registry-1.docker.io", "local": "docker.io" },
+            "registry.k8s.io": { "remote": "https://registry.k8s.io" }
+          }),
+          toPairs(docker.registries ?? {})
+        ))}
+
+  # ---------------------------------------------------------------------------
   # talos_common defaults
   # ---------------------------------------------------------------------------
   #
@@ -147,6 +173,43 @@ config:
               # and shaves ~128 MiB off the etcd data directory.
               max-snapshots: "3"
               max-wals: "3"
+
+  # ---------------------------------------------------------------------------
+  # Registry mirror (mirror_effective)
+  # ---------------------------------------------------------------------------
+  #
+  # When a mirror is active (explicit cluster.mirror or workstation mirror
+  # service — resolved by mirror_effective in platform-base), configure Talos
+  # to pull all images through the mirror using overridePath.
+  #
+  # windsor mirror stores images with the upstream host in the repository path
+  # (e.g. docker.io/library/nginx), so each mirror entry uses overridePath: true
+  # with the registry key embedded in the endpoint URL path (/v2/<key>).
+  #
+  # The mirror address uses terraform_output at render time (not config time)
+  # for the workstation case; cluster.mirror is available at config time.
+  #
+  - name: talos_registry_mirrors
+    when: mirror_effective.active == true
+    value:
+      mirrors: >-
+        ${fromPairs(map(
+          toPairs(default_registries.registries),
+          [
+            (get(get(#, 1), "local") != null && get(get(#, 1), "local") != "" ? get(get(#, 1), "local") : get(#, 0)),
+            { endpoints: ["http://" + ((cluster.mirror ?? ((terraform_output('workstation', 'mirror_hostname') ?? 'mirror') + ':5000'))) + "/v2/" + (get(get(#, 1), "local") != null && get(get(#, 1), "local") != "" ? get(get(#, 1), "local") : get(#, 0))], overridePath: true }
+          ]
+        ))}
+      config: {}
+
+  - name: talos_common
+    when: mirror_effective.active == true
+    value:
+      common_patch:
+        machine:
+          registries:
+            mirrors: ${talos_registry_mirrors.mirrors}
+            config: ${talos_registry_mirrors.config}
 
   # ---------------------------------------------------------------------------
   # Pinned Talos version

--- a/contexts/_template/facets/option-cni.yaml
+++ b/contexts/_template/facets/option-cni.yaml
@@ -30,7 +30,13 @@ terraform:
     dependsOn:
       - cluster
     inputs:
-      cluster_endpoint: "${cluster.endpoint ?? cluster_endpoint_fallback.endpoint}"
+      cluster_endpoint: >-
+        ${cluster.endpoint
+          ?? (cluster_endpoint_fallback.endpoint != '' ? cluster_endpoint_fallback.endpoint : null)
+          ?? (len(terraform_output("compute", "controlplanes") ?? []) > 0
+              && terraform_output("compute", "controlplanes")[0].endpoint != null
+                ? "https://" + split(terraform_output("compute", "controlplanes")[0].endpoint, ":")[0] + ":6443"
+                : "https://localhost:6443")}
       talos_mode: true
 
   # Dependency merges — insert the `cni` step into the existing terraform graph

--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -52,49 +52,40 @@ config:
       incus_image: "windsor:talos/v${talos.talos_version}/${workstation.arch ?? 'amd64'}"
 
   # ---------------------------------------------------------------------------
-  # Registry mirrors (pull-through cache)
+  # Registry mirrors (pull-through cache) and mirror registry
   # ---------------------------------------------------------------------------
   #
-  # `workstation_registries.registries` is the map of upstream → mirror used
-  # both by the workstation Terraform (to run the mirror containers) and by
-  # the Talos registry config (to redirect pulls).
+  # `workstation_registries.registries` is the canonical list of upstream
+  # registries used for pull-through containers and (when no explicit
+  # cluster.mirror is set) for Talos mirror keys.
   #
-  # Empty when workstation.services.registries == false. Otherwise uses
-  # user-supplied docker.registries or falls back to a sensible default set.
+  # When cluster.mirror is set, config-talos.yaml handles the Talos mirror
+  # config universally (any platform). This facet only generates Talos mirrors
+  # for two workstation-specific cases:
+  #   1. Pull-through mode: per-registry containers with hostnames from TF output
+  #   2. Local mirror mode: workstation.services.mirror without explicit cluster.mirror
   #
   - name: workstation_registries
     value:
-      registries: |
-        ${(workstation.services.registries ?? true) == false ? {} : (docker.registries ?? {
-          "gcr.io": { "remote": "https://gcr.io" },
-          "ghcr.io": { "remote": "https://ghcr.io" },
-          "quay.io": { "remote": "https://quay.io" },
-          "reg.kyverno.io": { "remote": "https://reg.kyverno.io" },
-          "registry-1.docker.io": { "remote": "https://registry-1.docker.io", "local": "docker.io" },
-          "registry.k8s.io": { "remote": "https://registry.k8s.io" }
-        })}
+      registries: "${(workstation.services.registries ?? true) == false ? {} : default_registries.registries}"
 
-  # Transform workstation TF output into the Talos machine.registries.mirrors
-  # shape. Only entries with both `remote` and `hostname` set are included;
-  # `local` (when present) is used as the mirror key so users can override the
-  # upstream name (e.g. "registry-1.docker.io" → "docker.io").
-  #
-  # config: {} — intentionally empty. Talos errors
-  # "TLS config specified for non-HTTPS registry" if tls is set for http://
-  # endpoints, and our mirrors are always plain HTTP.
-  - name: talos_registry_mirrors
-    when: cluster.driver == 'talos' && (cluster.enabled ?? true)
+  - name: workstation_mirror
     value:
-      mirrors: >-
-        ${fromPairs(map(
-          filter(toPairs(terraform_output("workstation", "registries") ?? {}),
-            get(get(#, 1), "remote") != null && get(get(#, 1), "remote") != "" && get(get(#, 1), "hostname") != null && get(get(#, 1), "hostname") != ""
-          ),
-          [
-            (get(get(#, 1), "local") != null && get(get(#, 1), "local") != "" ? get(get(#, 1), "local") : get(#, 0)),
-            { endpoints: ["http://" + get(get(#, 1), "hostname") + ":5000"] }
-          ]
-        ))}
+      # enabled: controls local mirror container creation (workstation.services.mirror)
+      enabled: "${(workstation.services.mirror ?? false) && (workstation.services.registries ?? true) != false}"
+      # active: true when ANY mirror is in use (local container OR explicit cluster.mirror).
+      # When active, pull-through caches are disabled.
+      active: "${((workstation.services.mirror ?? false) || (cluster.mirror ?? '') != '') && (workstation.services.registries ?? true) != false}"
+
+  # Pull-through mode: each registry has its own container and hostname.
+  # Only when no mirror is active (cluster.mirror not set, services.mirror off).
+  #
+  # NOTE: terraform_output is a deferred expression and cannot be used in config
+  # blocks. The pull-through registry mirrors are resolved at render time in
+  # the talos_common block below.
+  - name: talos_registry_mirrors
+    when: cluster.driver == 'talos' && (cluster.enabled ?? true) && workstation_mirror.active != true
+    value:
       config: {}
 
   # ---------------------------------------------------------------------------
@@ -106,14 +97,17 @@ config:
   # replace talos_common, they extend it.
   #
 
-  # Inject registry mirrors (always, for any workstation runtime).
+  # Inject registry config into Talos machine config.
+  # When a mirror is active, config-talos.yaml handles registry mirror
+  # injection. In pull-through mode, only the static config (no TLS) goes
+  # here. The actual mirror map requires terraform_output (deferred) and is
+  # passed via registry_config_patches terraform input below.
   - name: talos_common
-    when: cluster.driver == 'talos' && (cluster.enabled ?? true)
+    when: cluster.driver == 'talos' && (cluster.enabled ?? true) && mirror_effective.active != true
     value:
       common_patch:
         machine:
           registries:
-            mirrors: ${talos_registry_mirrors.mirrors}
             config: ${talos_registry_mirrors.config}
 
   # Docker only: when there are no workers, schedule workloads on control planes.
@@ -233,7 +227,9 @@ terraform:
       primary_node_ip: "${cidrhost(network_effective.cidr_block, 10)}"
       enable_dns: ${workstation.services.dns ?? true}
       enable_git: ${workstation.services.git ?? true}
-      registries: ${workstation_registries.registries ?? {}}
+      enable_mirror: ${workstation_mirror.enabled}
+      mirror_hostport: 5050
+      registries: "${workstation_mirror.active ? {} : (workstation_registries.registries ?? {})}"
 
   # Colima / docker / linux: loadbalancer exists, so DNS and webhook target
   # the LB IP. Webhook port is 80 when Gateway is active (routed through the
@@ -256,7 +252,9 @@ terraform:
       primary_node_ip: ${network_effective.loadbalancer_ips.start}
       enable_dns: ${workstation.services.dns ?? true}
       enable_git: ${workstation.services.git ?? true}
-      registries: ${workstation_registries.registries ?? {}}
+      enable_mirror: ${workstation_mirror.enabled}
+      mirror_hostport: 5050
+      registries: "${workstation_mirror.active ? {} : (workstation_registries.registries ?? {})}"
 
   # Incus: uses workstation/incus module. Reuses incusbr0 when running under
   # colima (colima creates the bridge); creates its own network otherwise.
@@ -276,7 +274,8 @@ terraform:
       primary_node_ip: ${network_effective.loadbalancer_ips.start}
       enable_dns: ${workstation.services.dns ?? true}
       enable_git: ${workstation.services.git ?? true}
-      registries: ${workstation_registries.registries ?? {}}
+      enable_mirror: ${workstation_mirror.enabled}
+      registries: "${workstation_mirror.active ? {} : (workstation_registries.registries ?? {})}"
       webhook_token: ${gitops.webhook.token ?? "abcdef123456"}
       git_username: ${workstation.git.username ?? "local"}
       git_password: ${workstation.git.password ?? "local"}
@@ -402,6 +401,16 @@ terraform:
       controlplane_disks: ${talos_common.controlplane_disks}
       worker_disks: ${talos_common.worker_disks}
       common_config_patches: ${talos_common.common_config_patches}
+      registry_config_patches: >-
+        ${mirror_effective.active != true ? string({machine: {registries: {mirrors: fromPairs(map(
+          filter(toPairs(terraform_output("workstation", "registries") ?? {}),
+            get(get(#, 1), "remote") != null && get(get(#, 1), "remote") != "" && get(get(#, 1), "hostname") != null && get(get(#, 1), "hostname") != ""
+          ),
+          [
+            (get(get(#, 1), "local") != null && get(get(#, 1), "local") != "" ? get(get(#, 1), "local") : get(#, 0)),
+            { endpoints: ["http://" + get(get(#, 1), "hostname") + ":5000"] }
+          ]
+        ))}}}) : ""}
       controlplane_volumes: ${talos_common.controlplane_volumes ?? []}
       worker_volumes: ${talos_common.worker_volumes ?? []}
 

--- a/contexts/_template/facets/platform-base.yaml
+++ b/contexts/_template/facets/platform-base.yaml
@@ -175,6 +175,20 @@ config:
     value:
       logs_driver: "${telemetry.logs.driver ?? 'fluentd'}"
 
+  # ---------------------------------------------------------------------------
+  # Mirror effective value
+  # ---------------------------------------------------------------------------
+  #
+  # Whether a mirror is active (explicit cluster.mirror or workstation mirror
+  # service). Used by config-talos and by `when:` guards that need a
+  # composition-time check. The actual mirror address is resolved at render
+  # time in the substitutions block (terraform_output is not available during
+  # config composition).
+  #
+  - name: mirror_effective
+    value:
+      active: "${(cluster.mirror ?? '') != '' || (workstation.services.mirror ?? false) == true}"
+
 # =============================================================================
 # Global substitutions
 # =============================================================================
@@ -195,6 +209,17 @@ substitutions:
   # FQDN suffix for externally-reachable resources on cloud platforms. Unused
   # on local/workstation contexts where private_domain covers everything.
   public_domain: ${dns.public_domain}
+
+  # Helm chart source override for mirror/air-gap mode. When a mirror is
+  # active (explicit cluster.mirror or workstation mirror service), all
+  # HelmRepositories switch to OCI and pull charts from the mirror.
+  # Otherwise, per-repo vendor defaults take effect via Flux envsubst fallback.
+  #
+  # The mirror address is resolved here (not in config) because
+  # terraform_output is only available at render time, after apply.
+  helm_repo_type: "${mirror_effective.active == true ? 'oci' : ''}"
+  helm_registry: "${mirror_effective.active == true ? 'oci://' + ((cluster.mirror ?? ((terraform_output('workstation', 'mirror_hostname') ?? 'mirror') + ':5000'))) + '/charts' : ''}"
+  helm_repo_insecure: "${mirror_effective.active == true && (workstation.runtime ?? '') != '' ? 'true' : ''}"
 
 # =============================================================================
 # Kustomize — base cluster resources

--- a/contexts/_template/facets/platform-docker.yaml
+++ b/contexts/_template/facets/platform-docker.yaml
@@ -22,29 +22,19 @@ config:
       k8s_service_host: "${cidrhost(network_effective.cidr_block, 10)}"
 
   # ---------------------------------------------------------------------------
-  # cluster_endpoint_fallback — best-effort Talos API endpoint
+  # cluster_endpoint_fallback — config-time best-effort endpoint
   # ---------------------------------------------------------------------------
   #
-  # Resolution order:
-  #   1. Compute output with a real endpoint → use that host on port 6443.
-  #   2. No compute output (docker-desktop bootstrap, no cluster yet)
-  #      → localhost:6443 (host port-forwarded into the control plane
-  #      container).
-  #   3. Compute exists but has empty endpoint → fall back to the first
-  #      configured controlplane node.
-  #   4. Nothing — last-ditch localhost:6443.
+  # Provides a fallback from user-supplied cluster config (no terraform_output
+  # — deferred expressions are not allowed in config blocks). The terraform
+  # cluster input below resolves the full chain including compute output.
   #
   - name: cluster_endpoint_fallback
     value:
       endpoint: >-
-        ${len(terraform_output("compute", "controlplanes") ?? []) > 0
-          && terraform_output("compute", "controlplanes")[0].endpoint != null
-          ? "https://" + split(terraform_output("compute", "controlplanes")[0].endpoint, ":")[0] + ":6443"
-          : (len(terraform_output("compute", "controlplanes") ?? []) == 0
-            ? "https://localhost:6443"
-            : (len(values(cluster.controlplanes.nodes ?? {})) > 0
-              ? "https://" + split(values(cluster.controlplanes.nodes ?? {})[0].endpoint, ":")[0] + ":6443"
-              : "https://localhost:6443"))}
+        ${cluster.endpoint ?? (len(values(cluster.controlplanes.nodes ?? {})) > 0
+          ? "https://" + split(values(cluster.controlplanes.nodes ?? {})[0].endpoint, ":")[0] + ":6443"
+          : "https://localhost:6443")}
 
 # =============================================================================
 # Terraform — cluster/talos with docker-specific node rewriting
@@ -64,7 +54,15 @@ terraform:
       - compute
     parallelism: 1
     inputs:
-      cluster_endpoint: "${cluster.endpoint ?? cluster_endpoint_fallback.endpoint}"
+      cluster_endpoint: >-
+        ${cluster.endpoint ?? (len(terraform_output("compute", "controlplanes") ?? []) > 0
+          && terraform_output("compute", "controlplanes")[0].endpoint != null
+          ? "https://" + split(terraform_output("compute", "controlplanes")[0].endpoint, ":")[0] + ":6443"
+          : (len(terraform_output("compute", "controlplanes") ?? []) == 0
+            ? "https://localhost:6443"
+            : (len(values(cluster.controlplanes.nodes ?? {})) > 0
+              ? "https://" + split(values(cluster.controlplanes.nodes ?? {})[0].endpoint, ":")[0] + ":6443"
+              : "https://localhost:6443")))}
       cluster_name: talos
       talos_version: ${talos.talos_version}
 
@@ -119,6 +117,16 @@ terraform:
       controlplane_disks: ${cluster.controlplanes.disks ?? []}
       worker_disks: ${cluster.workers.disks ?? []}
       common_config_patches: ${talos_common.common_config_patches}
+      registry_config_patches: >-
+        ${mirror_effective.active != true ? string({machine: {registries: {mirrors: fromPairs(map(
+          filter(toPairs(terraform_output("workstation", "registries") ?? {}),
+            get(get(#, 1), "remote") != null && get(get(#, 1), "remote") != "" && get(get(#, 1), "hostname") != null && get(get(#, 1), "hostname") != ""
+          ),
+          [
+            (get(get(#, 1), "local") != null && get(get(#, 1), "local") != "" ? get(get(#, 1), "local") : get(#, 0)),
+            { endpoints: ["http://" + get(get(#, 1), "hostname") + ":5000"] }
+          ]
+        ))}}}) : ""}
       controlplane_config_patches: "${talos_common_docker.controlplane_config_patches ?? \"\"}"
       worker_config_patches: "${talos_common_docker.worker_config_patches ?? \"\"}"
       controlplane_volumes: ${talos_common.controlplane_volumes ?? []}

--- a/contexts/_template/facets/platform-incus.yaml
+++ b/contexts/_template/facets/platform-incus.yaml
@@ -27,21 +27,16 @@ config:
       k8s_service_host: "${cidrhost(network_effective.cidr_block, 10)}"
 
   # ---------------------------------------------------------------------------
-  # cluster_endpoint_fallback
+  # cluster_endpoint_fallback — config-time best-effort endpoint
   # ---------------------------------------------------------------------------
   #
-  # Only derivable from compute output — if there's no compute yet, return
-  # empty string and let the caller fall back to an explicit cluster.endpoint.
+  # Provides a fallback from user-supplied cluster config (no terraform_output
+  # — deferred expressions are not allowed in config blocks). The terraform
+  # cluster input below resolves the full chain including compute output.
   #
   - name: cluster_endpoint_fallback
     value:
-      endpoint: >-
-        ${
-          len(terraform_output("compute", "controlplanes") ?? []) > 0
-          && terraform_output("compute", "controlplanes")[0].endpoint != null
-            ? "https://" + split(terraform_output("compute", "controlplanes")[0].endpoint, ":")[0] + ":6443"
-            : ""
-        }
+      endpoint: "${cluster.endpoint ?? ''}"
 
 # =============================================================================
 # Terraform — standalone incus (no workstation)
@@ -122,7 +117,11 @@ terraform:
       - compute
     parallelism: 1
     inputs:
-      cluster_endpoint: "${cluster.endpoint ?? cluster_endpoint_fallback.endpoint}"
+      cluster_endpoint: >-
+        ${cluster.endpoint ?? (len(terraform_output("compute", "controlplanes") ?? []) > 0
+          && terraform_output("compute", "controlplanes")[0].endpoint != null
+            ? "https://" + split(terraform_output("compute", "controlplanes")[0].endpoint, ":")[0] + ":6443"
+            : "")}
       cluster_name: talos
       talos_version: ${talos.talos_version}
       controlplanes: ${terraform_output("compute", "controlplanes") ?? values(cluster.controlplanes.nodes)}

--- a/contexts/_template/schema.yaml
+++ b/contexts/_template/schema.yaml
@@ -430,6 +430,13 @@ properties:
               cilium bootstraps Cilium via terraform/cni/cilium before Flux starts (disables
               flannel and kube-proxy in Talos machine config) and manages it via Flux GitOps.
         additionalProperties: false
+      mirror:
+        type: string
+        description: >
+          Mirror registry address (host:port, e.g. 10.0.0.5:5000 or mirror.internal:5000).
+          When set, all cluster registry mirrors point to http://<mirror> and pull-through
+          caches are disabled. Auto-populated from the workstation mirror container hostname
+          when workstation.services.mirror is true and this is not explicitly set.
     additionalProperties: false
 
   # DNS configuration
@@ -587,6 +594,10 @@ properties:
             type: boolean
             default: true
             description: Create registry proxy containers (from docker.registries when true)
+          mirror:
+            type: boolean
+            default: false
+            description: Enable local mirror registry container (pre-loaded images only; disables pull-through proxies).
         additionalProperties: false
         description: Toggle workstation services
       git:

--- a/contexts/_template/tests/option-workstation.test.yaml
+++ b/contexts/_template/tests/option-workstation.test.yaml
@@ -71,7 +71,6 @@ cases:
                     rotate-server-certificates: "true"
                 registries:
                   config: {}
-                  mirrors: {}
         - name: gitops
           path: gitops/flux
           destroy: false
@@ -252,7 +251,6 @@ cases:
                     rotate-server-certificates: "true"
                 registries:
                   config: {}
-                  mirrors: {}
         - name: gitops
           path: gitops/flux
           inputs:
@@ -419,6 +417,182 @@ cases:
           path: gitops/flux
           inputs:
             webhook_token: mysecrettoken
+
+  # Edge: workstation.services.mirror creates local mirror, configures talos,
+  # and auto-populates cluster.mirror so helm substitutions fire.
+  - name: workstation mirror service replaces pull-through caches
+    values:
+      provider: docker
+      workstation:
+        runtime: colima
+        services:
+          mirror: true
+      dns: *default-dns
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster: *default-cluster
+    terraformOutputs:
+      compute:
+        controlplanes:
+          - endpoint: 10.5.0.10:6443
+            node: 10.5.0.10
+            hostname: controlplane-1
+        workers: []
+      workstation:
+        mirror_hostname: mirror.test.local
+        registries: {}
+    expect:
+      terraform:
+        - name: workstation
+          path: workstation/docker
+          inputs:
+            registries: {}
+            enable_mirror: true
+            mirror_hostport: 5050
+        - name: cluster
+          path: cluster/talos
+          inputs:
+            common_config_patches: |-
+              cluster:
+                allowSchedulingOnControlPlanes: true
+                extraManifests:
+                - https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml
+                network:
+                  cni:
+                    name: none
+                proxy:
+                  disabled: true
+              machine:
+                kubelet:
+                  extraArgs:
+                    rotate-server-certificates: "true"
+                registries:
+                  config: {}
+                  mirrors:
+                    docker.io:
+                      endpoints:
+                      - http://mirror.test.local:5000/v2/docker.io
+                      overridePath: true
+                    gcr.io:
+                      endpoints:
+                      - http://mirror.test.local:5000/v2/gcr.io
+                      overridePath: true
+                    ghcr.io:
+                      endpoints:
+                      - http://mirror.test.local:5000/v2/ghcr.io
+                      overridePath: true
+                    quay.io:
+                      endpoints:
+                      - http://mirror.test.local:5000/v2/quay.io
+                      overridePath: true
+                    reg.kyverno.io:
+                      endpoints:
+                      - http://mirror.test.local:5000/v2/reg.kyverno.io
+                      overridePath: true
+                    registry.k8s.io:
+                      endpoints:
+                      - http://mirror.test.local:5000/v2/registry.k8s.io
+                      overridePath: true
+        - name: gitops
+          path: gitops/flux
+          destroy: false
+      config:
+        mirror_effective:
+          active: true
+
+  # Edge: explicit cluster.mirror address without local container
+  - name: explicit cluster mirror disables pull-through and configures talos
+    values:
+      provider: docker
+      workstation:
+        runtime: colima
+      dns: *default-dns
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster:
+        <<: *default-cluster
+        mirror: "10.0.0.5:5000"
+    terraformOutputs: *default-terraform-outputs
+    expect:
+      terraform:
+        - name: workstation
+          path: workstation/docker
+          inputs:
+            registries: {}
+            enable_mirror: false
+        - name: cluster
+          path: cluster/talos
+          inputs:
+            common_config_patches: |-
+              cluster:
+                allowSchedulingOnControlPlanes: true
+                extraManifests:
+                - https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml
+                network:
+                  cni:
+                    name: none
+                proxy:
+                  disabled: true
+              machine:
+                kubelet:
+                  extraArgs:
+                    rotate-server-certificates: "true"
+                registries:
+                  config: {}
+                  mirrors:
+                    docker.io:
+                      endpoints:
+                      - http://10.0.0.5:5000/v2/docker.io
+                      overridePath: true
+                    gcr.io:
+                      endpoints:
+                      - http://10.0.0.5:5000/v2/gcr.io
+                      overridePath: true
+                    ghcr.io:
+                      endpoints:
+                      - http://10.0.0.5:5000/v2/ghcr.io
+                      overridePath: true
+                    quay.io:
+                      endpoints:
+                      - http://10.0.0.5:5000/v2/quay.io
+                      overridePath: true
+                    reg.kyverno.io:
+                      endpoints:
+                      - http://10.0.0.5:5000/v2/reg.kyverno.io
+                      overridePath: true
+                    registry.k8s.io:
+                      endpoints:
+                      - http://10.0.0.5:5000/v2/registry.k8s.io
+                      overridePath: true
+        - name: gitops
+          path: gitops/flux
+          destroy: false
+
+  # Edge: mirror disabled by default — pull-through caches used as normal
+  - name: mirror disabled by default uses pull-through caches
+    values:
+      provider: docker
+      workstation:
+        runtime: colima
+      dns: *default-dns
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster: *default-cluster
+    terraformOutputs: *default-terraform-outputs
+    expect:
+      terraform:
+        - name: workstation
+          path: workstation/docker
+          inputs:
+            enable_mirror: false
+        - name: cluster
+          path: cluster/talos
+        - name: gitops
+          path: gitops/flux
+          destroy: false
 
   # Edge: gitops webhook settings are top-level and propagate to both gitops/flux and workstation modules.
   - name: gitops webhook feature flag disables receiver component

--- a/contexts/_template/tests/platform-docker.test.yaml
+++ b/contexts/_template/tests/platform-docker.test.yaml
@@ -178,8 +178,9 @@ cases:
         - name: lb-base
         - name: lb-resources
 
-  # Registry mirrors: when terraform_output("workstation", "registries") has hostname, common_config_patches must include non-empty mirrors. Colima: no certSANs.
-  - name: cluster common_config_patches includes registry mirrors when docker.registries have hostname
+  # Registry mirrors: when terraform_output("workstation", "registries") has hostname,
+  # registry_config_patches carries the pull-through mirror map (deferred expression).
+  - name: cluster registry_config_patches includes pull-through mirrors when docker.registries have hostname
     values:
       platform: docker
       workstation:
@@ -200,22 +201,9 @@ cases:
         - name: cluster
           path: cluster/talos
           inputs:
-            common_config_patches: |-
-              cluster:
-                allowSchedulingOnControlPlanes: true
-                extraManifests:
-                - https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml
-                network:
-                  cni:
-                    name: none
-                proxy:
-                  disabled: true
+            registry_config_patches: |-
               machine:
-                kubelet:
-                  extraArgs:
-                    rotate-server-certificates: "true"
                 registries:
-                  config: {}
                   mirrors:
                     gcr.io:
                       endpoints:

--- a/contexts/_template/tests/platform-metal.test.yaml
+++ b/contexts/_template/tests/platform-metal.test.yaml
@@ -283,6 +283,67 @@ cases:
           timeout: 5m
           interval: 5m
 
+  # Edge: cluster.mirror on metal configures Talos mirrors without workstation
+  # and sets helm_registry/helm_repo_type substitutions for air-gap Helm OCI.
+  - name: cluster mirror on metal configures talos registry mirrors
+    values:
+      provider: metal
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster:
+        <<: *default-cluster
+        mirror: "10.0.0.5:5000"
+    expect:
+      terraform:
+        - name: cluster
+          path: cluster/talos
+          inputs:
+            common_config_patches: |-
+              cluster:
+                allowSchedulingOnControlPlanes: true
+                extraManifests:
+                - https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml
+                network:
+                  cni:
+                    name: none
+                proxy:
+                  disabled: true
+              machine:
+                kubelet:
+                  extraArgs:
+                    rotate-server-certificates: "true"
+                registries:
+                  config: {}
+                  mirrors:
+                    docker.io:
+                      endpoints:
+                      - http://10.0.0.5:5000/v2/docker.io
+                      overridePath: true
+                    gcr.io:
+                      endpoints:
+                      - http://10.0.0.5:5000/v2/gcr.io
+                      overridePath: true
+                    ghcr.io:
+                      endpoints:
+                      - http://10.0.0.5:5000/v2/ghcr.io
+                      overridePath: true
+                    quay.io:
+                      endpoints:
+                      - http://10.0.0.5:5000/v2/quay.io
+                      overridePath: true
+                    reg.kyverno.io:
+                      endpoints:
+                      - http://10.0.0.5:5000/v2/reg.kyverno.io
+                      overridePath: true
+                    registry.k8s.io:
+                      endpoints:
+                      - http://10.0.0.5:5000/v2/registry.k8s.io
+                      overridePath: true
+      config:
+        mirror_effective:
+          active: true
+
   # Edge case: longhorn storage driver passes Talos extensions via cluster-extensions step
   - name: longhorn storage driver passes iscsi and util-linux extensions to cluster terraform
     values:

--- a/kustomize/cni/cilium/helm-repository.yaml
+++ b/kustomize/cni/cilium/helm-repository.yaml
@@ -7,4 +7,6 @@ metadata:
 spec:
   interval: 10m
   timeout: 5m
-  url: https://helm.cilium.io
+  type: ${helm_repo_type:=default}
+  url: ${helm_registry:=https://helm.cilium.io}
+  insecure: ${helm_repo_insecure:=false}

--- a/kustomize/csi/longhorn/helm-repository.yaml
+++ b/kustomize/csi/longhorn/helm-repository.yaml
@@ -7,4 +7,6 @@ metadata:
 spec:
   interval: 10m
   timeout: 5m
-  url: https://charts.longhorn.io
+  type: ${helm_repo_type:=default}
+  url: ${helm_registry:=https://charts.longhorn.io}
+  insecure: ${helm_repo_insecure:=false}

--- a/kustomize/csi/openebs/helm-repository.yaml
+++ b/kustomize/csi/openebs/helm-repository.yaml
@@ -7,4 +7,6 @@ metadata:
 spec:
   interval: 10m
   timeout: 5m
-  url: https://openebs.github.io/openebs
+  type: ${helm_repo_type:=default}
+  url: ${helm_registry:=https://openebs.github.io/openebs}
+  insecure: ${helm_repo_insecure:=false}

--- a/kustomize/database/cloudnativepg/helm-repository.yaml
+++ b/kustomize/database/cloudnativepg/helm-repository.yaml
@@ -7,4 +7,6 @@ metadata:
 spec:
   interval: 10m
   timeout: 3m
-  url: https://cloudnative-pg.github.io/charts
+  type: ${helm_repo_type:=default}
+  url: ${helm_registry:=https://cloudnative-pg.github.io/charts}
+  insecure: ${helm_repo_insecure:=false}

--- a/kustomize/dns/coredns/helm-repository.yaml
+++ b/kustomize/dns/coredns/helm-repository.yaml
@@ -7,4 +7,6 @@ metadata:
 spec:
   interval: 10m
   timeout: 3m
-  url: https://coredns.github.io/helm
+  type: ${helm_repo_type:=default}
+  url: ${helm_registry:=https://coredns.github.io/helm}
+  insecure: ${helm_repo_insecure:=false}

--- a/kustomize/dns/external-dns/helm-repository.yaml
+++ b/kustomize/dns/external-dns/helm-repository.yaml
@@ -7,4 +7,6 @@ metadata:
 spec:
   interval: 10m
   timeout: 3m
-  url: https://kubernetes-sigs.github.io/external-dns/
+  type: ${helm_repo_type:=default}
+  url: ${helm_registry:=https://kubernetes-sigs.github.io/external-dns/}
+  insecure: ${helm_repo_insecure:=false}

--- a/kustomize/gateway/base/envoy/helm-repository.yaml
+++ b/kustomize/gateway/base/envoy/helm-repository.yaml
@@ -7,5 +7,6 @@ metadata:
 spec:
   interval: 10m
   timeout: 3m
-  type: oci
-  url: oci://docker.io/envoyproxy
+  type: ${helm_repo_type:=oci}
+  url: ${helm_registry:=oci://docker.io/envoyproxy}
+  insecure: ${helm_repo_insecure:=false}

--- a/kustomize/ingress/nginx/helm-repository.yaml
+++ b/kustomize/ingress/nginx/helm-repository.yaml
@@ -7,4 +7,6 @@ metadata:
 spec:
   interval: 10m
   timeout: 3m
-  url: https://kubernetes.github.io/ingress-nginx
+  type: ${helm_repo_type:=default}
+  url: ${helm_registry:=https://kubernetes.github.io/ingress-nginx}
+  insecure: ${helm_repo_insecure:=false}

--- a/kustomize/lb/base/metallb/helm-repository.yaml
+++ b/kustomize/lb/base/metallb/helm-repository.yaml
@@ -7,4 +7,6 @@ metadata:
 spec:
   interval: 10m
   timeout: 3m
-  url: https://metallb.github.io/metallb
+  type: ${helm_repo_type:=default}
+  url: ${helm_registry:=https://metallb.github.io/metallb}
+  insecure: ${helm_repo_insecure:=false}

--- a/kustomize/lb/resources/kube-vip/helm-repository.yaml
+++ b/kustomize/lb/resources/kube-vip/helm-repository.yaml
@@ -7,5 +7,7 @@ metadata:
 spec:
   interval: 10m
   timeout: 3m
-  url: https://kube-vip.github.io/helm-charts
+  type: ${helm_repo_type:=default}
+  url: ${helm_registry:=https://kube-vip.github.io/helm-charts}
+  insecure: ${helm_repo_insecure:=false}
 

--- a/kustomize/object-store/base/minio/helm-repository.yaml
+++ b/kustomize/object-store/base/minio/helm-repository.yaml
@@ -7,4 +7,6 @@ metadata:
 spec:
   interval: 10m
   timeout: 3m
-  url: https://operator.min.io/
+  type: ${helm_repo_type:=default}
+  url: ${helm_registry:=https://operator.min.io/}
+  insecure: ${helm_repo_insecure:=false}

--- a/kustomize/observability/elasticsearch/helm-repository.yaml
+++ b/kustomize/observability/elasticsearch/helm-repository.yaml
@@ -5,4 +5,6 @@ metadata:
   namespace: system-observability
 spec:
   interval: 10m
-  url: https://helm.elastic.co
+  type: ${helm_repo_type:=default}
+  url: ${helm_registry:=https://helm.elastic.co}
+  insecure: ${helm_repo_insecure:=false}

--- a/kustomize/observability/grafana/helm-repository.yaml
+++ b/kustomize/observability/grafana/helm-repository.yaml
@@ -6,4 +6,6 @@ metadata:
 spec:
   interval: 10m
   timeout: 5m
-  url: https://grafana.github.io/helm-charts
+  type: ${helm_repo_type:=default}
+  url: ${helm_registry:=https://grafana.github.io/helm-charts}
+  insecure: ${helm_repo_insecure:=false}

--- a/kustomize/observability/kibana/helm-repository.yaml
+++ b/kustomize/observability/kibana/helm-repository.yaml
@@ -5,4 +5,6 @@ metadata:
   namespace: system-observability
 spec:
   interval: 10m
-  url: https://helm.elastic.co
+  type: ${helm_repo_type:=default}
+  url: ${helm_registry:=https://helm.elastic.co}
+  insecure: ${helm_repo_insecure:=false}

--- a/kustomize/observability/quickwit/helm-repository.yaml
+++ b/kustomize/observability/quickwit/helm-repository.yaml
@@ -7,4 +7,6 @@ metadata:
 spec:
   interval: 10m
   timeout: 3m
-  url: https://helm.quickwit.io
+  type: ${helm_repo_type:=default}
+  url: ${helm_registry:=https://helm.quickwit.io}
+  insecure: ${helm_repo_insecure:=false}

--- a/kustomize/pki/base/cert-manager/helm-repository.yaml
+++ b/kustomize/pki/base/cert-manager/helm-repository.yaml
@@ -7,4 +7,6 @@ metadata:
 spec:
   interval: 10m
   timeout: 3m
-  url: https://charts.jetstack.io
+  type: ${helm_repo_type:=default}
+  url: ${helm_registry:=https://charts.jetstack.io}
+  insecure: ${helm_repo_insecure:=false}

--- a/kustomize/policy/base/kyverno/helm-repository.yaml
+++ b/kustomize/policy/base/kyverno/helm-repository.yaml
@@ -7,4 +7,6 @@ metadata:
 spec:
   interval: 10m
   timeout: 3m
-  url: https://kyverno.github.io/kyverno
+  type: ${helm_repo_type:=default}
+  url: ${helm_registry:=https://kyverno.github.io/kyverno}
+  insecure: ${helm_repo_insecure:=false}

--- a/kustomize/telemetry/base/filebeat/helm-repository.yaml
+++ b/kustomize/telemetry/base/filebeat/helm-repository.yaml
@@ -5,4 +5,6 @@ metadata:
   namespace: system-telemetry
 spec:
   interval: 10m
-  url: https://helm.elastic.co
+  type: ${helm_repo_type:=default}
+  url: ${helm_registry:=https://helm.elastic.co}
+  insecure: ${helm_repo_insecure:=false}

--- a/kustomize/telemetry/base/fluentbit/helm-repository.yaml
+++ b/kustomize/telemetry/base/fluentbit/helm-repository.yaml
@@ -7,4 +7,6 @@ metadata:
 spec:
   interval: 10m
   timeout: 3m
-  url: https://fluent.github.io/helm-charts
+  type: ${helm_repo_type:=default}
+  url: ${helm_registry:=https://fluent.github.io/helm-charts}
+  insecure: ${helm_repo_insecure:=false}

--- a/kustomize/telemetry/base/prometheus/helm-repository.yaml
+++ b/kustomize/telemetry/base/prometheus/helm-repository.yaml
@@ -6,4 +6,6 @@ metadata:
 spec:
   interval: 10m
   timeout: 5m
-  url: https://prometheus-community.github.io/helm-charts
+  type: ${helm_repo_type:=default}
+  url: ${helm_registry:=https://prometheus-community.github.io/helm-charts}
+  insecure: ${helm_repo_insecure:=false}

--- a/kustomize/telemetry/resources/flux/helm-repository.yaml
+++ b/kustomize/telemetry/resources/flux/helm-repository.yaml
@@ -7,4 +7,6 @@ metadata:
 spec:
   interval: 10m
   timeout: 3m
-  url: https://fluxcd-community.github.io/helm-charts
+  type: ${helm_repo_type:=default}
+  url: ${helm_registry:=https://fluxcd-community.github.io/helm-charts}
+  insecure: ${helm_repo_insecure:=false}

--- a/kustomize/telemetry/resources/metrics-server/helm-repository.yaml
+++ b/kustomize/telemetry/resources/metrics-server/helm-repository.yaml
@@ -7,4 +7,6 @@ metadata:
 spec:
   interval: 10m
   timeout: 3m
-  url: https://kubernetes-sigs.github.io/metrics-server/
+  type: ${helm_repo_type:=default}
+  url: ${helm_registry:=https://kubernetes-sigs.github.io/metrics-server/}
+  insecure: ${helm_repo_insecure:=false}

--- a/kustomize/telemetry/resources/prometheus/flux/helm-repository.yaml
+++ b/kustomize/telemetry/resources/prometheus/flux/helm-repository.yaml
@@ -7,4 +7,6 @@ metadata:
 spec:
   interval: 10m
   timeout: 3m
-  url: https://fluxcd-community.github.io/helm-charts
+  type: ${helm_repo_type:=default}
+  url: ${helm_registry:=https://fluxcd-community.github.io/helm-charts}
+  insecure: ${helm_repo_insecure:=false}

--- a/terraform/cluster/talos/main.tf
+++ b/terraform/cluster/talos/main.tf
@@ -104,6 +104,7 @@ module "controlplane_bootstrap" {
   enable_health_check  = true
   config_patches = [for p in compact(concat([
     var.common_config_patches,
+    var.registry_config_patches,
     var.controlplane_config_patches,
     local.controlplane_extra_mounts_patch,
     lookup(var.controlplanes[0], "config_patches", []),
@@ -134,6 +135,7 @@ module "controlplanes" {
   enable_health_check  = true
   config_patches = [for p in compact(concat([
     var.common_config_patches,
+    var.registry_config_patches,
     var.controlplane_config_patches,
     local.controlplane_extra_mounts_patch,
     lookup(var.controlplanes[count.index + 1], "config_patches", []),
@@ -167,6 +169,7 @@ module "workers" {
   enable_health_check  = true
   config_patches = [for p in compact(concat([
     var.common_config_patches,
+    var.registry_config_patches,
     var.worker_config_patches,
     local.worker_extra_mounts_patch,
     lookup(var.workers[count.index], "config_patches", []),

--- a/terraform/cluster/talos/variables.tf
+++ b/terraform/cluster/talos/variables.tf
@@ -127,6 +127,16 @@ variable "common_config_patches" {
   }
 }
 
+variable "registry_config_patches" {
+  description = "A YAML string of registry mirror config patches to apply to all nodes. Separated from common_config_patches so it can be resolved from deferred expressions (terraform_output)."
+  type        = string
+  default     = ""
+  validation {
+    condition     = var.registry_config_patches == "" || can(yamldecode(var.registry_config_patches))
+    error_message = "registry_config_patches must be an empty string or a valid YAML string."
+  }
+}
+
 variable "controlplane_config_patches" {
   description = "A YAML string of controlplane config patches to apply. Can be an empty string or valid YAML."
   type        = string

--- a/terraform/workstation/docker/main.tf
+++ b/terraform/workstation/docker/main.tf
@@ -69,9 +69,13 @@ locals {
   registry_ips = {
     for i, k in local.registry_keys_sorted : k => cidrhost(var.network_cidr, local.registry_ip_base + i)
   }
+  # Mirror: single container at next available slot after registries (offset 4 when registries is empty).
+  mirror_ip       = var.enable_mirror ? cidrhost(var.network_cidr, local.registry_ip_base + length(local.registry_keys_sorted)) : null
+  mirror_hostname = "mirror.${local.domain_name}"
   service_ips = merge(
     { dns = local.dns_ip, git = local.git_ip },
-    local.registry_ips
+    local.registry_ips,
+    var.enable_mirror ? { mirror = local.mirror_ip } : {}
   )
   # Corefile forward: localhost mode = gateway:8053, else loadbalancer_start_ip
   dns_forward_target = coalesce(var.dns_forward_target, local.use_localhost_networking ? "${local.gateway}:8053" : local.loadbalancer_start_ip)
@@ -80,6 +84,7 @@ locals {
   corefile_host_entries = concat(
     var.enable_dns ? ["${local.use_localhost_networking ? "127.0.0.1" : local.dns_ip} dns.${local.domain_name}"] : [],
     [for k in local.registry_keys_sorted : "${local.use_localhost_networking ? "127.0.0.1" : local.registry_ips[k]} ${local.registry_host_prefix[k]}.${local.domain_name}"],
+    var.enable_mirror ? ["${local.use_localhost_networking ? "127.0.0.1" : local.mirror_ip} ${local.mirror_hostname}"] : [],
     var.enable_git ? ["${local.use_localhost_networking ? "127.0.0.1" : local.git_ip} git.${local.domain_name}"] : []
   )
   corefile_content = var.enable_dns ? templatefile("${path.module}/templates/Corefile.tpl", {
@@ -200,7 +205,7 @@ resource "docker_container" "dns" {
 # =============================================================================
 
 resource "docker_image" "registry" {
-  count = length(local.registries) > 0 ? 1 : 0
+  count = length(local.registries) > 0 || var.enable_mirror ? 1 : 0
   # renovate: datasource=docker depName=ghcr.io/distribution/distribution package=ghcr.io/distribution/distribution
   name = "ghcr.io/distribution/distribution:3.0.0@sha256:4ba3adf47f5c866e9a29288c758c5328ef03396cb8f5f6454463655fa8bc83e2"
 }
@@ -246,6 +251,48 @@ resource "docker_container" "registry" {
   }
   volumes {
     host_path      = "${var.project_root}/.windsor/cache/docker/registries/${each.key}"
+    container_path = "/var/lib/registry"
+  }
+}
+
+# =============================================================================
+# Container: mirror (pre-loaded registry, no pull-through proxy)
+# =============================================================================
+
+resource "docker_container" "mirror" {
+  count   = var.enable_mirror ? 1 : 0
+  name    = "mirror.${local.domain_name}"
+  image   = docker_image.registry[0].image_id
+  restart = "always"
+  dynamic "labels" {
+    for_each = local.common_labels
+    content {
+      label = labels.value.label
+      value = labels.value.value
+    }
+  }
+  labels {
+    label = "role"
+    value = "mirror"
+  }
+  labels {
+    label = "com.docker.compose.project"
+    value = local.compose_project
+  }
+  dynamic "ports" {
+    for_each = var.mirror_hostport != null && local.publish_ports ? [1] : []
+    content {
+      internal = 5000
+      external = var.mirror_hostport
+      protocol = "tcp"
+    }
+  }
+  networks_advanced {
+    name         = docker_network.main.name
+    ipv4_address = local.mirror_ip
+  }
+  volumes {
+    host_path      = "${var.project_root}/.windsor/cache/docker/mirror"
     container_path = "/var/lib/registry"
   }
 }

--- a/terraform/workstation/docker/outputs.tf
+++ b/terraform/workstation/docker/outputs.tf
@@ -26,8 +26,8 @@ output "next_ip" {
   description = "First IP for sequential node assignment. Fixed at host index var.node_start_offset (default 10); stable across registry add/remove because registries fill the reserved block [4, node_start_offset). Use as compute/docker start_ip when attaching to this network."
   value       = cidrhost(var.network_cidr, var.node_start_offset)
   precondition {
-    condition     = length(local.registry_keys_sorted) <= local.registry_ip_capacity
-    error_message = "Too many registries (${length(local.registry_keys_sorted)}) for the reserved block of ${local.registry_ip_capacity} slots (hosts 4..${var.node_start_offset - 1}). Raise node_start_offset or drop registries."
+    condition     = length(local.registry_keys_sorted) + (var.enable_mirror ? 1 : 0) <= local.registry_ip_capacity
+    error_message = "Too many registries (${length(local.registry_keys_sorted)}${var.enable_mirror ? " + mirror" : ""}) for the reserved block of ${local.registry_ip_capacity} slots (hosts 4..${var.node_start_offset - 1}). Raise node_start_offset or drop registries."
   }
 }
 
@@ -62,13 +62,18 @@ output "service_ips" {
 }
 
 output "containers" {
-  description = "Map of service name to container name: dns, git (when enabled), and each registry key."
+  description = "Map of service name to container name: dns, git (when enabled), mirror (when enabled), and each registry key."
   value = {
     for k, v in merge(
-      { dns = try(docker_container.dns[0].name, null), git = try(docker_container.git[0].name, null) },
+      { dns = try(docker_container.dns[0].name, null), git = try(docker_container.git[0].name, null), mirror = try(docker_container.mirror[0].name, null) },
       { for rk, rv in docker_container.registry : rk => rv.name }
     ) : k => v if v != null
   }
+}
+
+output "mirror_hostname" {
+  description = "Hostname of the mirror registry container. Null when enable_mirror is false."
+  value       = var.enable_mirror ? local.mirror_hostname : null
 }
 
 output "registries" {

--- a/terraform/workstation/docker/variables.tf
+++ b/terraform/workstation/docker/variables.tf
@@ -98,6 +98,18 @@ variable "node_start_offset" {
   }
 }
 
+variable "enable_mirror" {
+  description = "Create a local mirror registry container (no pull-through proxy). The mirror mounts .windsor/cache/docker/mirror and serves pre-loaded images. When true, pull-through registry containers are typically not created (pass registries = {} from the facet)."
+  type        = bool
+  default     = false
+}
+
+variable "mirror_hostport" {
+  description = "Host port to publish for the mirror container. Only published in docker-desktop mode (where bridge IPs are not routable from the host). Set to null to skip port publishing."
+  type        = number
+  default     = null
+}
+
 variable "registries" {
   description = "Map of registry configs (aligned with windsor docker.registries). Key is registry host (e.g. gcr.io, registry.k8s.io). Each entry: remote (proxy upstream URL; Distribution supports only remoteurl, username, password, ttl), hostport (publish port on host, optional). Omit remote for local-only registry. Null is coalesced to empty in the module. Count must fit in the reserved block (node_start_offset - 4); raise node_start_offset if you need more."
   type = map(object({

--- a/terraform/workstation/incus/main.tf
+++ b/terraform/workstation/incus/main.tf
@@ -67,6 +67,9 @@ locals {
   registry_ips = {
     for i, k in local.registry_keys_sorted : k => cidrhost(var.network_cidr, local.registry_ip_base + i)
   }
+  # Mirror: single container at next available slot after registries (offset 4 when registries is empty).
+  mirror_ip       = var.enable_mirror ? cidrhost(var.network_cidr, local.registry_ip_base + length(local.registry_keys_sorted)) : null
+  mirror_hostname = "mirror.${local.domain_name}"
   # Keep in sync with workstation/docker registry_host_prefix (same stripping logic).
   registry_remote_host = {
     for k, v in var.registries : k => try(
@@ -85,12 +88,14 @@ locals {
   registry_hostname = { for k in local.registry_keys_sorted : k => "${local.registry_hostname_base[k]}.${local.domain_name}" }
   service_ips = merge(
     { dns = local.dns_ip, git = local.git_ip },
-    local.registry_ips
+    local.registry_ips,
+    var.enable_mirror ? { mirror = local.mirror_ip } : {}
   )
   dns_forward_target = coalesce(var.dns_forward_target, local.loadbalancer_start_ip)
   corefile_host_entries = concat(
     var.enable_dns ? ["${local.dns_ip} dns.${local.domain_name}"] : [],
     [for k in local.registry_keys_sorted : "${local.registry_ips[k]} ${local.registry_hostname[k]}"],
+    var.enable_mirror ? ["${local.mirror_ip} ${local.mirror_hostname}"] : [],
     var.enable_git ? ["${local.git_ip} git.${local.domain_name}"] : []
   )
   corefile_content = var.enable_dns ? templatefile("${path.module}/templates/Corefile.tpl", {
@@ -215,6 +220,48 @@ resource "incus_instance" "registry" {
     type = "disk"
     properties = {
       source = "${var.project_root}/.windsor/cache/docker/registries/${each.key}"
+      path   = "/var/lib/registry"
+    }
+  }
+}
+
+# =============================================================================
+# Mirror cache dir (Incus requires disk source path to exist before create)
+# =============================================================================
+
+resource "local_file" "mirror_cache_dir" {
+  count    = var.enable_mirror ? 1 : 0
+  content  = ""
+  filename = "${var.project_root}/.windsor/cache/docker/mirror/.keep"
+}
+
+# =============================================================================
+# Instance: mirror (pre-loaded registry, no pull-through proxy)
+# =============================================================================
+
+resource "incus_instance" "mirror" {
+  count = var.enable_mirror ? 1 : 0
+  name  = replace(local.mirror_hostname, ".", "-")
+  type  = "container"
+  # renovate: datasource=docker depName=ghcr.io/distribution/distribution package=ghcr.io/distribution/distribution
+  image      = "ghcr:distribution/distribution:3.0.0@sha256:4ba3adf47f5c866e9a29288c758c5328ef03396cb8f5f6454463655fa8bc83e2"
+  depends_on = [incus_network.main, local_file.mirror_cache_dir]
+  config     = {}
+
+  device {
+    name = "eth0"
+    type = "nic"
+    properties = {
+      network        = local.attached_network
+      "ipv4.address" = local.mirror_ip
+    }
+  }
+
+  device {
+    name = "mirror-cache"
+    type = "disk"
+    properties = {
+      source = "${var.project_root}/.windsor/cache/docker/mirror"
       path   = "/var/lib/registry"
     }
   }

--- a/terraform/workstation/incus/outputs.tf
+++ b/terraform/workstation/incus/outputs.tf
@@ -21,8 +21,8 @@ output "next_ip" {
   description = "First IP for sequential node assignment. Fixed at host index var.node_start_offset (default 10); stable across registry add/remove because registries fill the reserved block [4, node_start_offset). Use as compute/incus start offset when attaching to this network."
   value       = cidrhost(var.network_cidr, var.node_start_offset)
   precondition {
-    condition     = length(local.registry_keys_sorted) <= local.registry_ip_capacity
-    error_message = "Too many registries (${length(local.registry_keys_sorted)}) for the reserved block of ${local.registry_ip_capacity} slots (hosts 4..${var.node_start_offset - 1}). Raise node_start_offset or drop registries."
+    condition     = length(local.registry_keys_sorted) + (var.enable_mirror ? 1 : 0) <= local.registry_ip_capacity
+    error_message = "Too many registries (${length(local.registry_keys_sorted)}${var.enable_mirror ? " + mirror" : ""}) for the reserved block of ${local.registry_ip_capacity} slots (hosts 4..${var.node_start_offset - 1}). Raise node_start_offset or drop registries."
   }
 }
 
@@ -57,13 +57,18 @@ output "service_ips" {
 }
 
 output "containers" {
-  description = "Map of service name to instance name: dns, git (when enabled), and each registry key."
+  description = "Map of service name to instance name: dns, git (when enabled), mirror (when enabled), and each registry key."
   value = {
     for k, v in merge(
-      { dns = try(incus_instance.dns[0].name, null), git = try(incus_instance.git[0].name, null) },
+      { dns = try(incus_instance.dns[0].name, null), git = try(incus_instance.git[0].name, null), mirror = try(incus_instance.mirror[0].name, null) },
       { for rk, rv in incus_instance.registry : rk => rv.name }
     ) : k => v if v != null
   }
+}
+
+output "mirror_hostname" {
+  description = "Hostname of the mirror registry instance. Null when enable_mirror is false."
+  value       = var.enable_mirror ? local.mirror_hostname : null
 }
 
 output "registries" {

--- a/terraform/workstation/incus/variables.tf
+++ b/terraform/workstation/incus/variables.tf
@@ -94,6 +94,12 @@ variable "enable_git" {
   default     = true
 }
 
+variable "enable_mirror" {
+  description = "Create a local mirror registry container (no pull-through proxy). The mirror mounts .windsor/cache/docker/mirror and serves pre-loaded images. When true, pull-through registry containers are typically not created (pass registries = {} from the facet)."
+  type        = bool
+  default     = false
+}
+
 variable "registries" {
   description = "Map of registry configs (aligned with windsor docker.registries). Key is registry host (e.g. gcr.io, registry.k8s.io). Each entry: remote (proxy upstream URL), hostport (unused for Incus; kept for API compatibility), local. Omit remote for local-only registry."
   type = map(object({


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> This PR extends Windsor's configuration layer and Terraform modules to support a unified mirror registry (for Docker images and Helm charts), affecting Talos machine config generation, workstation container provisioning, and all bundled HelmRepository resources.
>
> The core change introduces a `mirror_effective` computed value in `platform-base` that gates two distinct behaviors: Talos registry mirror injection (via a new `registry_config_patches` Terraform variable, separated from `common_config_patches` to allow deferred expression evaluation) and Helm OCI redirect (via new `helm_registry`/`helm_repo_type`/`helm_repo_insecure` Flux envsubst substitutions applied to every bundled HelmRepository). The `cluster.mirror` schema field enables bare-metal or air-gap clusters to point all image and chart pulls at a pre-loaded registry without running workstation-managed pull-through containers.
>
> The primary structural concern is a behavioral gap between `mirror_effective.active` (defined in `platform-base`) and `workstation_mirror.active` (defined in `option-workstation`): the latter adds a `registries != false` guard that the former does not share. This creates an edge case — `cluster.mirror` set alongside `workstation.services.registries: false` — where both facets' `talos_registry_mirrors` entries satisfy their `when:` conditions simultaneously, risking a same-name collision that could leave Talos with no mirror endpoints. Additionally, the `registry_config_patches` pull-through expression is duplicated verbatim across three separate Terraform input blocks; a change to the mirror path format or filter logic must be applied in all three places.
>
> Reviewed by Claude for commit `f484e8a`.

<!-- /claude-code-review:summary -->
