### PR TITLE
feat(facets): Add enablement for base features

### DIFF
--- a/contexts/_template/facets/addon-private-ca.yaml
+++ b/contexts/_template/facets/addon-private-ca.yaml
@@ -16,6 +16,12 @@ when: addons.private_ca.enabled == true
 #   - pki-resources installs the private-issuer/ca ClusterIssuer, which
 #     becomes the default issuer for workload certificates.
 #
+# Requires Kyverno (policy-resources): the private-issuer/ca component ships
+# a ClusterPolicy that mutates pods labeled use-custom-ca=true to mount the
+# CA bundle. Without Kyverno's CRDs the apply fails on "no matches for kind
+# ClusterPolicy"; the hard dep below surfaces the incompatibility as
+# DependencyNotReady instead.
+#
 kustomize:
 
   - name: pki-base
@@ -29,6 +35,7 @@ kustomize:
     path: pki/resources
     dependsOn:
       - pki-base
+      - policy-resources
     timeout: 5m
     interval: 5m
     components:

--- a/contexts/_template/facets/addon-private-dns.yaml
+++ b/contexts/_template/facets/addon-private-dns.yaml
@@ -31,6 +31,12 @@ when: addons.private_dns.enabled == true
 #   - external-dns/localhost: docker-desktop override — advertise 127.0.0.1
 #                             instead of the unreachable LB IP.
 #
+# Requires Kyverno (policy-resources) on docker-desktop: external-dns/localhost
+# ships a ClusterPolicy that rewrites ingress DNS targets to 127.0.0.1. Without
+# Kyverno's CRDs the apply fails on "no matches for kind ClusterPolicy"; the
+# docker-desktop-gated dep below surfaces the incompatibility as
+# DependencyNotReady instead.
+#
 kustomize:
 
   - name: dns
@@ -38,6 +44,7 @@ kustomize:
     dependsOn:
       - pki-base
       - "${gateway_effective.driver == 'cilium' ? 'cni' : (gateway_effective.enabled == true ? 'gateway-base' : '')}"
+      - "${workstation.runtime == 'docker-desktop' ? 'policy-resources' : ''}"
     timeout: 20m
     interval: 5m
     components:

--- a/contexts/_template/facets/option-cni.yaml
+++ b/contexts/_template/facets/option-cni.yaml
@@ -93,6 +93,13 @@ kustomize:
   # Two variants — they differ in Talos-specific settings and how
   # k8s_service_host is derived:
   #
+  # The dep on policy-resources serves two purposes. Normally (policies on) it
+  # preserves ordering so Cilium pods are re-rolled after Kyverno's mutation
+  # policies are live. When the cilium/gateway component is active it also
+  # ships a ClusterPolicy (LBIPAM IP sharing); disabling policies in that
+  # combination would otherwise fail on "no matches for kind ClusterPolicy",
+  # so the dep is kept present to surface it as DependencyNotReady instead.
+  #
 
   # Talos: cilium/talos applies Talos-specific security context + cgroup
   # settings. k8s_service_host comes from talos_common (cidrhost offset 10).
@@ -100,13 +107,13 @@ kustomize:
     path: cni
     when: talos_enabled
     dependsOn:
-      - policy-resources
-      - telemetry-base
+      - "${(policies.enabled ?? true) || (gateway_effective.enabled == true && gateway_effective.driver == 'cilium') ? 'policy-resources' : ''}"
+      - "${telemetry_effective.metrics_enabled || telemetry_effective.logs_enabled ? 'telemetry-base' : ''}"
     components:
       - cilium
       - cilium/talos
       - "${(gateway_effective.enabled == true && gateway_effective.driver == 'cilium') ? 'cilium/gateway' : ''}"
-      - cilium/prometheus
+      - "${telemetry_effective.metrics_enabled ? 'cilium/prometheus' : ''}"
       - cilium/hubble
       - cilium/l2
     substitutions:
@@ -124,12 +131,12 @@ kustomize:
     path: cni
     when: eks_enabled
     dependsOn:
-      - policy-resources
-      - telemetry-base
+      - "${(policies.enabled ?? true) || (gateway_effective.enabled == true && gateway_effective.driver == 'cilium') ? 'policy-resources' : ''}"
+      - "${telemetry_effective.metrics_enabled || telemetry_effective.logs_enabled ? 'telemetry-base' : ''}"
     components:
       - cilium
       - "${(gateway_effective.enabled == true && gateway_effective.driver == 'cilium') ? 'cilium/gateway' : ''}"
