### PR TITLE
feat(template): Include terraform backend with schema

### DIFF
--- a/contexts/_template/schema.yaml
+++ b/contexts/_template/schema.yaml
@@ -148,11 +148,36 @@ properties:
         description: Enable Terraform in stacks
       backend:
         type: object
+        additionalProperties: false
         properties:
           type:
             type: string
-            description: Backend type (e.g. local, s3, gcs)
-        additionalProperties: true
+            enum:
+              - local
+              - s3
+              - azurerm
+              - kubernetes
+              - none
+            description: Backend type (local, s3, azurerm, kubernetes, or none)
+          prefix:
+            type: string
+            description: Optional state key/prefix applied per module
+          local:
+            type: object
+            additionalProperties: true
+            description: Local backend configuration (https://developer.hashicorp.com/terraform/language/backend/local)
+          s3:
+            type: object
+            additionalProperties: true
+            description: S3 backend configuration (https://developer.hashicorp.com/terraform/language/backend/s3)
+          kubernetes:
+            type: object
+            additionalProperties: true
+            description: Kubernetes backend configuration (https://developer.hashicorp.com/terraform/language/backend/kubernetes)
+          azurerm:
+            type: object
+            additionalProperties: true
+            description: AzureRM backend configuration (https://developer.hashicorp.com/terraform/language/backend/azurerm)
         description: Terraform backend configuration
     additionalProperties: true
     description: Terraform execution and backend overrides


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> This change tightens a shared template schema that governs all Windsor terraform backend configurations; any existing config using a backend type not in the new enum will fail validation after upgrading.
>
> **Overview**
>
> The PR refines the `terraform.backend` schema from a loosely typed open object into a structured definition: it adds an enum for the `type` field, introduces named sub-objects for each supported backend (`local`, `s3`, `azurerm`, `kubernetes`), and flips `additionalProperties` to `false` at the top level. This makes misconfiguration detectable at validation time rather than silently at apply time.
>
> The `none` enum value is a Windsor-specific sentinel rather than a native Terraform backend type and will need corresponding handling in the layer that generates Terraform backend stanzas. The `gcs` backend, mentioned by name in the previous schema description, is absent from both the enum and the sub-object properties — this is a breaking change for any config currently using GCS.
>
> Reviewed by Claude for commit `7c7e02c`.

<!-- /claude-code-review:summary -->
