### PR TITLE
feat(cert-manager): update public issuer configurations for ACME and selfsigned certificates

### DIFF
--- a/contexts/_template/facets/option-gateway.yaml
+++ b/contexts/_template/facets/option-gateway.yaml
@@ -5,6 +5,23 @@ metadata:
   description: Configurable cluster traffic entrypoint
 
 # =============================================================================
+# Config — derived values consumed by this facet
+# =============================================================================
+#
+# cert_effective.public_issuer: which public ClusterIssuer is currently
+# deployed. The selfsigned and ACME public issuers are deployed as distinct
+# ClusterIssuers (`public-selfsigned`, `public-acme`) rather than one
+# `public` resource mutated in place — flipping the name flips a Certificate's
+# spec.issuerRef.name and forces cert-manager to reissue. See platform-aws.yaml
+# and kustomize/pki/resources/public-issuer/.
+#
+config:
+
+  - name: cert_effective
+    value:
+      public_issuer: "${(dns.public_domain ?? '') != '' ? 'public-acme' : 'public-selfsigned'}"
+
+# =============================================================================
 # Kustomize — Gateway API controller + shared Gateway resource
 # =============================================================================
 #
@@ -127,21 +144,18 @@ kustomize:
 
       # ClusterIssuer name for the Gateway's external-web-tls certificate.
       #
-      # AWS normally provides a `public` ClusterIssuer (selfsigned by
-      # default, ACME when dns.public_domain or dns.public_zone_id is
-      # set), so the cert can always reference `public` and just-works
-      # default → real-public-cert is a hot swap of the issuer's spec
-      # without renaming the ClusterIssuer or the cert resource. Other
-      # platforms keep the original `private`/`public` switch keyed on
-      # whether the operator wired up a public domain (those platforms
-      # don't yet auto-provide a public issuer).
-      #
-      # access=private (with dns.private_domain) forces `private`
-      # everywhere — ACME DNS-01 can't validate against a VPC-only zone
-      # (TXT records aren't publicly resolvable), so falling back to
-      # selfsigned is the only working option until an operator wires
-      # a private CA.
-      gateway_cert_issuer: "${gateway.access == 'private' && (dns.private_domain ?? '') != '' ? 'private' : (platform == 'aws' ? 'public' : ((dns.public_domain ?? '') == '' ? 'private' : 'public'))}"
+      #   private mode (gateway.access=private + dns.private_domain set)
+      #     → 'private': ACME DNS-01 can't validate against a VPC-only zone,
+      #     so fall back to private selfsigned until an operator wires a
+      #     private CA.
+      #   AWS, or any platform with dns.public_domain set
+      #     → cert_effective.public_issuer (resolves to 'public-acme' or
+      #     'public-selfsigned'). AWS always renders public-issuer/* via
+      #     pki-resources, so its public branch is always available.
+      #   anything else → 'private': no public ClusterIssuer is deployed
+      #     on those platforms, so falling back to private selfsigned is
+      #     the only safe option.
+      gateway_cert_issuer: "${gateway.access == 'private' && (dns.private_domain ?? '') != '' ? 'private' : (platform == 'aws' || (dns.public_domain ?? '') != '' ? cert_effective.public_issuer : 'private')}"
       # Only emitted when a consumer is active: the lb-address patch (in-cluster
       # LB) or the cilium gateway component. NodePort/cloud-managed-LB paths
       # have no consumer, so leave it empty and the harness drops it.

--- a/contexts/_template/facets/platform-aws.yaml
+++ b/contexts/_template/facets/platform-aws.yaml
@@ -246,18 +246,21 @@ kustomize:
   # pki-resources is always rendered on AWS so the gateway cert always has
   # a working ClusterIssuer to issue against. Two modes:
   #
-  #   1. Default (no public zone configured) → public-issuer/selfsigned.
-  #      Cert issues immediately, browsers warn (untrusted CA), good for
-  #      bringing up a cluster without DNS work. Flips to mode 2 below
-  #      with no manual cert resource changes.
+  #   1. Default (no public zone configured) → public-issuer/selfsigned,
+  #      which deploys ClusterIssuer `public-selfsigned`. Cert issues
+  #      immediately, browsers warn (untrusted CA), good for bringing up a
+  #      cluster without DNS work. Flips to mode 2 below with no manual
+  #      cert resource changes — the gateway_cert_issuer substitution in
+  #      option-gateway switches to `public-acme`, which cert-manager sees
+  #      as a Certificate spec change and reissues against the new issuer.
   #
-  #   2. ACME (operator set dns.public_domain) → public-issuer/acme.
-  #      Windsor created a public Route53 zone via the dns-zone stack
-  #      (so we have a place to write TXT records); cert-manager
-  #      satisfies DNS-01 against it (using the IAM role + Pod Identity
-  #      binding the cluster module provisioned). On switch, cert-manager
-  #      re-issues into the same Secret name — gateway picks up the new
-  #      cert with no restart.
+  #   2. ACME (operator set dns.public_domain) → public-issuer/acme,
+  #      which deploys ClusterIssuer `public-acme`. Windsor created a
+  #      public Route53 zone via the dns-zone stack (so we have a place to
+  #      write TXT records); cert-manager satisfies DNS-01 against it
+  #      (using the IAM role + Pod Identity binding the cluster module
+  #      provisioned). On switch, cert-manager re-issues into the same
+  #      Secret name — gateway picks up the new cert with no restart.
   #
   # The trigger is "we have a Route53 zone we can write TXT records into",
   # not "an email is set" — email is required by Let's Encrypt for account

