### PR TITLE
fix(csi): Use talos extensions appropriately with longhorn only

### DIFF
--- a/contexts/_template/facets/option-cni.yaml
+++ b/contexts/_template/facets/option-cni.yaml
@@ -39,15 +39,7 @@ terraform:
       # re-runs don't flap the deployment between Flux reconciles. Same
       # single-node → 1, else → 2 rule applied by the Flux substitution.
       operator_replicas: "${topology_effective == 'single-node' ? 1 : 2}"
-
-  # Dependency merges — insert the `cni` step into the existing terraform graph
-  # so Talos extensions and Flux both wait for Cilium bootstrap to finish.
-  - name: cluster-extensions
-    when: "talos_provisioned"
-    path: cluster/talos/extensions
-    dependsOn:
-      - cni
-
+  
   - name: gitops
     when: "talos_provisioned"
     path: gitops/flux

--- a/contexts/_template/facets/option-storage.yaml
+++ b/contexts/_template/facets/option-storage.yaml
@@ -24,36 +24,31 @@ terraform:
   # cluster-extensions — apply Talos system extensions
   # ---------------------------------------------------------------------------
   #
-  # Only runs when talos_common.extensions has entries (populated by the
-  # storage-driver-specific config in platform-*/config-talos).
+  # Only runs when extensions are needed for the chosen storage driver
+  # (currently: longhorn → iscsi-tools + util-linux-tools).
   #
-  # When Cilium is active, option-cni merges `dependsOn: [cni]` into this
-  # entry so extensions wait for node networking to be up.
+  # When Cilium is the CNI, the cni terraform step bootstraps Cilium directly
+  # against the Talos API. Extensions also touches Talos, so it must wait for
+  # cni to finish to avoid concurrent machine-config writes — hence the
+  # conditional dependsOn entry below.
   #
   - name: cluster-extensions
-    when: "len(talos_common.extensions ?? []) > 0 && cluster_provisioned"
+    when: "(cluster.storage.driver ?? 'openebs') == 'longhorn' && cluster_provisioned"
     path: cluster/talos/extensions
     dependsOn:
       - cluster
+      - "${cni_effective.driver == 'cilium' ? 'cni' : ''}"
     parallelism: 1
     inputs:
       talos_version: ${talos.talos_version}
