### PR TITLE
chore(kustomize): Move helm repositories in to individual namespaces

### DIFF
--- a/kustomize/cni/cilium/helm-release.yaml
+++ b/kustomize/cni/cilium/helm-release.yaml
@@ -28,7 +28,6 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: cilium
-        namespace: system-gitops
   values:
     # Cluster identity surfaces in Hubble flows, metrics, and (if enabled later) ClusterMesh
     # routing. Sourced from the Windsor context name — generic, not Cilium-specific.

--- a/kustomize/cni/cilium/helm-repository.yaml
+++ b/kustomize/cni/cilium/helm-repository.yaml
@@ -3,7 +3,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: cilium
-  namespace: system-gitops
+  namespace: system-cni
 spec:
   interval: 10m
   timeout: 5m

--- a/kustomize/csi/longhorn/helm-release.yaml
+++ b/kustomize/csi/longhorn/helm-release.yaml
@@ -23,7 +23,6 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: longhorn
-        namespace: system-gitops
   values:
     image:
       longhorn:

--- a/kustomize/csi/longhorn/helm-repository.yaml
+++ b/kustomize/csi/longhorn/helm-repository.yaml
@@ -3,7 +3,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: longhorn
-  namespace: system-gitops
+  namespace: system-csi
 spec:
   interval: 10m
   timeout: 5m

--- a/kustomize/csi/openebs/helm-release.yaml
+++ b/kustomize/csi/openebs/helm-release.yaml
@@ -15,7 +15,6 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: openebs
-        namespace: system-gitops
   values:
     localpv-provisioner:
       enabled: false

--- a/kustomize/csi/openebs/helm-repository.yaml
+++ b/kustomize/csi/openebs/helm-repository.yaml
@@ -3,7 +3,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: openebs
-  namespace: system-gitops
+  namespace: system-csi
 spec:
   interval: 10m
   timeout: 5m

--- a/kustomize/database/cloudnativepg/helm-release.yaml
+++ b/kustomize/database/cloudnativepg/helm-release.yaml
@@ -15,7 +15,6 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: cloudnativepg
-        namespace: system-gitops
   values:
     config:
       clusterWide: true

--- a/kustomize/database/cloudnativepg/helm-repository.yaml
+++ b/kustomize/database/cloudnativepg/helm-repository.yaml
@@ -3,7 +3,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: cloudnativepg
-  namespace: system-gitops
+  namespace: system-database
 spec:
   interval: 10m
   timeout: 3m

--- a/kustomize/dns/coredns/helm-release.yaml
+++ b/kustomize/dns/coredns/helm-release.yaml
@@ -22,7 +22,6 @@ spec:
       sourceRef: 
         kind: HelmRepository
         name: coredns
-        namespace: system-gitops
   values:
     image:
       # renovate: datasource=docker depName=coredns/coredns package=coredns/coredns

--- a/kustomize/dns/coredns/helm-repository.yaml
+++ b/kustomize/dns/coredns/helm-repository.yaml
@@ -3,7 +3,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: coredns
-  namespace: system-gitops
+  namespace: system-dns
 spec:
   interval: 10m
   timeout: 3m

--- a/kustomize/dns/external-dns/helm-release.yaml
+++ b/kustomize/dns/external-dns/helm-release.yaml
@@ -22,7 +22,6 @@ spec:
       sourceRef: 
         kind: HelmRepository
         name: external-dns
-        namespace: system-gitops
   values:
     image:
       # renovate: datasource=docker depName=registry.k8s.io/external-dns/external-dns package=registry.k8s.io/external-dns/external-dns

--- a/kustomize/dns/external-dns/helm-repository.yaml
+++ b/kustomize/dns/external-dns/helm-repository.yaml
@@ -3,7 +3,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: external-dns
-  namespace: system-gitops
+  namespace: system-dns
 spec:
   interval: 10m
   timeout: 3m