-      - cilium/prometheus
+      - "${telemetry_effective.metrics_enabled ? 'cilium/prometheus' : ''}"
       - cilium/hubble
     substitutions:
       k8s_service_host: "${split(split(terraform_output(\"cluster\", \"cluster_endpoint\") ?? \"https://localhost:443\", \"://\")[1], \":\")[0]}"

--- a/contexts/_template/facets/option-storage.yaml
+++ b/contexts/_template/facets/option-storage.yaml
@@ -74,7 +74,7 @@ kustomize:
     path: csi
     when: talos_common.storage_driver == 'openebs'
     dependsOn:
-      - policy-resources
+      - "${(policies.enabled ?? true) ? 'policy-resources' : ''}"
     components:
       - openebs
       - openebs/dynamic-localpv
@@ -97,8 +97,8 @@ kustomize:
     path: csi
     when: talos_common.storage_driver == 'longhorn'
     dependsOn:
-      - policy-resources
-      - telemetry-base
+      - "${(policies.enabled ?? true) ? 'policy-resources' : ''}"
+      - "${telemetry_effective.metrics_enabled || telemetry_effective.logs_enabled ? 'telemetry-base' : ''}"
     components:
       - longhorn
       - "${((cluster.controlplanes.schedulable ?? false) || topology_effective == 'single-node') ? 'longhorn/single-node' : ''}"

--- a/contexts/_template/facets/platform-base.yaml
+++ b/contexts/_template/facets/platform-base.yaml
@@ -239,14 +239,39 @@ config:
   # Telemetry driver
   # ---------------------------------------------------------------------------
   #
-  # Default log aggregation driver is fluentd. Other valid values: 'none'
-  # (disable aggregation entirely), 'elasticsearch' (the observability addon
-  # runs filebeat → Elasticsearch instead). Consumed by option-telemetry and
-  # by telemetry-resources below.
+  # metrics_enabled / logs_enabled: independent gates for the two halves of the
+  # telemetry pipeline. Both default on; disable individually to trim resources
+  # on small clusters (e.g. metrics-only when HPA is needed but logs aren't, or
+  # logs-only for debugging without the Prometheus overhead).
+  #
+  # Both are force-on when addons.observability is enabled — the observability
+  # addon expects a metrics backend and a log pipeline to be present, so opting
+  # the addon in trumps explicit disables here.
+  #
+  # logs_driver: aggregator choice. Valid values: 'fluentd' (default), 'none'
+  # (keep fluent-bit shipper but drop the fluentd aggregator), 'elasticsearch'
+  # (filebeat → Elasticsearch, set by addon-observability). Coerced to 'none'
+  # when the logs pipeline is disabled so downstream `when:` guards on the
+  # fluentd aggregator fall through cleanly.
   #
   - name: telemetry_effective
     value:
+      metrics_enabled: ${telemetry.metrics.enabled ?? true}
+      logs_enabled: ${telemetry.logs.enabled ?? true}
       logs_driver: "${telemetry.logs.driver ?? 'fluentd'}"
+
+  # Observability addon forces both pipelines on.
+  - name: telemetry_effective
+    when: addons.observability.enabled == true
+    value:
+      metrics_enabled: true
+      logs_enabled: true
+
+  # No logs pipeline → nothing to aggregate.
+  - name: telemetry_effective
+    when: telemetry.logs.enabled == false && addons.observability.enabled != true
+    value:
+      logs_driver: none
 
 # =============================================================================
 # Global substitutions
@@ -327,6 +352,7 @@ kustomize:
   #
   - name: policy-base
     path: policy/base
+    when: (policies.enabled ?? true) == true
     components:
       - kyverno
       - "${(policies.reporting ?? 'disabled') == 'enabled' ? 'kyverno/reports' : ''}"
@@ -336,6 +362,7 @@ kustomize:
 
   - name: policy-resources
     path: policy/resources
+    when: (policies.enabled ?? true) == true
     dependsOn:
       - policy-base
     components:
@@ -355,11 +382,11 @@ kustomize:
   - name: pki-base
     path: pki/base
     dependsOn:
-      - policy-resources
-      - telemetry-base
+      - "${(policies.enabled ?? true) ? 'policy-resources' : ''}"
+      - "${telemetry_effective.metrics_enabled || telemetry_effective.logs_enabled ? 'telemetry-base' : ''}"
     components:
       - cert-manager