-      controlplanes: >-
-        ${len(terraform_output("compute", "controlplanes") ?? []) > 0
-          ? map(terraform_output("compute", "controlplanes"), fromPairs(filter(toPairs(#), get(#, 0) == "node" || get(#, 0) == "endpoint")))
-          : map(values(cluster.controlplanes.nodes), fromPairs(filter(toPairs(#), get(#, 0) == "node" || get(#, 0) == "endpoint")))}
-      workers: >-
-        ${len(terraform_output("compute", "workers") ?? []) > 0
-          ? map(terraform_output("compute", "workers"), fromPairs(filter(toPairs(#), get(#, 0) == "node" || get(#, 0) == "endpoint")))
-          : ((cluster.workers.count ?? 0) > 0
-            ? map(values(cluster.workers.nodes), fromPairs(filter(toPairs(#), get(#, 0) == "node" || get(#, 0) == "endpoint")))
-            : [])}
+      controlplanes: ${talos_node_targets.controlplanes ?? []}
+      workers: ${talos_node_targets.workers ?? []}
       extensions: ${talos_common.extensions ?? []}
 
   # Dependency merge: Flux waits for extensions before reconciling, so CSI
   # DaemonSets find the kernel modules they expect.
   - name: gitops
-    when: "len(talos_common.extensions ?? []) > 0 && cluster_provisioned"
+    when: "(cluster.storage.driver ?? 'openebs') == 'longhorn' && cluster_provisioned"
     path: gitops/flux
     dependsOn:
       - cluster-extensions
@@ -117,12 +112,13 @@ kustomize:
   # ---------------------------------------------------------------------------
   #
   # Inject the Longhorn dashboard into the observability kustomization when
-  # Longhorn + observability are both active (or when dev mode is on, which
-  # auto-enables observability).
+  # Longhorn is the active storage driver AND observability is on (or dev mode
+  # is on, which auto-enables observability). The longhorn driver gate is
+  # required — the dashboard is meaningless without longhorn metrics to render.
   #
   - name: observability
     path: observability
-    when: (talos_common.storage_driver == 'longhorn' && addons.observability.enabled == true) || dev == true
+    when: talos_common.storage_driver == 'longhorn' && (addons.observability.enabled == true || dev == true)
     dependsOn:
       - telemetry-base
     components:

--- a/contexts/_template/facets/platform-docker.yaml
+++ b/contexts/_template/facets/platform-docker.yaml
@@ -21,6 +21,17 @@ config:
     value:
       k8s_service_host: "${cidrhost(network_effective.cidr_block, 10)}"
 
+  # Node targets for post-cluster steps (e.g. cluster/talos/extensions). Reads
+  # compute outputs (compute always runs before cluster, which runs before
+  # extensions), projected to the {node, endpoint} shape that the extensions
+  # module accepts.
+  - name: talos_node_targets
+    value:
+      controlplanes: >-
+        ${map(terraform_output("compute", "controlplanes") ?? [], fromPairs(filter(toPairs(#), get(#, 0) == "node" || get(#, 0) == "endpoint")))}
+      workers: >-
+        ${map(terraform_output("compute", "workers") ?? [], fromPairs(filter(toPairs(#), get(#, 0) == "node" || get(#, 0) == "endpoint")))}
+
   # ---------------------------------------------------------------------------
   # cluster_endpoint_fallback — best-effort Talos API endpoint
   # ---------------------------------------------------------------------------

--- a/contexts/_template/facets/platform-incus.yaml
+++ b/contexts/_template/facets/platform-incus.yaml
@@ -43,6 +43,24 @@ config:
             : ""
         }
 
+  # Node targets for post-cluster steps (e.g. cluster/talos/extensions). Mirrors
+  # the same compute-output-or-fallback resolution that the `cluster` step uses,
+  # projected to the {node, endpoint} shape that the extensions module accepts.
+  - name: talos_node_targets
+    value:
+      controlplanes: >-
+        ${map(
+          len(terraform_output("compute", "controlplanes") ?? []) > 0
+            ? terraform_output("compute", "controlplanes")
+            : values(cluster.controlplanes.nodes ?? {}),
+          fromPairs(filter(toPairs(#), get(#, 0) == "node" || get(#, 0) == "endpoint")))}
+      workers: >-
+        ${map(
+          len(terraform_output("compute", "workers") ?? []) > 0
+            ? terraform_output("compute", "workers")
+            : ((cluster.workers.count ?? 0) > 0 ? values(cluster.workers.nodes) : []),
+          fromPairs(filter(toPairs(#), get(#, 0) == "node" || get(#, 0) == "endpoint")))}
+
 # =============================================================================
 # Terraform — standalone incus (no workstation)
 # =============================================================================

--- a/contexts/_template/facets/platform-metal.yaml
+++ b/contexts/_template/facets/platform-metal.yaml
@@ -22,6 +22,19 @@ config:
     value:
       endpoint: "${cluster.endpoint ?? ('https://' + split(values(cluster.controlplanes.nodes)[0].endpoint, ':')[0] + ':6443')}"
 
+  # Node targets for post-cluster steps (e.g. cluster/talos/extensions). Same
+  # node list the `cluster` step receives, projected to the {node, endpoint}
+  # shape that the extensions module's variable schema accepts. No compute
+  # layer on metal — read straight from the user-supplied node map.
+  - name: talos_node_targets
+    value:
+      controlplanes: >-
+        ${map(values(cluster.controlplanes.nodes ?? {}), fromPairs(filter(toPairs(#), get(#, 0) == "node" || get(#, 0) == "endpoint")))}
+      workers: >-
+        ${(cluster.workers.count ?? 0) > 0
+          ? map(values(cluster.workers.nodes), fromPairs(filter(toPairs(#), get(#, 0) == "node" || get(#, 0) == "endpoint")))
+          : []}
+
 # =============================================================================
 # Terraform — cluster/talos + gitops
 # =============================================================================

--- a/contexts/_template/tests/platform-metal.test.yaml
+++ b/contexts/_template/tests/platform-metal.test.yaml
@@ -285,7 +285,10 @@ cases:
           timeout: 5m
           interval: 5m
 
-  # Edge case: longhorn storage driver passes Talos extensions via cluster-extensions step
+  # Edge case: longhorn storage driver passes Talos extensions via cluster-extensions step.
+  # Also asserts the controlplanes/workers inputs come from the user-supplied node map
+  # (no compute layer on metal), projected to the {node, endpoint} shape the
+  # extensions module accepts — i.e. talos_node_targets is wired correctly.
   - name: longhorn storage driver passes iscsi and util-linux extensions to cluster terraform
     values:
       provider: metal
@@ -315,3 +318,20 @@ cases:
             extensions:
               - siderolabs/iscsi-tools
               - siderolabs/util-linux-tools
+            controlplanes:
+              - node: 10.5.0.10
+                endpoint: 10.5.0.10:50000
+
+  # Edge case: openebs (default) does not need Talos extensions, so cluster-extensions
+  # must NOT appear in the rendered blueprint and gitops must not depend on it.
+  # Guards against regressions in the option-storage `when:` filter.
+  - name: openebs storage driver excludes cluster-extensions terraform step
+    values:
+      provider: metal
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster: *default-cluster
+    exclude:
+      terraform:
+        - name: cluster-extensions


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> Changes shared facet logic that governs whether and when Talos extensions run across all Talos-based platforms; the empty-string dependency pattern is novel in the terraform context and untested for non-Cilium CNI configurations.
>
> **Overview**
>
> This PR consolidates the `cluster-extensions` Terraform step entirely within `option-storage.yaml`, now gated on Longhorn being the active driver rather than on whether extensions are populated. The CNI ordering dependency — Cilium must finish writing its machine config before the extensions step can run — is expressed via a conditional `dependsOn` entry that evaluates to either `'cni'` or `''` depending on the resolved CNI driver. The change also extracts per-platform `talos_node_targets` projections into each platform facet, removing complex inline expressions that were duplicated in `option-storage.yaml`.
>
> The most notable correctness improvement is the observability `when:` condition fix: the Longhorn Grafana dashboard was previously enabled by `dev == true` alone regardless of storage driver; it now requires both Longhorn and dev/observability to be active.
>
> The new tests cover the Longhorn + Cilium path and the openebs exclusion, but there is no test for Longhorn + a non-Cilium CNI — the path that exercises the empty-string branch in `dependsOn`. Whether the blueprint resolver silently filters empty dependency names (as it does for kustomize components) is unverified.
>
> Reviewed by Claude for commit `bd2d8bd`.

<!-- /claude-code-review:summary -->