--- a/kustomize/gateway/base/envoy/helm-release.yaml
+++ b/kustomize/gateway/base/envoy/helm-release.yaml
@@ -19,7 +19,6 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: envoyproxy
-        namespace: system-gitops
   values:
     global:
       images:

--- a/kustomize/ingress/nginx/helm-release.yaml
+++ b/kustomize/ingress/nginx/helm-release.yaml
@@ -15,7 +15,6 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: ingress-nginx
-        namespace: system-ingress
   values:
     controller:
       image:

--- a/kustomize/lb/base/metallb/helm-release.yaml
+++ b/kustomize/lb/base/metallb/helm-release.yaml
@@ -14,7 +14,6 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: metallb
-        namespace: system-gitops
   values:
     controller:
       image:

--- a/kustomize/lb/base/metallb/helm-repository.yaml
+++ b/kustomize/lb/base/metallb/helm-repository.yaml
@@ -3,7 +3,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: metallb
-  namespace: system-gitops
+  namespace: system-lb
 spec:
   interval: 10m
   timeout: 3m

--- a/kustomize/lb/resources/kube-vip/cloud-provider-helm-release.yaml
+++ b/kustomize/lb/resources/kube-vip/cloud-provider-helm-release.yaml
@@ -15,7 +15,6 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: kube-vip
-        namespace: system-gitops
   values:
     image:
       repository: kubevip/kube-vip-cloud-provider

--- a/kustomize/lb/resources/kube-vip/helm-release.yaml
+++ b/kustomize/lb/resources/kube-vip/helm-release.yaml
@@ -14,7 +14,6 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: kube-vip
-        namespace: system-gitops
   values:
     image:
       repository: ghcr.io/kube-vip/kube-vip

--- a/kustomize/lb/resources/kube-vip/helm-repository.yaml
+++ b/kustomize/lb/resources/kube-vip/helm-repository.yaml
@@ -3,7 +3,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: kube-vip
-  namespace: system-gitops
+  namespace: system-lb
 spec:
   interval: 10m
   timeout: 3m

--- a/kustomize/object-store/base/minio/helm-release.yaml
+++ b/kustomize/object-store/base/minio/helm-release.yaml
@@ -14,7 +14,6 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: minio
-        namespace: system-gitops
   values:
     operator:
       image:

--- a/kustomize/object-store/base/minio/helm-repository.yaml
+++ b/kustomize/object-store/base/minio/helm-repository.yaml
@@ -3,7 +3,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: minio
-  namespace: system-gitops
+  namespace: system-object-store
 spec:
   interval: 10m
   timeout: 3m

--- a/kustomize/object-store/resources/common/tenant.yaml
+++ b/kustomize/object-store/resources/common/tenant.yaml
@@ -14,7 +14,6 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: minio
-        namespace: system-gitops
   values:
     tenant:
       name: common

--- a/kustomize/observability/elasticsearch/helm-release.yaml
+++ b/kustomize/observability/elasticsearch/helm-release.yaml
@@ -14,7 +14,6 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: elastic-elasticsearch
-        namespace: system-observability
   values:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.5.1@sha256:dd4cd0943aae9b4b881fa578eca46015af399a309c0d3b5dc86a30adc932f434
     createCert: false

--- a/kustomize/observability/grafana/helm-release.yaml
+++ b/kustomize/observability/grafana/helm-release.yaml
@@ -15,7 +15,6 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: grafana
-        namespace: system-gitops
   values:
     grafana.ini:
       date_formats:

--- a/kustomize/observability/grafana/helm-repository.yaml
+++ b/kustomize/observability/grafana/helm-repository.yaml
@@ -2,7 +2,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: grafana
-  namespace: system-gitops
+  namespace: system-observability
 spec:
   interval: 10m
   timeout: 5m

--- a/kustomize/observability/kibana/helm-release.yaml
+++ b/kustomize/observability/kibana/helm-release.yaml
@@ -14,7 +14,6 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: elastic-kibana
-        namespace: system-observability
   values:
     # renovate: datasource=docker depName=docker.elastic.co/kibana/kibana package=docker.elastic.co/kibana/kibana
     image: docker.elastic.co/kibana/kibana:9.3.3@sha256:36301dc49650e47484b23803d60f78e0ac763ab4d7edab6c75c1f54a186d5f9d

