### PR TITLE
fix(cluster/talos): Remove hostname for talos 1.12+ compatibility

### DIFF
--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -361,8 +361,10 @@ terraform:
   # ---------------------------------------------------------------------------
   #
 
-  # Incus: strip hostname from each compute node (Incus sets it via
-  # user.hostname; Talos 1.12 rejects "static hostname is already set").
+  # Incus: nodes come from compute output (Incus provisioned VMs) or from
+  # cluster.*.nodes if compute hasn't run yet. Hostname flows through as a
+  # passthrough field — Talos 1.12+ reads it from the VM runtime (Incus
+  # user.hostname), not from Talos config.
   - name: cluster
     when: "platform == 'incus' && (cluster.enabled ?? true)"
     path: cluster/talos
@@ -381,11 +383,11 @@ terraform:
       talos_version: ${talos.talos_version}
       controlplanes: >-
         ${len(terraform_output("compute", "controlplanes") ?? []) > 0
-          ? map(terraform_output("compute", "controlplanes"), fromPairs(concat(filter(toPairs(#), get(#, 0) != "hostname"), [["hostname", null]])))
+          ? terraform_output("compute", "controlplanes")
           : values(cluster.controlplanes.nodes)}
       workers: >-
         ${len(terraform_output("compute", "controlplanes") ?? []) > 0
-          ? map(terraform_output("compute", "workers") ?? [], fromPairs(concat(filter(toPairs(#), get(#, 0) != "hostname"), [["hostname", null]])))
+          ? (terraform_output("compute", "workers") ?? [])
           : ((cluster.workers.count ?? 0) > 0 ? values(cluster.workers.nodes) : [])}
       controlplane_disks: ${talos_common.controlplane_disks}
       worker_disks: ${talos_common.worker_disks}

--- a/contexts/_template/facets/platform-docker.yaml
+++ b/contexts/_template/facets/platform-docker.yaml
@@ -81,18 +81,14 @@ terraform:
 
       # controlplanes: two code paths per node —
       #
-      # Path A (compute output present): strip hostname from each node.
-      # Docker already sets the hostname; Talos 1.12 rejects explicit
-      # overrides with "static hostname is already set".
+      # Path A (compute output present): pass nodes through unchanged.
+      # docker-desktop adds a per-node machine.certSANs patch including the
+      # real IP, hostname, localhost, and 127.0.0.1 so Talos API certs work
+      # when the client is the host reaching through the docker-desktop tunnel.
       #
       # Path B (no compute output, bootstrap-from-host): rewrite
       # endpoint/node to 127.0.0.1:(50000+i). This lets the host Talos
       # CLI bootstrap the control plane containers via port forwards.
-      #
-      # docker-desktop extra: each controlplane also gets a per-node
-      # machine.certSANs patch including its real IP, hostname, localhost,
-      # and 127.0.0.1 — so Talos API certs work when the client is the
-      # host reaching through the docker-desktop tunnel.
       controlplanes: >-
         ${map(
           len(terraform_output("compute", "controlplanes") ?? []) > 0
@@ -100,32 +96,33 @@ terraform:
             : reduce(
                 take(values(cluster.controlplanes.nodes ?? {}), int(cluster.controlplanes.count ?? 1)),
                 concat(#acc, [fromPairs(concat(
-                  filter(toPairs(#), get(#, 0) != "hostname" && get(#, 0) != "endpoint" && get(#, 0) != "node"),
-                  [["hostname", null], ["endpoint", "127.0.0.1:" + string(50000 + len(#acc))], ["node", "127.0.0.1"]]
+                  filter(toPairs(#), get(#, 0) != "endpoint" && get(#, 0) != "node"),
+                  [["endpoint", "127.0.0.1:" + string(50000 + len(#acc))], ["node", "127.0.0.1"]]
                 ))]),
                 []
               ),
-          fromPairs(concat(
-            filter(toPairs(#), get(#, 0) != "hostname"),
-            [["hostname", null]],
-            workstation.runtime == 'docker-desktop' ? [["config_patches", "machine:\n  certSANs:\n  - " + (get(#, "node") != null && get(#, "node") != "" ? get(#, "node") : split(get(#, "endpoint"), ":")[0]) + (get(#, "hostname") != null && get(#, "hostname") != "" ? "\n  - " + get(#, "hostname") : "") + "\n  - localhost\n  - 127.0.0.1"]] : []
-          ))
+          workstation.runtime == 'docker-desktop'
+            ? fromPairs(concat(
+                toPairs(#),
+                [["config_patches", "machine:\n  certSANs:\n  - " + (get(#, "node") != null && get(#, "node") != "" ? get(#, "node") : split(get(#, "endpoint"), ":")[0]) + (get(#, "hostname") != null && get(#, "hostname") != "" ? "\n  - " + get(#, "hostname") : "") + "\n  - localhost\n  - 127.0.0.1"]]
+              ))
+            : #
         )}
 
-      # workers: mirror of controlplanes. Strip hostname when compute output
-      # is present; rewrite endpoint to 127.0.0.1 offsets when bootstrapping
-      # from the host. Worker ports are offset by controlplane count.
+      # workers: mirror of controlplanes. Pass nodes through when compute
+      # output is present; rewrite endpoint to 127.0.0.1 offsets when
+      # bootstrapping from the host. Worker ports are offset by controlplane count.
       workers: >-
-        ${(len(terraform_output("compute", "controlplanes") ?? []) > 0
-          ? map(terraform_output("compute", "workers") ?? [], fromPairs(concat(filter(toPairs(#), get(#, 0) != "hostname"), [["hostname", null]])))
+        ${len(terraform_output("compute", "controlplanes") ?? []) > 0
+          ? (terraform_output("compute", "workers") ?? [])
           : ((cluster.workers.count ?? 0) == 0 ? [] : reduce(
               take(values(cluster.workers.nodes ?? {}), int(cluster.workers.count ?? 0)),
               concat(#acc, [fromPairs(concat(
-                filter(toPairs(#), get(#, 0) != "hostname" && get(#, 0) != "endpoint" && get(#, 0) != "node"),
-                [["hostname", null], ["endpoint", "127.0.0.1:" + string(50000 + (cluster.controlplanes.count ?? 1) + len(#acc))], ["node", "127.0.0.1"]]
+                filter(toPairs(#), get(#, 0) != "endpoint" && get(#, 0) != "node"),
+                [["endpoint", "127.0.0.1:" + string(50000 + (cluster.controlplanes.count ?? 1) + len(#acc))], ["node", "127.0.0.1"]]
               ))]),
               []
-            )))}
+            ))}
 
       controlplane_disks: ${cluster.controlplanes.disks ?? []}
       worker_disks: ${cluster.workers.disks ?? []}

--- a/terraform/cluster/talos/main.tf
+++ b/terraform/cluster/talos/main.tf
@@ -85,7 +85,6 @@ locals {
 
 module "controlplane_bootstrap" {
   source               = "./modules/machine"
-  hostname             = try(var.controlplanes[0].hostname, "")
   node                 = var.controlplanes[0].node
   client_configuration = talos_machine_secrets.this.client_configuration
   machine_secrets      = try(talos_machine_secrets.this.machine_secrets, "")
@@ -115,7 +114,6 @@ module "controlplanes" {
   depends_on = [module.controlplane_bootstrap]
 
   source               = "./modules/machine"
-  hostname             = try(var.controlplanes[count.index + 1].hostname, "")
   node                 = var.controlplanes[count.index + 1].node
   client_configuration = talos_machine_secrets.this.client_configuration
   machine_secrets      = try(talos_machine_secrets.this.machine_secrets, "")
@@ -149,7 +147,6 @@ module "workers" {
   depends_on = [module.controlplane_bootstrap] // Depends on the first control plane completing
 
   source               = "./modules/machine"
-  hostname             = try(var.workers[count.index].hostname, "")
   node                 = var.workers[count.index].node
   client_configuration = try(talos_machine_secrets.this.client_configuration, "")
   machine_secrets      = try(talos_machine_secrets.this.machine_secrets, "")

--- a/terraform/cluster/talos/modules/machine/main.tf
+++ b/terraform/cluster/talos/modules/machine/main.tf
@@ -23,25 +23,22 @@ terraform {
 
 locals {
 
-  # Optional hostname and install block. Set hostname only when provided; otherwise leave to host/runtime (e.g. containers).
-  machine_config_patch = yamlencode({
-    machine = merge(
-      var.hostname != null && var.hostname != "" ? { network = { hostname = var.hostname } } : {},
-      # Include install block only if disk_selector is not null
-      var.disk_selector != null ? {
-        install = {
-          diskSelector    = var.disk_selector     # Disk selector to use for the machine
-          wipe            = var.wipe_disk         # Whether to wipe the disk before installation
-          extraKernelArgs = var.extra_kernel_args # Additional kernel arguments
-          image           = var.image             # Image to be used for installation
-        }
-      } : {}
-    )
-  })
+  # Install block is patched only when a disk_selector is provided. Hostname is not patched:
+  # Talos 1.12+ auto-derives machine.network.hostname from the runtime (Docker container name,
+  # VM hostname, DHCP, etc.) and rejects an explicit override with "static hostname is already set".
+  machine_config_patch = var.disk_selector != null ? yamlencode({
+    machine = {
+      install = {
+        diskSelector    = var.disk_selector
+        wipe            = var.wipe_disk
+        extraKernelArgs = var.extra_kernel_args
+        image           = var.image
+      }
+    }
+  }) : ""
 
-  # Combine machine configuration patch with additional configuration patches
   config_patches = concat(
-    [local.machine_config_patch],
+    compact([local.machine_config_patch]),
     [for patch in var.config_patches : patch]
   )
 }

--- a/terraform/cluster/talos/modules/machine/test.tftest.hcl
+++ b/terraform/cluster/talos/modules/machine/test.tftest.hcl
@@ -65,7 +65,7 @@ variables {
   enable_health_check = false
 }
 
-run "machine_config_patch_with_disk_and_hostname" {
+run "machine_config_patch_with_disk" {
   variables {
     disk_selector = {
       busPath  = ""
@@ -81,7 +81,6 @@ run "machine_config_patch_with_disk_and_hostname" {
     wipe_disk         = true
     extra_kernel_args = ["console=tty0"]
     image             = "test-image"
-    extensions        = [{ image = "test-extension" }]
   }
   assert {
     condition     = strcontains(local.machine_config_patch, "\"name\": \"/dev/sda\"")
@@ -94,10 +93,6 @@ run "machine_config_patch_with_disk_and_hostname" {
   assert {
     condition     = strcontains(local.machine_config_patch, "\"image\": \"test-image\"")
     error_message = "Should include image test-image"
-  }
-  assert {
-    condition     = strcontains(local.machine_config_patch, "- \"image\": \"test-extension\"")
-    error_message = "Should include extension test-extension"
   }
 }
 
@@ -124,11 +119,11 @@ run "config_patches_includes_extra" {
     ]
   }
   assert {
-    condition     = length(local.config_patches) == 2
-    error_message = "Should include both machine_config_patch and extra patch"
+    condition     = length(local.config_patches) == 1
+    error_message = "Should include only the extra patch when no disk_selector is provided"
   }
   assert {
-    condition     = strcontains(local.config_patches[1], "- 8.8.8.8")
+    condition     = strcontains(local.config_patches[0], "- 8.8.8.8")
     error_message = "Should include nameservers in extra patch"
   }
 }

--- a/terraform/cluster/talos/modules/machine/test.tftest.hcl
+++ b/terraform/cluster/talos/modules/machine/test.tftest.hcl
@@ -128,6 +128,42 @@ run "config_patches_includes_extra" {
   }
 }
 
+run "config_patches_with_disk_and_extra" {
+  variables {
+    disk_selector = {
+      busPath  = ""
+      modalias = ""
+      model    = ""
+      name     = "/dev/sda"
+      serial   = ""
+      size     = "0"
+      type     = ""
+      uuid     = ""
+      wwid     = ""
+    }
+    config_patches = [
+      <<-EOT
+      machine:
+        network:
+          nameservers:
+            - 8.8.8.8
+      EOT
+    ]
+  }
+  assert {
+    condition     = length(local.config_patches) == 2
+    error_message = "Should include both machine_config_patch (install block) and extra patch"
+  }
+  assert {
+    condition     = strcontains(local.config_patches[0], "diskSelector")
+    error_message = "First patch should be the install/diskSelector block"
+  }
+  assert {
+    condition     = strcontains(local.config_patches[1], "- 8.8.8.8")
+    error_message = "Second patch should be the extra nameservers patch"
+  }
+}
+
 run "bootstrap_mode_generates_kubeconfig" {
   variables {
     bootstrap       = true

--- a/terraform/cluster/talos/modules/machine/variables.tf
+++ b/terraform/cluster/talos/modules/machine/variables.tf
@@ -70,12 +70,6 @@ variable "cluster_name" {
   }
 }
 
-variable "hostname" {
-  description = "Optional hostname to set in Talos config. When null or empty, hostname is left to the host/runtime (e.g. Docker sets it on containers)."
-  type        = string
-  default     = ""
-}
-
 variable "cluster_endpoint" {
   description = "The cluster endpoint."
   type        = string

--- a/terraform/cluster/talos/variables.tf
+++ b/terraform/cluster/talos/variables.tf
@@ -60,7 +60,6 @@ variable "cluster_endpoint" {
 variable "controlplanes" {
   description = "A list of machine configuration details for control planes."
   type = list(object({
-    hostname = optional(string)
     endpoint = string
     node     = string
     disks    = optional(list(any), [])
@@ -90,7 +89,6 @@ variable "controlplanes" {
 variable "workers" {
   description = "A list of machine configuration details"
   type = list(object({
-    hostname = optional(string)
     endpoint = string
     node     = string
     disks    = optional(list(any), [])


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> Isolated to hostname handling in Talos machine config; the change is narrowly scoped and the Terraform type system's silent attribute dropping means no hard breakage.
>
> **Overview**
>
> Removes explicit `machine.network.hostname` injection from the Talos machine configuration. Talos 1.12 began rejecting the override with "static hostname is already set" because the runtime (Docker container name, Incus VM hostname, DHCP) already sets it. The fix strips the `hostname` field from Terraform variable types at both the top-level `cluster/talos` module and the `machine` sub-module, and simplifies the facet expressions in `platform-docker.yaml` and `option-workstation.yaml` by removing the map-transforms that previously nulled the field before passing nodes to Terraform.
>
> One subtle behavioral shift: in the docker-desktop bootstrap path (Path B), nodes previously had hostname nulled before the certSANs patch was computed, so hostname never appeared in cert SANs. Now the original hostname passes through and is included in certSANs if configured. Extra SAN entries do not cause TLS failures, so this is safe.
>
> The follow-up commit adds a `config_patches_with_disk_and_extra` test that exercises the `compact` + `concat` path when both a `disk_selector` and extra patches are present, closing the coverage gap noted in the previous review.
>
> Reviewed by Claude for commit `a482cbc`.

<!-- /claude-code-review:summary -->
