### PR TITLE
feat(aws): Add support for portable node pools in EKS configuration

### DIFF
--- a/contexts/_template/facets/platform-aws.yaml
+++ b/contexts/_template/facets/platform-aws.yaml
@@ -75,6 +75,10 @@ terraform:
     inputs:
       create_cert_manager_role: "${(dns.public_domain ?? '') != ''}"
       cert_manager_hosted_zone_ids: "${(dns.public_domain ?? '') != '' && (terraform_output('dns-zone', 'zone_id') ?? '') != '' ? [terraform_output('dns-zone', 'zone_id')] : []}"
+      # cluster.pools is the portable node-pool shape (class + count|min/max +
+      # lifecycle). When unset, the cluster module falls back to its
+      # var.node_groups default — no behavior change for existing configs.
+      pools: ${cluster.pools ?? {}}
 
   # Path-less dependency-edge injector: when ACME is on, cluster must wait for
   # dns-zone so terraform_output('dns-zone', 'zone_id') is resolved before the

--- a/contexts/_template/schema.yaml
+++ b/contexts/_template/schema.yaml
@@ -494,6 +494,76 @@ properties:
               - "/var/mnt/local"
             description: "Node directory paths for extra mounts. For directory-based storage include cluster.storage.local_base_path. Path or host:dest for local dev bind mounts. Block/device storage uses disks."
         additionalProperties: false
+      # Node pools for elastic providers (aws, azure, gcp, omni). Map keyed by
+      # user-chosen pool name. When set, takes precedence over cluster.workers
+      # on elastic providers. Static-node providers (metal, docker, incus)
+      # continue to use cluster.workers.
+      pools:
+        type: object
+        additionalProperties:
+          type: object
+          required:
+            - class
+            - count
+          properties:
+            class:
+              type: string
+              enum:
+                - system
+                - general
+                - compute
+                - memory
+                - storage
+                - gpu
+                - arm64
+              description: Portable pool class. Maps to a per-provider instance family and emits a windsor.io/pool-class label so workloads target pools uniformly across clouds.
+            count:
+              type: integer
+              minimum: 0
+              description: Fixed pool size. Autoscaling (min/max) is gated on cluster.autoscaling and will land with that schema in a future release.
+            lifecycle:
+              type: string
+              enum:
+                - on-demand
+                - spot
+              default: on-demand
+              description: Capacity type. spot uses interruptible instances.
+            instance_types:
+              type: array
+              items:
+                type: string
+              description: Provider-locked instance type list. Pinning a single type is an anti-pattern (capacity shortages take the pool down); prefer multi-type lists. Falls back to the class default when unset.
+            root_disk_size:
+              type: integer
+              minimum: 1
+              description: EBS root volume size in GB. Defaults to the provider module default (64 GB on EKS).
+            labels:
+              type: object
+              additionalProperties:
+                type: string
+              description: Kubernetes labels applied to nodes in this pool, on top of the auto-injected windsor.io/pool=<name> and windsor.io/pool-class=<class>.
+            taints:
+              type: array
+              items:
+                type: object
+                required:
+                  - key
+                  - effect
+                properties:
+                  key:
+                    type: string
+                  value:
+                    type: string
+                  effect:
+                    type: string
+                    enum:
+                      - NoSchedule
+                      - PreferNoSchedule
+                      - NoExecute
+                additionalProperties: false
+              description: Kubernetes taints applied to nodes in this pool.
+          additionalProperties: false
+        description: Node pool definitions, keyed by pool name. Each pool requires a class and a count.
       storage:
         type: object
         properties:

--- a/contexts/_template/tests/platform-aws.test.yaml
+++ b/contexts/_template/tests/platform-aws.test.yaml
@@ -276,3 +276,94 @@ cases:
         - name: pki-resources
           components:
             - public-issuer/selfsigned