--- a/contexts/_template/tests/platform-aws.test.yaml
+++ b/contexts/_template/tests/platform-aws.test.yaml
@@ -168,7 +168,7 @@ cases:
   # ACME path on (production): dns.public_domain triggers the standalone
   # dns-zone stack, the cert-manager IAM role on the cluster, the
   # public-issuer/acme component on pki-resources, and the gateway TLS
-  # cert switches to the `public` ClusterIssuer with the public domain.
+  # cert switches to the `public-acme` ClusterIssuer with the public domain.
   - name: dns.public_domain wires up ACME Route53 issuer end to end
     values:
       provider: aws
@@ -254,7 +254,7 @@ cases:
             - envoy/default-404/external-dns
             - flux-webhook
           substitutions:
-            gateway_cert_issuer: public
+            gateway_cert_issuer: public-acme
             external_domain: example.com
 
   # Dev mode flips the ACME server to Let's Encrypt staging to avoid
@@ -469,10 +469,11 @@ cases:
   # to publish records to). The whole private-mode cascade gates on both,
   # so without private_domain the cluster stays on the public path — better
   # than ending up with a half-private gateway no one can reach. Asserted
-  # via the cert issuer falling to the AWS-default `public` (the cascade's
-  # private branch would force `private`); empty `lb_scheme` substitution
-  # is dropped from output so we can't assert it directly, but the cert
-  # issuer is the proxy.
+  # via the cert issuer falling to `public-selfsigned` (no public_domain
+  # was set, so ACME isn't selected; the cascade's private branch would
+  # otherwise force `private`). Empty `lb_scheme` substitution is dropped
+  # from output so we can't assert it directly, but the cert issuer is
+  # the proxy.
   - name: gateway.access=private without private_domain stays public
     values:
       provider: aws
@@ -485,7 +486,7 @@ cases:
         - name: gateway-resources
           path: gateway/resources
           substitutions:
-            gateway_cert_issuer: public
+            gateway_cert_issuer: public-selfsigned
 
   # Negative branch: Cilium provides its own gateway implementation
   # (no Envoy data-plane Service to annotate). The aws-nlb component

--- a/kustomize/pki/resources/kustomization.yaml
+++ b/kustomize/pki/resources/kustomization.yaml
@@ -3,9 +3,13 @@ kind: Kustomization
 resources: []
 # No resources or components by default — facets that need a ClusterIssuer
 # add a self-contained subcomponent:
-#   - private-issuer/ca           full private CA (trust-manager-distributed)
-#   - private-issuer/selfsigned   private selfsigned (dev / fallback)
-#   - public-issuer/acme          ACME public (Let's Encrypt + DNS-01)
-#   - public-issuer/selfsigned    public selfsigned (dev only)
+#   - private-issuer/ca           full private CA (trust-manager-distributed)   → ClusterIssuer/private
+#   - private-issuer/selfsigned   private selfsigned (dev / fallback)           → ClusterIssuer/private
+#   - public-issuer/acme          ACME public (Let's Encrypt + DNS-01)          → ClusterIssuer/public-acme
+#   - public-issuer/selfsigned    public selfsigned (dev / pre-ACME bootstrap)  → ClusterIssuer/public-selfsigned
+# The two public-issuer variants emit distinct ClusterIssuers so that swapping
+# between them (e.g. when an operator first sets dns.public_domain) shows up as
+# a Certificate spec change and triggers cert-manager reissuance — mutating one
+# `public` issuer in place wouldn't.
 # Each subcomponent creates its ClusterIssuer with the right spec inline,
 # so empty stubs never reach cert-manager's webhook.

--- a/kustomize/pki/resources/public-issuer/acme/cluster-issuer.yaml
+++ b/kustomize/pki/resources/public-issuer/acme/cluster-issuer.yaml
@@ -1,7 +1,7 @@
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: public
+  name: public-acme
 spec:
   acme:
     server: ${acme_server}

--- a/kustomize/pki/resources/public-issuer/selfsigned/cluster-issuer.yaml
+++ b/kustomize/pki/resources/public-issuer/selfsigned/cluster-issuer.yaml
@@ -1,6 +1,6 @@
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: public
+  name: public-selfsigned
 spec:
   selfSigned: {}


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> Renames shared Kubernetes ClusterIssuers — existing clusters will see a brief reconciliation gap until both the pki-resources and gateway Kustomizations converge.
>
> **Overview**
>
> Splits the single `public` cert-manager ClusterIssuer into two distinct resources — `public-selfsigned` and `public-acme` — so that toggling between modes via `dns.public_domain` registers as a `Certificate.spec.issuerRef.name` change and forces cert-manager to reissue rather than silently retaining a certificate from the previous issuer. A new `cert_effective` config block in the gateway facet centralizes the issuer-name selection logic, replacing an inline ternary that was repeated across the expression.
>
> The pki-resources deployment expression in `platform-aws.yaml` and the new `cert_effective.public_issuer` both key exclusively on `dns.public_domain`, so the deployed ClusterIssuer and the Certificate's `issuerRef` will always agree. Test assertions are updated from the shared `public` name to the appropriate distinct name for each scenario.
>
> Reviewed by Claude for commit `f638a07`.

<!-- /claude-code-review:summary -->