-      - cert-manager/prometheus
+      - "${telemetry_effective.metrics_enabled ? 'cert-manager/prometheus' : ''}"
     timeout: 20m
     interval: 5m
 
@@ -384,27 +411,29 @@ kustomize:
   #
   - name: telemetry-base
     path: telemetry/base
+    when: telemetry_effective.metrics_enabled || telemetry_effective.logs_enabled
     components:
-      - prometheus
-      - prometheus/flux
-      - fluentbit
+      - "${telemetry_effective.metrics_enabled ? 'prometheus' : ''}"
+      - "${telemetry_effective.metrics_enabled ? 'prometheus/flux' : ''}"
+      - "${telemetry_effective.logs_enabled ? 'fluentbit' : ''}"
     timeout: 30m
     interval: 10m
 
   - name: telemetry-resources
     path: telemetry/resources
+    when: telemetry_effective.metrics_enabled || telemetry_effective.logs_enabled
     dependsOn:
       - telemetry-base
     components:
-      - metrics-server
-      - prometheus
-      - prometheus/flux
-      - fluentbit
-      - fluentbit/containerd
-      - fluentbit/kubernetes
-      - fluentbit/parser
-      - fluentbit/systemd
-      - fluentbit/prometheus
+      - "${telemetry_effective.metrics_enabled ? 'metrics-server' : ''}"
+      - "${telemetry_effective.metrics_enabled ? 'prometheus' : ''}"
+      - "${telemetry_effective.metrics_enabled ? 'prometheus/flux' : ''}"
+      - "${telemetry_effective.logs_enabled ? 'fluentbit' : ''}"
+      - "${telemetry_effective.logs_enabled ? 'fluentbit/containerd' : ''}"
+      - "${telemetry_effective.logs_enabled ? 'fluentbit/kubernetes' : ''}"
+      - "${telemetry_effective.logs_enabled ? 'fluentbit/parser' : ''}"
+      - "${telemetry_effective.logs_enabled ? 'fluentbit/systemd' : ''}"
+      - "${telemetry_effective.logs_enabled && telemetry_effective.metrics_enabled ? 'fluentbit/prometheus' : ''}"
       - "${telemetry_effective.logs_driver == 'fluentd' ? 'fluentbit/fluentd' : ''}"
     timeout: 10m
     interval: 5m
@@ -424,7 +453,7 @@ kustomize:
     components:
       - fluentd
       - fluentd/filters/otel
-      - fluentd/prometheus
+      - "${telemetry_effective.metrics_enabled ? 'fluentd/prometheus' : ''}"
       - "${log_level != 'trace' ? 'fluentd/filters/log-level/' + (log_level ?? 'info') : ''}"
     timeout: 15m
     interval: 10m

--- a/contexts/_template/schema.yaml
+++ b/contexts/_template/schema.yaml
@@ -283,16 +283,35 @@ properties:
   telemetry:
     type: object
     properties:
+      metrics:
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: true
+            description: >
+              Deploy the metrics pipeline (Prometheus operator, kube-prometheus-stack, metrics-server)
+              and all per-component ServiceMonitors. Disable on resource-constrained clusters that
+              don't need in-cluster metrics. Force-on when addons.observability.enabled is true,
+              since the observability addon requires Prometheus to scrape.
+        additionalProperties: false
       logs:
         type: object
         properties:
+          enabled:
+            type: boolean
+            default: true
+            description: >
+              Deploy the logs pipeline (fluent-bit per-node shipper + fluentd aggregator). Disable
+              on resource-constrained clusters. Force-on when addons.observability.enabled is true,
+              since the observability addon's log sinks need the fluent-bit/fluentd path.
           driver:
             type: string
             enum:
               - fluentd
               - none
             default: fluentd
-            description: Log aggregation driver for FluentBit output (fluentd is default, none disables aggregation)
+            description: Log aggregation driver for FluentBit output (fluentd is default, none keeps the per-node shipper but drops the central aggregator)
         additionalProperties: false
     additionalProperties: false
 
@@ -300,6 +319,14 @@ properties:
     type: object
     description: Policy configuration
     properties:
