### PR TITLE
feat(gateway): Add service_type to select NodePort or LoadBalancer

### DIFF
--- a/contexts/_template/facets/option-gateway.yaml
+++ b/contexts/_template/facets/option-gateway.yaml
@@ -96,6 +96,9 @@ kustomize:
       gateway_class_name: ${gateway_effective.driver}
       gateway_dns_target: "${lb_effective.enabled == true ? network_effective.loadbalancer_ips.start : ''}"
       external_domain: ${dns.private_domain}
-      loadbalancer_start_ip: ${network_effective.loadbalancer_ips.start}
+      # Only emitted when a consumer is active: the lb-address patch (in-cluster
+      # LB) or the cilium gateway component. NodePort/cloud-managed-LB paths
+      # have no consumer, so leave it empty and the harness drops it.
+      loadbalancer_start_ip: "${(lb_effective.enabled == true || gateway_effective.driver == 'cilium') ? network_effective.loadbalancer_ips.start : ''}"
     timeout: 10m
     interval: 5m

--- a/contexts/_template/facets/platform-base.yaml
+++ b/contexts/_template/facets/platform-base.yaml
@@ -120,6 +120,14 @@ config:
     value:
       mode: nodeport
 
+  # Explicit gateway.service_type wins over driver/platform auto-detect. Lets
+  # any platform expose the gateway via NodePort (e.g. single-node Talos VMs
+  # without a cluster LB) or force LoadBalancer on docker-desktop.
+  - name: lb_effective
+    when: (gateway.service_type ?? '') != ''
+    value:
+      mode: "${gateway.service_type == 'NodePort' ? 'nodeport' : 'loadbalancer'}"
+
   # ---------------------------------------------------------------------------
   # DNS domains
   # ---------------------------------------------------------------------------

--- a/contexts/_template/facets/platform-base.yaml
+++ b/contexts/_template/facets/platform-base.yaml
@@ -123,10 +123,21 @@ config:
   # Explicit gateway.service_type wins over driver/platform auto-detect. Lets
   # any platform expose the gateway via NodePort (e.g. single-node Talos VMs
   # without a cluster LB) or force LoadBalancer on docker-desktop.
+  #
+  # NodePort also forces lb_effective.enabled=false: even when the cluster has
+  # a loadbalancer_driver configured (e.g. kube-vip), a NodePort service will
+  # never be assigned a LoadBalancer IP, so the lb-address patch and
+  # gateway_dns_target would reconcile against an IP that never materializes.
   - name: lb_effective
-    when: (gateway.service_type ?? '') != ''
+    when: gateway.service_type == 'NodePort'
     value:
-      mode: "${gateway.service_type == 'NodePort' ? 'nodeport' : 'loadbalancer'}"
+      enabled: false
+      mode: nodeport
+
+  - name: lb_effective
+    when: gateway.service_type == 'LoadBalancer'
+    value:
+      mode: loadbalancer
 
   # ---------------------------------------------------------------------------
   # DNS domains

--- a/contexts/_template/schema.yaml
+++ b/contexts/_template/schema.yaml
@@ -560,6 +560,12 @@ properties:
           - envoy
           - cilium
         description: Gateway driver
+      service_type:
+        type: string
+        enum:
+          - LoadBalancer
+          - NodePort
+        description: Kubernetes Service type used to expose the gateway. When unset, defaults to LoadBalancer except on docker-desktop, which is forced to NodePort. Set to NodePort to expose the gateway on any driver without a cluster LB (e.g. single-node Talos VMs).
     additionalProperties: false
 
   # Ingress configuration

--- a/contexts/_template/tests/option-gateway.test.yaml
+++ b/contexts/_template/tests/option-gateway.test.yaml
@@ -187,15 +187,18 @@ cases:
         - *gateway-resources-envoy
 
   # Explicit gateway.service_type: NodePort works on any platform (e.g. a bare
-  # metal single-node cluster with no cluster LB).
-  - name: explicit gateway.service_type NodePort selects nodeport variant on metal
+  # metal single-node cluster with no cluster LB). Network omits
+  # loadbalancer_driver so lb_effective.enabled is false — proves the nodeport
+  # component is selected purely from gateway.service_type.
+  - name: explicit gateway.service_type NodePort selects nodeport variant on metal with no LB
     values:
       provider: metal
       gateway:
         enabled: true
         driver: envoy
         service_type: NodePort
-      network: *default-network
+      network:
+        cidr_block: 10.5.0.0/16
       cluster: *default-cluster
     expect:
       kustomize:

--- a/contexts/_template/tests/option-gateway.test.yaml
+++ b/contexts/_template/tests/option-gateway.test.yaml
@@ -205,6 +205,33 @@ cases:
         - *gateway-base-envoy-np
         - *gateway-resources-envoy
 