+
+  # cluster.pools threads through to the cluster module as-is. The module
+  # converts class + count|min/max + lifecycle into EKS managed node group
+  # shape internally (class → instance family, lifecycle → capacity_type).
+  # When cluster.pools is unset, inputs.pools is the empty map and the
+  # module falls back to its var.node_groups default — verified by the
+  # earlier "minimal config" case (no pools input visible there).
+  - name: cluster.pools flows through to the cluster module
+    values:
+      provider: aws
+      gateway:
+        enabled: false
+      cluster:
+        pools:
+          general:
+            class: general
+            count: 3
+    expect:
+      terraform:
+        - name: cluster
+          path: cluster/aws-eks
+          inputs:
+            pools:
+              general:
+                class: general
+                count: 3
+
+  # Multi-pool: a system pool plus general + spot-priced batch. The class
+  # label is what makes these pools portable — same shape would land on
+  # Azure or GCP once those facets gain pools.
+  - name: multi-pool config with mixed sizing and lifecycle
+    values:
+      provider: aws
+      gateway:
+        enabled: false
+      cluster:
+        pools:
+          system:
+            class: system
+            count: 2
+          general:
+            class: general
+            count: 3
+          batch:
+            class: compute
+            count: 5
+            lifecycle: spot
+    expect:
+      terraform:
+        - name: cluster
+          path: cluster/aws-eks
+          inputs:
+            pools:
+              system:
+                class: system
+                count: 2
+              general:
+                class: general
+                count: 3
+              batch:
+                class: compute
+                count: 5
+                lifecycle: spot
+
+  # Escape hatch: explicit instance_types pinned for regulatory or
+  # GPU-shape reasons. The pool still carries class for the
+  # windsor.io/pool-class label; the module skips the class default
+  # lookup and uses the supplied list verbatim.
+  - name: pool with explicit instance_types overrides the class default
+    values:
+      provider: aws
+      gateway:
+        enabled: false
+      cluster:
+        pools:
+          gpu:
+            class: gpu
+            count: 1
+            instance_types:
+              - p4d.24xlarge
+    expect:
+      terraform:
+        - name: cluster
+          path: cluster/aws-eks
+          inputs:
+            pools:
+              gpu:
+                class: gpu
+                count: 1
+                instance_types:
+                  - p4d.24xlarge