+      enabled:
+        type: boolean
+        default: true
+        description: >
+          Deploy the Kyverno admission controller and cluster policies. Set to false to skip both
+          policy-base and policy-resources entirely — useful for single-node or resource-constrained
+          clusters. Individual policies (require_image_digest, resource_limits_requests) can be
+          disabled separately via their own fields.
       reporting:
         type: string
         enum:

--- a/contexts/_template/tests/addon-private-ca.test.yaml
+++ b/contexts/_template/tests/addon-private-ca.test.yaml
@@ -44,6 +44,7 @@ cases:
           path: pki/resources
           dependsOn:
             - pki-base
+            - policy-resources
           timeout: 5m
           interval: 5m
           components:
@@ -70,6 +71,7 @@ cases:
           path: pki/resources
           dependsOn:
             - pki-base
+            - policy-resources
           timeout: 5m
           interval: 5m
           components:

--- a/contexts/_template/tests/addon-private-dns.test.yaml
+++ b/contexts/_template/tests/addon-private-dns.test.yaml
@@ -75,6 +75,7 @@ cases:
           dependsOn:
             - pki-base
             - gateway-base
+            - policy-resources
           timeout: 20m
           interval: 5m
           components:
@@ -111,6 +112,7 @@ cases:
           dependsOn:
             - pki-base
             - gateway-base
+            - policy-resources
           timeout: 20m
           interval: 5m
           components:

--- a/contexts/_template/tests/option-cni.test.yaml
+++ b/contexts/_template/tests/option-cni.test.yaml
@@ -292,3 +292,77 @@ cases:
           dependsOn:
             - cluster
             - cni
+
+  # telemetry.metrics.enabled=false drops the cilium/prometheus ServiceMonitor
+  # (no Prometheus to scrape). telemetry-base dep stays because logs still need it.
+  - name: telemetry metrics disabled strips cilium/prometheus component
+    values:
+      provider: metal
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster: *default-cluster
+      telemetry:
+        metrics:
+          enabled: false
+    expect:
+      kustomize:
+        - name: cni
+          path: cni
+          dependsOn:
+            - policy-resources
+            - telemetry-base
+          components:
+            - cilium
+            - cilium/talos
+            - cilium/hubble
+            - cilium/l2
+
+  # Both halves of telemetry disabled: drop the cilium/prometheus component
+  # AND the telemetry-base dependency (the kustomization isn't emitted).
+  - name: telemetry metrics and logs disabled drops cilium/prometheus and telemetry-base dep
+    values:
+      provider: metal
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster: *default-cluster
+      telemetry:
+        metrics:
+          enabled: false
+        logs:
+          enabled: false
+    expect:
+      kustomize:
+        - name: cni
+          path: cni
+          dependsOn:
+            - policy-resources
+          components:
+            - cilium
+            - cilium/talos
+            - cilium/hubble
+            - cilium/l2
+
+  # policies.enabled=false drops the policy-resources dependency edge.
+  - name: policies.enabled false strips policy-resources dep on cni
+    values:
+      provider: metal
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster: *default-cluster
+      policies:
+        enabled: false
+    expect:
+      kustomize:
+        - name: cni
+          path: cni
+          dependsOn:
+            - telemetry-base
+          components:
+            - cilium
+            - cilium/talos
+            - cilium/prometheus
+            - cilium/hubble
+            - cilium/l2

--- a/contexts/_template/tests/platform-base.test.yaml
+++ b/contexts/_template/tests/platform-base.test.yaml
@@ -332,3 +332,175 @@ cases:
             - kyverno/reports
             - kyverno/cleanup
 