+  # NodePort must suppress lb_effective.enabled even when loadbalancer_driver
+  # is configured: a NodePort service will never get a LoadBalancer IP, so
+  # lb-address (which patches the Gateway with that IP) and gateway_dns_target
+  # must not apply. Uses *default-network which has loadbalancer_driver set,
+  # and flannel CNI so lb_effective.enabled would otherwise be true.
+  - name: explicit NodePort suppresses lb-address even when loadbalancer_driver is set
+    values:
+      provider: metal
+      gateway:
+        enabled: true
+        driver: envoy
+        service_type: NodePort
+      network: *default-network
+      cluster:
+        <<: *default-cluster
+        cni:
+          driver: flannel
+    expect:
+      kustomize:
+        - *gateway-base-envoy-np
+        - name: gateway-resources
+          path: gateway/resources
+          components:
+            - flux-webhook
+          substitutions:
+            gateway_class_name: envoy
+
   # Explicit gateway.service_type: LoadBalancer overrides docker-desktop's
   # default NodePort fallback.
   - name: explicit gateway.service_type LoadBalancer overrides docker-desktop default

--- a/contexts/_template/tests/option-gateway.test.yaml
+++ b/contexts/_template/tests/option-gateway.test.yaml
@@ -359,10 +359,10 @@ cases:
             gateway_class_name: envoy
             loadbalancer_start_ip: "10.5.1.10"
 
-  # AWS: no network.loadbalancer_ips configured, so loadbalancer_start_ip falls back to the
-  # cidrhost default (10.5.1.10 from the default /16). gateway_dns_target evaluates to "" and
-  # is omitted from output because lb_effective.enabled is false on AWS (cloud-managed LB).
-  - name: aws envoy gateway-resources uses cidr-derived loadbalancer_start_ip
+  # AWS uses a cloud-managed LB (lb_effective.enabled == false) and is not cilium,
+  # so loadbalancer_start_ip and gateway_dns_target both evaluate to "" and are
+  # omitted from output. Only gateway_class_name remains.
+  - name: aws envoy gateway-resources omits loadbalancer substitutions
     values:
       provider: aws
       gateway:
@@ -376,7 +376,6 @@ cases:
             - gateway-base
           substitutions:
             gateway_class_name: envoy
-            loadbalancer_start_ip: "10.5.1.10"
           timeout: 10m
           interval: 5m
 

--- a/contexts/_template/tests/option-gateway.test.yaml
+++ b/contexts/_template/tests/option-gateway.test.yaml
@@ -186,6 +186,50 @@ cases:
         - *gateway-base-envoy-np
         - *gateway-resources-envoy
 
+  # Explicit gateway.service_type: NodePort works on any platform (e.g. a bare
+  # metal single-node cluster with no cluster LB).
+  - name: explicit gateway.service_type NodePort selects nodeport variant on metal
+    values:
+      provider: metal
+      gateway:
+        enabled: true
+        driver: envoy
+        service_type: NodePort
+      network: *default-network
+      cluster: *default-cluster
+    expect:
+      kustomize:
+        - *gateway-base-envoy-np
+        - *gateway-resources-envoy
+
+  # Explicit gateway.service_type: LoadBalancer overrides docker-desktop's
+  # default NodePort fallback.
+  - name: explicit gateway.service_type LoadBalancer overrides docker-desktop default
+    values:
+      platform: docker
+      gateway:
+        enabled: true
+        driver: envoy
+        service_type: LoadBalancer
+      workstation:
+        enabled: true
+        runtime: docker-desktop
+      network: *default-network
+      cluster: *default-cluster
+    terraformOutputs:
+      compute:
+        controlplanes:
+          - endpoint: 10.5.0.10:6443
+            node: 10.5.0.10
+            hostname: controlplane-1
+        workers: []
+      workstation:
+        registries: {}
+    expect:
+      kustomize:
+        - *gateway-base-envoy-lb
+        - *gateway-resources-envoy
+
   # Backward compatibility: ingress alias still works
   - name: legacy ingress alias maps envoy-gateway to envoy
     values:


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> Opt-in override field; all existing deployments that omit `gateway.service_type` continue through auto-detection logic unchanged.
>
> **Overview**
>
> The PR introduces a `service_type` field (`LoadBalancer` | `NodePort`) on the gateway schema, letting operators explicitly pin the Kubernetes Service exposure mode and override driver/platform auto-detection. The most common use cases are bare-metal single-node clusters without a cluster LB (NodePort) and docker-desktop deployments where a real LoadBalancer controller is available.
>
> The NodePort path explicitly forces `lb_effective.enabled: false`, which suppresses the lb-address kustomize component and `gateway_dns_target` even when the cluster has a `loadbalancer_driver` configured — preventing the gateway from reconciling against a LoadBalancer IP that will never materialize. A parallel refinement scopes the `loadbalancer_start_ip` substitution to emit only when a consumer is active (in-cluster LB or Cilium), bringing the AWS gateway path in line by dropping a stale substitution that had no downstream consumer.
>
> Three test cases cover the meaningful variants: NodePort on bare metal, NodePort overriding a configured LB driver (the key safety regression test), and LoadBalancer overriding the docker-desktop default. Prior review concerns about NodePort not suppressing `lb_effective.enabled` and a mismatched test fixture have both been resolved.
>
> Reviewed by Claude for commit `a16117d`.

<!-- /claude-code-review:summary -->