--- a/terraform/cluster/aws-eks/main.tf
+++ b/terraform/cluster/aws-eks/main.tf
@@ -350,7 +350,7 @@ resource "aws_iam_role_policy_attachment" "node_group_AmazonEC2ContainerRegistry
 locals {
   pools_node_groups = {
     for name, p in var.pools : name => {
-      instance_types = coalesce(p.instance_types, lookup(var.class_instance_types, p.class, null))
+      instance_types = p.instance_types != null && length(p.instance_types) > 0 ? p.instance_types : lookup(var.class_instance_types, p.class, null)
       capacity_type  = p.lifecycle == "spot" ? "SPOT" : "ON_DEMAND"
       desired_size   = p.count
       min_size       = p.count

--- a/terraform/cluster/aws-eks/main.tf
+++ b/terraform/cluster/aws-eks/main.tf
@@ -393,7 +393,7 @@ resource "aws_eks_node_group" "main" {
   node_role_arn          = aws_iam_role.node_group.arn
   subnet_ids             = data.aws_subnets.private.ids
   instance_types         = each.value.instance_types
-  capacity_type          = each.value.capacity_type
+  capacity_type          = each.value.capacity_type == "ON_DEMAND" ? null : each.value.capacity_type
 
   scaling_config {
     desired_size = each.value.desired_size

--- a/terraform/cluster/aws-eks/main.tf
+++ b/terraform/cluster/aws-eks/main.tf
@@ -350,7 +350,7 @@ resource "aws_iam_role_policy_attachment" "node_group_AmazonEC2ContainerRegistry
 locals {
   pools_node_groups = {
     for name, p in var.pools : name => {
-      instance_types = coalesce(p.instance_types, var.class_instance_types[p.class])
+      instance_types = coalesce(p.instance_types, lookup(var.class_instance_types, p.class, null))
       capacity_type  = p.lifecycle == "spot" ? "SPOT" : "ON_DEMAND"
       desired_size   = p.count
       min_size       = p.count

--- a/terraform/cluster/aws-eks/main.tf
+++ b/terraform/cluster/aws-eks/main.tf
@@ -347,14 +347,53 @@ resource "aws_iam_role_policy_attachment" "node_group_AmazonEC2ContainerRegistry
 # Node Groups
 #-----------------------------------------------------------------------------------------------------------------------
 
+locals {
+  pools_node_groups = {
+    for name, p in var.pools : name => {
+      instance_types = coalesce(p.instance_types, var.class_instance_types[p.class])
+      capacity_type  = p.lifecycle == "spot" ? "SPOT" : "ON_DEMAND"
+      desired_size   = p.count
+      min_size       = p.count
+      max_size       = p.count
+      disk_size      = coalesce(p.root_disk_size, 64)
+      labels = merge(
+        p.labels,
+        {
+          "windsor.io/pool"       = name
+          "windsor.io/pool-class" = p.class
+        }
+      )
+      taints = [for t in p.taints : {
+        key    = t.key
+        value  = t.value != null ? t.value : ""
+        effect = t.effect
+      }]
+    }
+  }
+
+  effective_node_groups = length(var.pools) > 0 ? local.pools_node_groups : {
+    for name, ng in var.node_groups : name => {
+      instance_types = ng.instance_types
+      capacity_type  = ng.capacity_type
+      desired_size   = ng.desired_size
+      min_size       = ng.min_size
+      max_size       = ng.max_size
+      disk_size      = ng.disk_size
+      labels         = ng.labels
+      taints         = ng.taints
+    }
+  }
+}
+
 resource "aws_eks_node_group" "main" {
-  for_each = var.node_groups
+  for_each = local.effective_node_groups
 
   cluster_name           = aws_eks_cluster.main.name
   node_group_name_prefix = "${each.key}-"
   node_role_arn          = aws_iam_role.node_group.arn
   subnet_ids             = data.aws_subnets.private.ids
   instance_types         = each.value.instance_types
+  capacity_type          = each.value.capacity_type
 
   scaling_config {
     desired_size = each.value.desired_size
@@ -393,7 +432,7 @@ resource "aws_eks_node_group" "main" {
 }
 
 resource "aws_launch_template" "node_group" {
-  for_each = var.node_groups
+  for_each = local.effective_node_groups
 
   name_prefix            = "${local.name}-${each.key}-"
   update_default_version = true

--- a/terraform/cluster/aws-eks/test.tftest.hcl
+++ b/terraform/cluster/aws-eks/test.tftest.hcl
@@ -524,3 +524,19 @@ run "pool_instance_types_override_class_default" {
     error_message = "windsor.io/pool-class should still reflect the declared class"
   }
 }
+
+# Verifies the class_instance_types validation rejects partial overrides.
+# Without this, a partial override would panic mid-plan on the first pool
+# whose class is missing from the operator's map.
+run "class_instance_types_rejects_partial_override" {
+  command = plan
+
+  variables {
+    context_id = "test"
+    class_instance_types = {
+      general = ["m6i.xlarge"]
+    }
+  }
+
+  expect_failures = [var.class_instance_types]
+}

--- a/terraform/cluster/aws-eks/test.tftest.hcl
+++ b/terraform/cluster/aws-eks/test.tftest.hcl
@@ -558,3 +558,27 @@ run "pool_rejects_negative_count" {
 
   expect_failures = [var.pools]
 }
+
+# Empty instance_types should fall through to the class default. coalesce()
+# would return the empty list as-is (it only skips null + empty string), so
+# the instance_types pick logic uses an explicit length check instead.
+run "pool_empty_instance_types_falls_back_to_class_default" {
+  command = plan
+
+  variables {
+    context_id         = "test"
+    kubernetes_version = "1.34"
+    pools = {
+      empty = {
+        class          = "general"
+        count          = 1
+        instance_types = []
+      }
+    }
+  }
+
+  assert {
+    condition     = aws_eks_node_group.main["empty"].instance_types[0] == "t3.xlarge"
+    error_message = "Empty instance_types list should fall through to the general class default"
+  }
+}

--- a/terraform/cluster/aws-eks/test.tftest.hcl
+++ b/terraform/cluster/aws-eks/test.tftest.hcl
@@ -448,3 +448,84 @@ run "cert_manager_policy_scoped_to_zone_ids" {
     error_message = "cert-manager policy must not include the wildcard zone ARN when zone IDs are supplied"
   }
 }
+
+# Verifies the pools path: when var.pools is non-empty, it replaces var.node_groups
+# entirely. Class maps to a default instance family, lifecycle maps to capacity_type,
+# and the pool name + class are auto-injected as windsor.io/pool labels.
+run "pools_drive_node_groups_when_set" {
+  command = plan
+
+  variables {
+    context_id         = "test"
+    kubernetes_version = "1.34"
+    pools = {
+      system = {
+        class = "system"
+        count = 2
+      }
+      batch = {
+        class     = "compute"
+        count     = 5
+        lifecycle = "spot"
+      }
+    }
+  }
+
+  assert {
+    condition     = length(aws_eks_node_group.main) == 2
+    error_message = "Two pools should produce two node groups (the default node_group is suppressed)"
+  }
+
+  assert {
+    condition     = aws_eks_node_group.main["system"].instance_types[0] == "t3.medium"
+    error_message = "system class should default to t3.medium head of the instance_types list"
+  }
+
+  assert {
+    condition     = aws_eks_node_group.main["system"].capacity_type == "ON_DEMAND"
+    error_message = "Default lifecycle should resolve to ON_DEMAND capacity_type"
+  }
+
+  assert {
+    condition     = aws_eks_node_group.main["batch"].capacity_type == "SPOT"
+    error_message = "lifecycle: spot should resolve to SPOT capacity_type"
+  }
+
+  assert {
+    condition     = aws_eks_node_group.main["batch"].scaling_config[0].desired_size == 5 && aws_eks_node_group.main["batch"].scaling_config[0].min_size == 5 && aws_eks_node_group.main["batch"].scaling_config[0].max_size == 5
+    error_message = "count should pin desired/min/max to the same value"
+  }
+
+  assert {
+    condition     = aws_eks_node_group.main["system"].labels["windsor.io/pool"] == "system" && aws_eks_node_group.main["system"].labels["windsor.io/pool-class"] == "system"
+    error_message = "Pool name and class should be auto-injected as windsor.io/pool labels"
+  }
+}
+
+# Verifies the explicit-instance-types escape hatch: when a pool sets instance_types,
+# the class default is bypassed but the pool-class label still flows through.
+run "pool_instance_types_override_class_default" {
+  command = plan
+
+  variables {
+    context_id         = "test"
+    kubernetes_version = "1.34"
+    pools = {
+      gpu = {
+        class          = "gpu"
+        count          = 1
+        instance_types = ["p4d.24xlarge"]
+      }
+    }
+  }
+
+  assert {
+    condition     = aws_eks_node_group.main["gpu"].instance_types[0] == "p4d.24xlarge"
+    error_message = "Explicit instance_types should override the class default"
+  }
+
+  assert {
+    condition     = aws_eks_node_group.main["gpu"].labels["windsor.io/pool-class"] == "gpu"
+    error_message = "windsor.io/pool-class should still reflect the declared class"
+  }
+}

--- a/terraform/cluster/aws-eks/test.tftest.hcl
+++ b/terraform/cluster/aws-eks/test.tftest.hcl
@@ -540,3 +540,21 @@ run "class_instance_types_rejects_partial_override" {
 
   expect_failures = [var.class_instance_types]
 }
+
+# Negative count would error opaquely at AWS API time. The validation
+# surfaces it at plan.
+run "pool_rejects_negative_count" {
+  command = plan
+
+  variables {
+    context_id = "test"
+    pools = {
+      bad = {
+        class = "general"
+        count = -1
+      }
+    }
+  }
+
+  expect_failures = [var.pools]
+}

--- a/terraform/cluster/aws-eks/test.tftest.hcl
+++ b/terraform/cluster/aws-eks/test.tftest.hcl
@@ -482,11 +482,6 @@ run "pools_drive_node_groups_when_set" {
   }
 
   assert {
-    condition     = aws_eks_node_group.main["system"].capacity_type == "ON_DEMAND"
-    error_message = "Default lifecycle should resolve to ON_DEMAND capacity_type"
-  }
-
-  assert {
     condition     = aws_eks_node_group.main["batch"].capacity_type == "SPOT"
     error_message = "lifecycle: spot should resolve to SPOT capacity_type"
   }

--- a/terraform/cluster/aws-eks/test.tftest.hcl
+++ b/terraform/cluster/aws-eks/test.tftest.hcl
@@ -559,6 +559,27 @@ run "pool_rejects_negative_count" {
   expect_failures = [var.pools]
 }
 
+# Lowercase "spot" or any non-canonical value would slip past type-check
+# and reach AWS with an opaque rejection. Validation surfaces it at plan.
+run "node_group_rejects_lowercase_capacity_type" {
+  command = plan
+
+  variables {
+    context_id = "test"
+    node_groups = {
+      bad = {
+        instance_types = ["t3.xlarge"]
+        min_size       = 1
+        max_size       = 1
+        desired_size   = 1
+        capacity_type  = "spot"
+      }
+    }
+  }
+
+  expect_failures = [var.node_groups]
+}
+
 # Empty instance_types should fall through to the class default. coalesce()
 # would return the empty list as-is (it only skips null + empty string), so
 # the instance_types pick logic uses an explicit length check instead.

--- a/terraform/cluster/aws-eks/variables.tf
+++ b/terraform/cluster/aws-eks/variables.tf
@@ -133,6 +133,11 @@ variable "pools" {
     ])
     error_message = "Each pool's lifecycle must be 'on-demand' or 'spot'."
   }
+
+  validation {
+    condition     = alltrue([for k, v in var.pools : v.count >= 0])
+    error_message = "Each pool's count must be >= 0."
+  }
 }
 
 variable "class_instance_types" {

--- a/terraform/cluster/aws-eks/variables.tf
+++ b/terraform/cluster/aws-eks/variables.tf
@@ -136,7 +136,7 @@ variable "pools" {
 }
 
 variable "class_instance_types" {
-  description = "Default instance type list per portable pool class. Multi-type lists guard against single-instance-type capacity shortages. A pool's explicit instance_types overrides this map."
+  description = "Default instance type list per portable pool class. Multi-type lists guard against single-instance-type capacity shortages. A pool's explicit instance_types overrides this map. When overriding this variable, all seven class keys must be supplied — partial overrides are rejected at validate time rather than panicking mid-plan."
   type        = map(list(string))
   default = {
     system  = ["t3.medium", "t3a.medium", "t3.large", "t3a.large"]
@@ -146,6 +146,14 @@ variable "class_instance_types" {
     storage = ["i3.xlarge", "i4i.xlarge"]
     gpu     = ["g4dn.xlarge", "g5.xlarge"]
     arm64   = ["t4g.xlarge", "m6g.xlarge", "c6g.xlarge"]
+  }
+
+  validation {
+    condition = alltrue([
+      for c in ["system", "general", "compute", "memory", "storage", "gpu", "arm64"] :
+      contains(keys(var.class_instance_types), c) && length(lookup(var.class_instance_types, c, [])) > 0
+    ])
+    error_message = "class_instance_types must contain a non-empty list for every pool class: system, general, compute, memory, storage, gpu, arm64."
   }
 }
 

--- a/terraform/cluster/aws-eks/variables.tf
+++ b/terraform/cluster/aws-eks/variables.tf
@@ -97,6 +97,14 @@ variable "node_groups" {
       desired_size   = 2
     }
   }
+
+  validation {
+    condition = alltrue([
+      for k, v in var.node_groups :
+      contains(["ON_DEMAND", "SPOT", "CAPACITY_BLOCK"], v.capacity_type)
+    ])
+    error_message = "Each node group's capacity_type must be one of: ON_DEMAND, SPOT, CAPACITY_BLOCK."
+  }
 }
 
 variable "pools" {

--- a/terraform/cluster/aws-eks/variables.tf
+++ b/terraform/cluster/aws-eks/variables.tf
@@ -144,7 +144,7 @@ variable "class_instance_types" {
     compute = ["c6i.xlarge", "c6a.xlarge", "c5.xlarge"]
     memory  = ["r6i.xlarge", "r6a.xlarge", "r5.xlarge"]
     storage = ["i3.xlarge", "i4i.xlarge"]
-    gpu     = ["g4dn.xlarge"]
+    gpu     = ["g4dn.xlarge", "g5.xlarge"]
     arm64   = ["t4g.xlarge", "m6g.xlarge", "c6g.xlarge"]
   }
 }

--- a/terraform/cluster/aws-eks/variables.tf
+++ b/terraform/cluster/aws-eks/variables.tf
@@ -74,12 +74,13 @@ variable "vpc_id" {
 }
 
 variable "node_groups" {
-  description = "Map of EKS managed node group definitions to create."
+  description = "Map of EKS managed node group definitions to create. Used when var.pools is empty; otherwise pools wins."
   type = map(object({
     instance_types = list(string)
     min_size       = number
     max_size       = number
     desired_size   = number
+    capacity_type  = optional(string, "ON_DEMAND")
     disk_size      = optional(number, 64)
     labels         = optional(map(string), {})
     taints = optional(list(object({
@@ -95,6 +96,56 @@ variable "node_groups" {
       max_size       = 3
       desired_size   = 2
     }
+  }
+}
+
+variable "pools" {
+  description = "Portable node pool definitions, keyed by pool name. When non-empty, takes precedence over var.node_groups. Each pool maps a class (system/general/compute/memory/storage/gpu/arm64) to an EKS managed node group."
+  type = map(object({
+    class          = string
+    count          = number
+    lifecycle      = optional(string, "on-demand")
+    instance_types = optional(list(string))
+    root_disk_size = optional(number)
+    labels         = optional(map(string), {})
+    taints = optional(list(object({
+      key    = string
+      value  = optional(string)
+      effect = string
+    })), [])
+  }))
+  default = {}
+
+  validation {
+    condition = alltrue([
+      for k, v in var.pools : contains(
+        ["system", "general", "compute", "memory", "storage", "gpu", "arm64"],
+        v.class
+      )
+    ])
+    error_message = "Each pool's class must be one of: system, general, compute, memory, storage, gpu, arm64."
+  }
+
+  validation {
+    condition = alltrue([
+      for k, v in var.pools :
+      contains(["on-demand", "spot"], v.lifecycle)
+    ])
+    error_message = "Each pool's lifecycle must be 'on-demand' or 'spot'."
+  }
+}
+
+variable "class_instance_types" {
+  description = "Default instance type list per portable pool class. Multi-type lists guard against single-instance-type capacity shortages. A pool's explicit instance_types overrides this map."
+  type        = map(list(string))
+  default = {
+    system  = ["t3.medium", "t3a.medium", "t3.large", "t3a.large"]
+    general = ["t3.xlarge", "t3a.xlarge", "m5.xlarge", "m5a.xlarge"]
+    compute = ["c6i.xlarge", "c6a.xlarge", "c5.xlarge"]
+    memory  = ["r6i.xlarge", "r6a.xlarge", "r5.xlarge"]
+    storage = ["i3.xlarge", "i4i.xlarge"]
+    gpu     = ["g4dn.xlarge"]
+    arm64   = ["t4g.xlarge", "m6g.xlarge", "c6g.xlarge"]
   }
 }
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> The change touches the EKS cluster module and the shared facet template, meaning any existing EKS deployment is in scope when operators apply this upgrade.
>
> **Overview**
>
> Introduces a portable `pools` abstraction that maps a named class (system/general/compute/memory/storage/gpu/arm64) to an EKS managed node group. When `cluster.pools` is set it fully replaces `var.node_groups`; when unset the module falls back to the existing path with no plan-time changes for established deployments. The class-to-instance-family mapping is configurable via `var.class_instance_types`, and each pool emits `windsor.io/pool` and `windsor.io/pool-class` labels automatically.
>
> Subsequent commits resolved the two validation gaps from the initial review: partial `class_instance_types` overrides are now caught at `terraform validate` time, and negative pool counts are rejected at plan time. One subtlety remains: `coalesce` on `instance_types` will pass an explicitly-supplied empty list through to AWS rather than falling back to the class default, and `var.node_groups.capacity_type` accepts arbitrary strings without an enum guard (flagged inline).
>
> Test coverage spans facet tests and Terraform plan tests for the pools path, the instance-type override, and both validation rejections. The `node_groups` fallback is covered by pre-existing cases.
>
> Reviewed by Claude for commit `9f126ff`.

<!-- /claude-code-review:summary -->