+  # policies.enabled=false skips both policy kustomizations entirely and
+  # drops the policy-resources dep from pki-base.
+  - name: policies.enabled false excludes policy kustomizations and drops pki-base dep
+    values:
+      provider: metal
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster: *default-cluster
+      policies:
+        enabled: false
+    expect:
+      kustomize:
+        - name: pki-base
+          path: pki/base
+          dependsOn:
+            - telemetry-base
+          components:
+            - cert-manager
+            - cert-manager/prometheus
+    exclude:
+      kustomize:
+        - name: policy-base
+        - name: policy-resources
+
+  # Both metrics and logs disabled skips both telemetry kustomizations, the
+  # fluentd aggregator, and strips telemetry-base / cert-manager/prometheus
+  # from pki-base entirely.
+  - name: telemetry metrics and logs both disabled excludes telemetry pipeline and trims pki-base
+    values:
+      provider: metal
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster: *default-cluster
+      telemetry:
+        metrics:
+          enabled: false
+        logs:
+          enabled: false
+    expect:
+      kustomize:
+        - name: pki-base
+          path: pki/base
+          dependsOn:
+            - policy-resources
+          components:
+            - cert-manager
+    exclude:
+      kustomize:
+        - name: telemetry-base
+        - name: telemetry-resources
+        - name: observability
+
+  # Metrics on, logs off: Prometheus stack deploys, fluent-bit and fluentd are
+  # dropped. cert-manager/prometheus stays (metrics are on).
+  - name: telemetry logs disabled keeps metrics pipeline and drops fluent-bit
+    values:
+      provider: metal
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster: *default-cluster
+      telemetry:
+        logs:
+          enabled: false
+    expect:
+      kustomize:
+        - name: telemetry-base
+          path: telemetry/base
+          components:
+            - prometheus
+            - prometheus/flux
+        - name: telemetry-resources
+          path: telemetry/resources
+          dependsOn:
+            - telemetry-base
+          components:
+            - metrics-server
+            - prometheus
+            - prometheus/flux
+        - name: pki-base
+          path: pki/base
+          dependsOn:
+            - policy-resources
+            - telemetry-base
+          components:
+            - cert-manager
+            - cert-manager/prometheus
+    exclude:
+      kustomize:
+        - name: observability
+
+  # Logs on, metrics off: fluent-bit ships + fluentd aggregates, Prometheus
+  # stack is dropped. cert-manager/prometheus and fluentbit/prometheus (the
+  # ServiceMonitors) are excluded — no Prometheus to scrape.
+  - name: telemetry metrics disabled keeps logs pipeline and drops Prometheus
+    values:
+      provider: metal
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster: *default-cluster
+      telemetry:
+        metrics:
+          enabled: false
+    expect:
+      kustomize:
+        - name: telemetry-base
+          path: telemetry/base
+          components:
+            - fluentbit
+        - name: telemetry-resources
+          path: telemetry/resources
+          dependsOn:
+            - telemetry-base
+          components:
+            - fluentbit
+            - fluentbit/containerd
+            - fluentbit/kubernetes
+            - fluentbit/parser
+            - fluentbit/systemd
+            - fluentbit/fluentd
+        - name: pki-base
+          path: pki/base
+          dependsOn:
+            - policy-resources
+            - telemetry-base
+          components:
+            - cert-manager
+        - name: observability
+          path: observability
+          dependsOn:
+            - telemetry-base
+          components:
+            - fluentd
+            - fluentd/filters/otel
+
+  # Observability addon force-overrides both telemetry toggles — Grafana needs
+  # Prometheus to scrape and the fluentbit→fluentd path to ship logs.
+  - name: observability addon overrides telemetry metrics and logs disabled
+    values:
+      provider: metal
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster: *default-cluster
+      telemetry:
+        metrics:
+          enabled: false
+        logs:
+          enabled: false
+      addons:
+        observability:
+          enabled: true
+    expect:
+      kustomize:
+        - name: telemetry-base
+          path: telemetry/base
+          components:
+            - prometheus
+            - prometheus/flux
+            - fluentbit
+        - name: pki-base
+          path: pki/base
+          dependsOn:
+            - policy-resources
+            - telemetry-base
+          components:
+            - cert-manager
+            - cert-manager/prometheus
+


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> Broadly scoped change to shared facet configuration that controls what deploys on every cluster template; missed conditionals in addon dependencies could stall Flux reconciliation silently.
>
> **Overview**
>
> This PR introduces independent enablement gates for the telemetry (metrics and logs) and policy (Kyverno) subsystems, wiring them through a computed `telemetry_effective` config value that propagates to all downstream facets via conditional dependency expressions and conditional component lists. The result is that resource-constrained clusters can disable either or both pipelines without forking the facet YAML.
>
> The structural approach — nullable `dependsOn` entries expressed as ternary strings — is consistent with the existing gateway driver pattern. Test coverage is broad, with exclusion assertions confirming that gated kustomizations are absent rather than merely empty.
>
> Two dependency edges in the addon facets use unconditional or incompletely guarded `policy-resources` references that could cause Flux stalls when `policies.enabled: false` is combined with the private-ca or docker-desktop DNS addon; see inline comments for specifics.
>
> Reviewed by Claude for commit `23b19a1`.

<!-- /claude-code-review:summary -->