--- a/kustomize/observability/quickwit/helm-release.yaml
+++ b/kustomize/observability/quickwit/helm-release.yaml
@@ -15,7 +15,6 @@ spec:
       sourceRef: 
         kind: HelmRepository
         name: quickwit
-        namespace: system-gitops
   values:
     image:
       # renovate: datasource=docker depName=quickwit/quickwit package=quickwit/quickwit

--- a/kustomize/observability/quickwit/helm-repository.yaml
+++ b/kustomize/observability/quickwit/helm-repository.yaml
@@ -3,7 +3,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: quickwit
-  namespace: system-gitops
+  namespace: system-observability
 spec:
   interval: 10m
   timeout: 3m

--- a/kustomize/pki/base/cert-manager/helm-release.yaml
+++ b/kustomize/pki/base/cert-manager/helm-release.yaml
@@ -15,7 +15,6 @@ spec:
       sourceRef: 
         kind: HelmRepository
         name: jetstack
-        namespace: system-gitops
   values:
     image:
       # renovate: datasource=docker depName=quay.io/jetstack/cert-manager-controller package=quay.io/jetstack/cert-manager-controller

--- a/kustomize/pki/base/cert-manager/helm-repository.yaml
+++ b/kustomize/pki/base/cert-manager/helm-repository.yaml
@@ -3,7 +3,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: jetstack
-  namespace: system-gitops
+  namespace: system-pki
 spec:
   interval: 10m
   timeout: 3m

--- a/kustomize/pki/base/trust-manager/helm-release.yaml
+++ b/kustomize/pki/base/trust-manager/helm-release.yaml
@@ -18,7 +18,6 @@ spec:
       sourceRef: 
         kind: HelmRepository
         name: jetstack
-        namespace: system-gitops
   values:
     image:
       # renovate: datasource=docker depName=quay.io/jetstack/trust-manager package=quay.io/jetstack/trust-manager

--- a/kustomize/pki/base/trust-manager/helm-repository.yaml
+++ b/kustomize/pki/base/trust-manager/helm-repository.yaml
@@ -2,10 +2,9 @@
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
-  name: envoyproxy
-  namespace: system-gateway
+  name: jetstack
+  namespace: system-pki-trust
 spec:
   interval: 10m
   timeout: 3m
-  type: oci
-  url: oci://docker.io/envoyproxy
+  url: https://charts.jetstack.io

--- a/kustomize/pki/base/trust-manager/kustomization.yaml
+++ b/kustomize/pki/base/trust-manager/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources:
+  - helm-repository.yaml
   - helm-release.yaml

--- a/kustomize/policy/base/kyverno/helm-release.yaml
+++ b/kustomize/policy/base/kyverno/helm-release.yaml
@@ -14,7 +14,6 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: kyverno
-        namespace: system-gitops
   values:
     crds:
       migration:

--- a/kustomize/policy/base/kyverno/helm-repository.yaml
+++ b/kustomize/policy/base/kyverno/helm-repository.yaml
@@ -3,7 +3,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: kyverno
-  namespace: system-gitops
+  namespace: system-policy
 spec:
   interval: 10m
   timeout: 3m

--- a/kustomize/telemetry/base/filebeat/helm-release.yaml
+++ b/kustomize/telemetry/base/filebeat/helm-release.yaml
@@ -14,7 +14,6 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: elastic-filebeat
-        namespace: system-telemetry
   values:
     # renovate: datasource=docker depName=docker.elastic.co/beats/filebeat package=docker.elastic.co/beats/filebeat
     image: docker.elastic.co/beats/filebeat:9.3.3@sha256:2ea4af46a22a02a4eaf04b329cc229e92320452ec51cb281b83733f85f5aa2e9

--- a/kustomize/telemetry/base/fluentbit/helm-release.yaml
+++ b/kustomize/telemetry/base/fluentbit/helm-release.yaml
@@ -15,7 +15,6 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: fluent
-        namespace: system-gitops
   values:
     operator:
       image:

--- a/kustomize/telemetry/base/fluentbit/helm-repository.yaml
+++ b/kustomize/telemetry/base/fluentbit/helm-repository.yaml
@@ -3,7 +3,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: fluent
-  namespace: system-gitops
+  namespace: system-telemetry
 spec:
   interval: 10m
   timeout: 3m

--- a/kustomize/telemetry/base/prometheus/helm-release.yaml
+++ b/kustomize/telemetry/base/prometheus/helm-release.yaml
@@ -14,7 +14,6 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: prometheus-community
-        namespace: system-gitops
   values:
     grafana:
       enabled: false

--- a/kustomize/telemetry/base/prometheus/helm-repository.yaml
+++ b/kustomize/telemetry/base/prometheus/helm-repository.yaml
@@ -2,7 +2,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: prometheus-community
-  namespace: system-gitops
+  namespace: system-telemetry
 spec:
   interval: 10m
   timeout: 5m

--- a/kustomize/telemetry/resources/flux/helm-release.yaml
+++ b/kustomize/telemetry/resources/flux/helm-release.yaml
@@ -14,7 +14,6 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: fluxcd-community
-        namespace: system-gitops
   values:
     cli:
       # renovate: datasource=docker depName=ghcr.io/fluxcd/flux-cli package=ghcr.io/fluxcd/flux-cli

--- a/kustomize/telemetry/resources/metrics-server/helm-release.yaml
+++ b/kustomize/telemetry/resources/metrics-server/helm-release.yaml
@@ -14,7 +14,6 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: metrics-server
-        namespace: system-gitops
   values:
     image:
       # renovate: datasource=docker depName=registry.k8s.io/metrics-server/metrics-server package=registry.k8s.io/metrics-server/metrics-server

--- a/kustomize/telemetry/resources/metrics-server/helm-repository.yaml
+++ b/kustomize/telemetry/resources/metrics-server/helm-repository.yaml
@@ -3,7 +3,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: metrics-server
-  namespace: system-gitops
+  namespace: system-telemetry
 spec:
   interval: 10m
   timeout: 3m

--- a/kustomize/telemetry/resources/prometheus/flux/helm-release.yaml
+++ b/kustomize/telemetry/resources/prometheus/flux/helm-release.yaml
@@ -14,7 +14,6 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: fluxcd-community
-        namespace: system-gitops
   values:
     cli:
       # renovate: datasource=docker depName=ghcr.io/fluxcd/flux-cli package=ghcr.io/fluxcd/flux-cli


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> Each HelmRepository is now collocated with its component namespace, so Flux resolves chart sources locally without depending on a shared `system-gitops` authority.
>
> **Overview**
>
> This PR relocates every HelmRepository from the central `system-gitops` namespace into the namespace of the component it serves — `system-cni` for Cilium, `system-pki` for cert-manager, `system-telemetry` for Prometheus, and so on. The corresponding HelmRelease sourceRefs drop their explicit `namespace` override, which causes Flux to resolve each repository against the HelmRelease's own namespace — the Flux default when no namespace is specified.
>
> Trust-manager is the one structural outlier: it lives in `system-pki-trust` rather than sharing `system-pki` with cert-manager, so it receives its own `jetstack` HelmRepository and doubles the polling load on the Jetstack registry. The `fluxcd-community` repositories are intentionally left in `system-gitops` because their HelmReleases also reside there.
>
> During rollout, Flux will briefly see a missing sourceRef while old `system-gitops` HelmRepository objects are replaced by their component-namespace counterparts. Flux retries reconciliation automatically, so the impact window is transient and self-healing.
>
> Reviewed by Claude for commit `a6ad752`.
<!-- /claude-code-review:summary -->
