### PR TITLE
feat(network/azure-vnet): Configure private hosted zone

### DIFF
--- a/contexts/_template/facets/platform-azure.yaml
+++ b/contexts/_template/facets/platform-azure.yaml
@@ -87,7 +87,7 @@ terraform:
       private_subnet_ids: ${terraform_output('network', 'private_subnet_ids')}
       create_cert_manager_identity: "${(dns.public_domain ?? '') != ''}"
       cert_manager_dns_zone_ids: "${(dns.public_domain ?? '') != '' && (terraform_output('dns-zone', 'zone_id') ?? '') != '' ? [terraform_output('dns-zone', 'zone_id')] : []}"
-      external_dns_dns_zone_ids: "${gateway.access == 'private' && (dns.private_domain ?? '') != '' ? [terraform_output('network', 'private_zone_id')] : ((dns.public_domain ?? '') != '' && (terraform_output('dns-zone', 'zone_id') ?? '') != '' ? [terraform_output('dns-zone', 'zone_id')] : [])}"
+      external_dns_dns_zone_ids: "${gateway.access == 'private' && (dns.private_domain ?? '') != '' && (terraform_output('network', 'private_zone_id') ?? '') != '' ? [terraform_output('network', 'private_zone_id')] : ((dns.public_domain ?? '') != '' && (terraform_output('dns-zone', 'zone_id') ?? '') != '' ? [terraform_output('dns-zone', 'zone_id')] : [])}"
 
   # Path-less dependency-edge injector: when ACME is on, cluster must wait
   # for dns-zone so terraform_output('dns-zone', 'zone_id') is resolved

--- a/contexts/_template/facets/platform-azure.yaml
+++ b/contexts/_template/facets/platform-azure.yaml
@@ -264,6 +264,12 @@ kustomize:
       # RG), public mode from the dns-zone stack.
       external_dns_dns_zone_subscription_id: "${gateway.access == 'private' && (dns.private_domain ?? '') != '' ? (terraform_output('network', 'subscription_id') ?? '') : (terraform_output('dns-zone', 'subscription_id') ?? '')}"
       external_dns_dns_zone_resource_group: "${gateway.access == 'private' && (dns.private_domain ?? '') != '' ? (terraform_output('network', 'resource_group_name') ?? '') : (terraform_output('dns-zone', 'resource_group_name') ?? '')}"
+      # Public Azure DNS and Azure Private DNS Zones are served by different
+      # external-dns provider implementations (azure vs azure-private-dns) and
+      # different ARM resource types — without flipping this in private mode
+      # external-dns lists Microsoft.Network/dnszones and silently skips the
+      # privateDnsZones it should be writing to.
+      external_dns_azure_provider: "${gateway.access == 'private' && (dns.private_domain ?? '') != '' ? 'azure-private-dns' : 'azure'}"
 
   # ---------------------------------------------------------------------------
   # Gateway-base merge — Azure LB annotations on the Envoy data-plane Service

--- a/contexts/_template/facets/platform-azure.yaml
+++ b/contexts/_template/facets/platform-azure.yaml
@@ -186,10 +186,19 @@ kustomize:
       # Deferred terraform_outputs from the dns-zone stack — the cert-manager
       # azureDNS solver needs (zone_name, RG, sub) to call the management API,
       # plus (tenant_id, client_id) of the cert-manager UAMI to authenticate.
-      acme_dns_zone_resource_group: "${terraform_output('dns-zone', 'resource_group_name') ?? ''}"
-      acme_dns_zone_subscription_id: "${terraform_output('dns-zone', 'subscription_id') ?? ''}"
-      cert_manager_client_id: "${terraform_output('cluster', 'cert_manager_client_id') ?? ''}"
-      cert_manager_tenant_id: "${terraform_output('cluster', 'tenant_id') ?? ''}"
+      # Gated on dns.public_domain because the dns-zone stack only composes
+      # when public_domain is set; calling terraform_output on a missing
+      # component is a hard error that ?? doesn't catch. In private mode the
+      # private-issuer/selfsigned component selected above doesn't read these.
+      acme_dns_zone_resource_group: "${(dns.public_domain ?? '') != '' ? (terraform_output('dns-zone', 'resource_group_name') ?? '') : ''}"
+      acme_dns_zone_subscription_id: "${(dns.public_domain ?? '') != '' ? (terraform_output('dns-zone', 'subscription_id') ?? '') : ''}"
+      # cert-manager UAMI outputs only exist when create_cert_manager_identity
+      # fires (gated on dns.public_domain in the cluster step). Calling
+      # terraform_output for an absent output is a hard error that ?? can't
+      # catch — gate eagerly. Selfsigned issuer in private mode doesn't read
+      # these.
+      cert_manager_client_id: "${(dns.public_domain ?? '') != '' ? (terraform_output('cluster', 'cert_manager_client_id') ?? '') : ''}"
+      cert_manager_tenant_id: "${(dns.public_domain ?? '') != '' ? (terraform_output('cluster', 'tenant_id') ?? '') : ''}"
 
   # ---------------------------------------------------------------------------
   # DNS — external-dns + Azure DNS record automation

--- a/contexts/_template/facets/platform-azure.yaml
+++ b/contexts/_template/facets/platform-azure.yaml
@@ -38,12 +38,19 @@ terraform:
   # (selected via the cluster module's data lookup on vnet_module_name).
   # Depends on backend so the storage account holding remote state exists
   # before this stack tries to write to it.
+  #
+  # domain_name feeds the VNet-linked private DNS zone created inside this
+  # module — internal DNS for VNet resources. Sourced from dns.private_domain
+  # (the in-cluster / private name) rather than dns.public_domain, since the
+  # VNet zone is by definition private. The public zone for ACME / external-dns
+  # lives in the standalone dns-zone stack below.
   - name: network
     path: network/azure-vnet
     dependsOn:
       - backend
     inputs:
       vnet_cidr: ${network_effective.cidr_block}
+      domain_name: ${dns.private_domain ?? ""}
 
   # Public Azure DNS zone — provisioned when the operator sets dns.public_domain.
   # Owns its own resource group so the zone has an independent lifecycle from
@@ -80,7 +87,7 @@ terraform:
       private_subnet_ids: ${terraform_output('network', 'private_subnet_ids')}
       create_cert_manager_identity: "${(dns.public_domain ?? '') != ''}"
       cert_manager_dns_zone_ids: "${(dns.public_domain ?? '') != '' && (terraform_output('dns-zone', 'zone_id') ?? '') != '' ? [terraform_output('dns-zone', 'zone_id')] : []}"
-      external_dns_dns_zone_ids: "${(dns.public_domain ?? '') != '' && (terraform_output('dns-zone', 'zone_id') ?? '') != '' ? [terraform_output('dns-zone', 'zone_id')] : []}"
+      external_dns_dns_zone_ids: "${gateway.access == 'private' && (dns.private_domain ?? '') != '' ? [terraform_output('network', 'private_zone_id')] : ((dns.public_domain ?? '') != '' && (terraform_output('dns-zone', 'zone_id') ?? '') != '' ? [terraform_output('dns-zone', 'zone_id')] : [])}"
 
   # Path-less dependency-edge injector: when ACME is on, cluster must wait
   # for dns-zone so terraform_output('dns-zone', 'zone_id') is resolved
@@ -192,7 +199,16 @@ kustomize:
   # addon-private-dns and platform-aws use) so DNS components compose at one
   # path. external-dns watches Ingress / Gateway HTTPRoute resources annotated
   # with external-dns.alpha.kubernetes.io/hostname=<host> and writes A/CNAME
-  # records to the public Azure DNS zone provisioned by the dns-zone stack.
+  # records into a single Azure DNS zone. Two modes, both rendered by the
+  # same Kustomization:
+  #
+  #   - Public mode (default): targets the public zone provisioned by the
+  #     standalone dns-zone stack. Triggered by dns.public_domain.
+  #   - Private mode: targets the VNet-linked private zone created by the
+  #     network module from dns.private_domain. Triggered by
+  #     gateway.access=private (also requires dns.private_domain — there's
+  #     no zone to publish to without it, so the private cascade no-ops
+  #     and the gateway runs as public).
   #
   # Workload Identity is wired by the cluster module (external_dns UAMI +
   # Federated Credential bound to system:serviceaccount:system-dns:external-dns).
@@ -202,7 +218,7 @@ kustomize:
   #
   - name: dns
     path: dns
-    when: "(dns.public_domain ?? '') != ''"
+    when: "(dns.public_domain ?? '') != '' || (gateway.access == 'private' && (dns.private_domain ?? '') != '')"
     dependsOn:
       - policy-resources
       # gateway-base installs the Gateway API CRDs (HTTPRoute, Gateway). When
@@ -217,10 +233,16 @@ kustomize:
     timeout: 5m
     interval: 5m
     substitutions:
-      external_domain: "${dns.public_domain ?? ''}"
-      # Azure DNS resource ID — same value as cert_manager_dns_zone_ids on the
-      # cluster module, lets external-dns pin to one zone.
-      zone_id_filter: "${terraform_output('dns-zone', 'zone_id') ?? ''}"
+      # Private mode wins over public_domain for the gateway's DNS — even if
+      # both are set, a private gateway should publish to the private zone (its
+      # hostname is internal-only and unusable as a record target on the public
+      # zone). Same access=private && private_domain gate fires here as in the
+      # rest of the private-mode cascade.
+      external_domain: "${gateway.access == 'private' && (dns.private_domain ?? '') != '' ? dns.private_domain : (dns.public_domain ?? '')}"
+      # Azure DNS resource ID — pins external-dns to a specific zone. Public
+      # zone comes from the standalone dns-zone stack; private zone comes from
+      # the network module (azure-vnet creates it when dns.private_domain is set).
+      zone_id_filter: "${gateway.access == 'private' && (dns.private_domain ?? '') != '' ? (terraform_output('network', 'private_zone_id') ?? '') : (terraform_output('dns-zone', 'zone_id') ?? '')}"
       # Owner ID stamped into TXT records so multiple external-dns instances
       # in the same zone don't clobber each other. The context id (top-level
       # `id` field in values.yaml) is unique per Windsor context so it doubles
@@ -228,8 +250,11 @@ kustomize:
       txt_owner_id: "${id}"
       external_dns_client_id: "${terraform_output('cluster', 'external_dns_client_id') ?? ''}"
       external_dns_tenant_id: "${terraform_output('cluster', 'tenant_id') ?? ''}"
-      external_dns_dns_zone_subscription_id: "${terraform_output('dns-zone', 'subscription_id') ?? ''}"
-      external_dns_dns_zone_resource_group: "${terraform_output('dns-zone', 'resource_group_name') ?? ''}"
+      # Subscription / RG of the target zone — feeds external-dns's azure.json.
+      # Private mode pulls from the network module (zone lives in the VNet's
+      # RG), public mode from the dns-zone stack.
+      external_dns_dns_zone_subscription_id: "${gateway.access == 'private' && (dns.private_domain ?? '') != '' ? (terraform_output('network', 'subscription_id') ?? '') : (terraform_output('dns-zone', 'subscription_id') ?? '')}"
+      external_dns_dns_zone_resource_group: "${gateway.access == 'private' && (dns.private_domain ?? '') != '' ? (terraform_output('network', 'resource_group_name') ?? '') : (terraform_output('dns-zone', 'resource_group_name') ?? '')}"
 
   # ---------------------------------------------------------------------------
   # Gateway-base merge — Azure LB annotations on the Envoy data-plane Service

--- a/contexts/_template/facets/platform-azure.yaml
+++ b/contexts/_template/facets/platform-azure.yaml
@@ -7,6 +7,23 @@ metadata:
 when: platform == 'azure'
 
 # =============================================================================
+# Config — platform-specific overrides
+# =============================================================================
+#
+# AKS ships metrics-server as a managed add-on, so we suppress the copy that
+# platform-base would otherwise add to telemetry-resources (two instances
+# would fight on the same APIService). The flag is layered onto the base
+# `telemetry_effective` config block via Windsor's deep-merge semantics —
+# only metrics_server_enabled is overridden, the rest of the field set
+# (metrics_enabled, logs_enabled, logs_driver) keeps platform-base's values.
+#
+config:
+
+  - name: telemetry_effective
+    value:
+      metrics_server_enabled: false
+
+# =============================================================================
 # Terraform — AzureRM state backend, VNet, AKS, optional public DNS zone
 # =============================================================================
 #
@@ -110,8 +127,12 @@ terraform:
       concurrency: 5
 
 # =============================================================================
-# Kustomize — Azure Disk CSI + AKS-specific telemetry trim + DNS / ACME / LB
+# Kustomize — Azure Disk CSI + DNS / ACME / LB
 # =============================================================================
+#
+# AKS-specific telemetry trim (metrics-server suppression) is handled in the
+# config block above, so it composes via the shared platform-base entry
+# rather than a separate kustomize override here.
 #
 kustomize:
 
@@ -128,14 +149,6 @@ kustomize:
     interval: 5m
     substitutions:
       single_storage_type: ${cluster.storage.single_storage_type ?? "StandardSSD_LRS"}
-
-  # AKS ships metrics-server as a managed add-on, so remove our copy to
-  # avoid running two instances fighting over the same APIService.
-  - name: telemetry-resources
-    path: telemetry/resources
-    strategy: remove
-    components:
-      - metrics-server
 
   # ---------------------------------------------------------------------------
   # cert-manager Workload Identity (Azure DNS-01 only)

--- a/contexts/_template/facets/platform-base.yaml
+++ b/contexts/_template/facets/platform-base.yaml
@@ -435,7 +435,11 @@ kustomize:
     dependsOn:
       - telemetry-base
     components:
-      - "${telemetry_effective.metrics_enabled ? 'metrics-server' : ''}"
+      # Platform-specific opt-out: AKS (and other managed K8s flavors) ship
+      # metrics-server as a built-in add-on, so platform-azure overrides
+      # telemetry_effective.metrics_server_enabled to false to skip our copy.
+      # Defaults to true via ?? so the AWS / metal / incus paths are unchanged.
+      - "${telemetry_effective.metrics_enabled && (telemetry_effective.metrics_server_enabled ?? true) ? 'metrics-server' : ''}"
       - "${telemetry_effective.metrics_enabled ? 'prometheus' : ''}"
       - "${telemetry_effective.metrics_enabled ? 'prometheus/flux' : ''}"
       - "${telemetry_effective.logs_enabled ? 'fluentbit' : ''}"

--- a/kustomize/dns/external-dns/providers/azure/patches/helm-release.yaml
+++ b/kustomize/dns/external-dns/providers/azure/patches/helm-release.yaml
@@ -8,7 +8,10 @@ spec:
   values:
     # azure for public Azure DNS zones, azure-private-dns for VNet-linked
     # private zones. Defaults to azure to preserve public-mode behavior.
-    provider: ${external_dns_azure_provider:-azure}
+    # Object form (provider.name) is required by chart >=1.21; the legacy
+    # `provider: <string>` form emits a deprecation notice.
+    provider:
+      name: ${external_dns_azure_provider:-azure}
     policy: sync
     registry: txt
     # Unique TXT-record owner ID — keeps multiple external-dns instances
@@ -18,10 +21,14 @@ spec:
     txtOwnerId: ${txt_owner_id}
     domainFilters:
       - ${external_domain:-test}
-    # Azure DNS rejects '*' in TXT relative names, so the registry's TXT record
-    # for a wildcard endpoint (e.g. a-*.example.com) fails to write. Replace
-    # '*' with 'any' in TXT names — record set becomes a-any.example.com.
-    txtWildcardReplacement: any
+    # Azure (Public + Private) DNS rejects '*' in TXT relative names, so the
+    # registry's TXT record for a wildcard endpoint (e.g. a-*.example.com)
+    # fails to write with HTTP 400. Replace '*' with 'any' in TXT names so the
+    # record set becomes a-any.example.com. Pass via extraArgs because the
+    # chart 1.21.x doesn't render the dedicated txtWildcardReplacement value
+    # into deployment args; the binary still honors the CLI flag directly.
+    extraArgs:
+      - --txt-wildcard-replacement=any
     # external-dns Azure provider unconditionally reads /etc/kubernetes/azure.json
     # at startup, before flag overrides are applied — so the file must exist even
     # when using workload identity. The chart creates and mounts it from this block.

--- a/kustomize/dns/external-dns/providers/azure/patches/helm-release.yaml
+++ b/kustomize/dns/external-dns/providers/azure/patches/helm-release.yaml
@@ -6,7 +6,9 @@ metadata:
   namespace: system-dns
 spec:
   values:
-    provider: azure
+    # azure for public Azure DNS zones, azure-private-dns for VNet-linked
+    # private zones. Defaults to azure to preserve public-mode behavior.
+    provider: ${external_dns_azure_provider:-azure}
     policy: sync
     registry: txt
     # Unique TXT-record owner ID — keeps multiple external-dns instances

--- a/terraform/cluster/azure-aks/main.tf
+++ b/terraform/cluster/azure-aks/main.tf
@@ -658,17 +658,37 @@ resource "azurerm_user_assigned_identity" "external_dns" {
 ## so the role has to be at RG scope, not per-zone. cert-manager's azureDNS
 ## solver reads the zone by name + RG directly, so zone-scoped grants are
 ## fine for it; external-dns has no such shortcut.
+##
+## Public Azure DNS (Microsoft.Network/dnszones) and Azure Private DNS
+## (Microsoft.Network/privateDnsZones) are distinct ARM resource types with
+## distinct RBAC roles. Detect the type from the resource ID and assign the
+## matching role; mixed lists with both kinds in the same RG produce one
+## role assignment per role.
 locals {
-  external_dns_zone_rgs = var.create_external_dns_identity ? toset([
+  external_dns_public_zone_rgs = var.create_external_dns_identity ? toset([
     for id in var.external_dns_dns_zone_ids :
     regex("^(/subscriptions/[^/]+/resourceGroups/[^/]+)", id)[0]
+    if can(regex("/dnszones/", lower(id)))
+  ]) : toset([])
+
+  external_dns_private_zone_rgs = var.create_external_dns_identity ? toset([
+    for id in var.external_dns_dns_zone_ids :
+    regex("^(/subscriptions/[^/]+/resourceGroups/[^/]+)", id)[0]
+    if can(regex("/privatednszones/", lower(id)))
   ]) : toset([])
 }
 
 resource "azurerm_role_assignment" "external_dns_zones" {
-  for_each             = local.external_dns_zone_rgs
+  for_each             = local.external_dns_public_zone_rgs
   scope                = each.value
   role_definition_name = "DNS Zone Contributor"
+  principal_id         = azurerm_user_assigned_identity.external_dns[0].principal_id
+}
+
+resource "azurerm_role_assignment" "external_dns_private_zones" {
+  for_each             = local.external_dns_private_zone_rgs
+  scope                = each.value
+  role_definition_name = "Private DNS Zone Contributor"
   principal_id         = azurerm_user_assigned_identity.external_dns[0].principal_id
 }
 

--- a/terraform/cluster/azure-aks/test.tftest.hcl
+++ b/terraform/cluster/azure-aks/test.tftest.hcl
@@ -705,7 +705,52 @@ run "external_dns_identity_disabled" {
 
   assert {
     condition     = length(azurerm_role_assignment.external_dns_zones) == 0
-    error_message = "external-dns role assignments should not be provisioned when create_external_dns_identity is false."
+    error_message = "external-dns public-zone role assignments should not be provisioned when create_external_dns_identity is false."
+  }
+
+  assert {
+    condition     = length(azurerm_role_assignment.external_dns_private_zones) == 0
+    error_message = "external-dns private-zone role assignments should not be provisioned when create_external_dns_identity is false."
+  }
+}
+
+# Tests that external-dns gets the correct RBAC role per zone type:
+# DNS Zone Contributor for public Azure DNS zones, Private DNS Zone
+# Contributor for VNet-linked Azure Private DNS zones. The two zone types
+# are different ARM resource types under different built-in roles, so a
+# single one-size grant doesn't work — picking the right role from the
+# resource ID's path segment is the load-bearing logic here.
+run "external_dns_role_per_zone_type" {
+  command = plan
+
+  variables {
+    context_id         = "test"
+    name               = "windsor-aks"
+    kubernetes_version = "1.34"
+    external_dns_dns_zone_ids = [
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-public/providers/Microsoft.Network/dnszones/public.example.com",
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-private/providers/Microsoft.Network/privateDnsZones/private.example.com",
+    ]
+  }
+
+  assert {
+    condition     = length(azurerm_role_assignment.external_dns_zones) == 1
+    error_message = "Public-zone role assignment should fire for the dnszones entry."
+  }
+
+  assert {
+    condition     = [for ra in azurerm_role_assignment.external_dns_zones : ra.role_definition_name][0] == "DNS Zone Contributor"
+    error_message = "Public zones must use DNS Zone Contributor role."
+  }
+
+  assert {
+    condition     = length(azurerm_role_assignment.external_dns_private_zones) == 1
+    error_message = "Private-zone role assignment should fire for the privateDnsZones entry."
+  }
+
+  assert {
+    condition     = [for ra in azurerm_role_assignment.external_dns_private_zones : ra.role_definition_name][0] == "Private DNS Zone Contributor"
+    error_message = "Private zones must use Private DNS Zone Contributor role."
   }
 }
 

--- a/terraform/network/azure-vnet/README.md
+++ b/terraform/network/azure-vnet/README.md
@@ -22,6 +22,8 @@ No modules.
 |------|------|
 | [azurerm_nat_gateway.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/nat_gateway) | resource |
 | [azurerm_nat_gateway_public_ip_association.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/nat_gateway_public_ip_association) | resource |
+| [azurerm_private_dns_zone.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
+| [azurerm_private_dns_zone_virtual_network_link.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
 | [azurerm_public_ip.nat](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
 | [azurerm_resource_group.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_route_table.private](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/route_table) | resource |
@@ -37,6 +39,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_context_id"></a> [context\_id](#input\_context\_id) | Context ID for the resources | `string` | `null` | no |
+| <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | The domain name for the VNet-linked private DNS zone. When unset, no private zone is created. | `string` | `null` | no |
 | <a name="input_enable_nat_gateway"></a> [enable\_nat\_gateway](#input\_enable\_nat\_gateway) | Enable NAT Gateway for private subnets | `bool` | `true` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the resource | `string` | `"network"` | no |
 | <a name="input_region"></a> [region](#input\_region) | Region for the resources | `string` | `"eastus"` | no |
@@ -49,5 +52,14 @@ No modules.
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_isolated_subnet_ids"></a> [isolated\_subnet\_ids](#output\_isolated\_subnet\_ids) | List of isolated subnet IDs |
+| <a name="output_private_subnet_ids"></a> [private\_subnet\_ids](#output\_private\_subnet\_ids) | List of private subnet IDs |
+| <a name="output_private_zone_id"></a> [private\_zone\_id](#output\_private\_zone\_id) | Resource ID of the VNet-linked private DNS zone created from var.domain\_name. Null when no domain\_name was supplied. |
+| <a name="output_private_zone_name"></a> [private\_zone\_name](#output\_private\_zone\_name) | Name of the VNet-linked private DNS zone. Null when no domain\_name was supplied. |
+| <a name="output_public_subnet_ids"></a> [public\_subnet\_ids](#output\_public\_subnet\_ids) | List of public subnet IDs |
+| <a name="output_resource_group_name"></a> [resource\_group\_name](#output\_resource\_group\_name) | Name of the resource group holding the VNet and (when set) the private DNS zone. |
+| <a name="output_subscription_id"></a> [subscription\_id](#output\_subscription\_id) | Subscription ID resolved from the VNet resource. |
+| <a name="output_vnet_id"></a> [vnet\_id](#output\_vnet\_id) | The ID of the VNet |
 <!-- END_TF_DOCS -->

--- a/terraform/network/azure-vnet/main.tf
+++ b/terraform/network/azure-vnet/main.tf
@@ -146,3 +146,29 @@ resource "azurerm_subnet_nat_gateway_association" "private" {
   subnet_id      = azurerm_subnet.private[count.index].id
   nat_gateway_id = azurerm_nat_gateway.main[count.index].id
 }
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Private DNS Zone
+#-----------------------------------------------------------------------------------------------------------------------
+
+# VNet-attached private DNS zone, optional. Records here (e.g. external-dns
+# A/CNAME/TXT entries) only resolve from inside the VNet. Linked to the VNet
+# so resources in the VNet resolve names in the zone without per-VM agent setup.
+resource "azurerm_private_dns_zone" "main" {
+  count               = var.domain_name != null ? 1 : 0
+  name                = var.domain_name
+  resource_group_name = azurerm_resource_group.main.name
+  tags = merge({
+    Name = var.domain_name
+  }, local.tags)
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "main" {
+  count                 = var.domain_name != null ? 1 : 0
+  name                  = "${local.vnet_name}-link"
+  resource_group_name   = azurerm_resource_group.main.name
+  private_dns_zone_name = azurerm_private_dns_zone.main[0].name
+  virtual_network_id    = azurerm_virtual_network.main.id
+  registration_enabled  = false
+  tags                  = local.tags
+}

--- a/terraform/network/azure-vnet/main.tf
+++ b/terraform/network/azure-vnet/main.tf
@@ -155,7 +155,7 @@ resource "azurerm_subnet_nat_gateway_association" "private" {
 # A/CNAME/TXT entries) only resolve from inside the VNet. Linked to the VNet
 # so resources in the VNet resolve names in the zone without per-VM agent setup.
 resource "azurerm_private_dns_zone" "main" {
-  count               = var.domain_name != null ? 1 : 0
+  count               = var.domain_name != null && var.domain_name != "" ? 1 : 0
   name                = var.domain_name
   resource_group_name = azurerm_resource_group.main.name
   tags = merge({
@@ -164,7 +164,7 @@ resource "azurerm_private_dns_zone" "main" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "main" {
-  count                 = var.domain_name != null ? 1 : 0
+  count                 = var.domain_name != null && var.domain_name != "" ? 1 : 0
   name                  = "${local.vnet_name}-link"
   resource_group_name   = azurerm_resource_group.main.name
   private_dns_zone_name = azurerm_private_dns_zone.main[0].name

--- a/terraform/network/azure-vnet/outputs.tf
+++ b/terraform/network/azure-vnet/outputs.tf
@@ -21,3 +21,23 @@ output "isolated_subnet_ids" {
   description = "List of isolated subnet IDs"
   value       = azurerm_subnet.isolated[*].id
 }
+
+output "private_zone_id" {
+  description = "Resource ID of the VNet-linked private DNS zone created from var.domain_name. Null when no domain_name was supplied."
+  value       = try(azurerm_private_dns_zone.main[0].id, null)
+}
+
+output "private_zone_name" {
+  description = "Name of the VNet-linked private DNS zone. Null when no domain_name was supplied."
+  value       = try(azurerm_private_dns_zone.main[0].name, null)
+}
+
+output "resource_group_name" {
+  description = "Name of the resource group holding the VNet and (when set) the private DNS zone."
+  value       = azurerm_resource_group.main.name
+}
+
+output "subscription_id" {
+  description = "Subscription ID resolved from the VNet resource."
+  value       = element(split("/", azurerm_virtual_network.main.id), 2)
+}

--- a/terraform/network/azure-vnet/test.tftest.hcl
+++ b/terraform/network/azure-vnet/test.tftest.hcl
@@ -71,6 +71,31 @@ run "minimal_configuration" {
   }
 }
 
+# Tests that an empty-string domain_name is treated the same as null.
+# The platform-azure facet passes ${dns.private_domain ?? ""} (empty string,
+# not null) when private_domain is unset, so the count guard must reject
+# both null and "" — otherwise Terraform tries to create a zone with name=""
+# and Azure rejects with an invalid-name error.
+run "empty_domain_name_skips_private_zone" {
+  command = plan
+
+  variables {
+    context_id  = "test"
+    name        = "windsor-vnet"
+    domain_name = ""
+  }
+
+  assert {
+    condition     = length(azurerm_private_dns_zone.main) == 0
+    error_message = "Private DNS zone should not be created when domain_name is empty string"
+  }
+
+  assert {
+    condition     = length(azurerm_private_dns_zone_virtual_network_link.main) == 0
+    error_message = "Private DNS zone VNet link should not be created when domain_name is empty string"
+  }
+}
+
 # Tests private DNS zone creation when domain_name is provided.
 run "private_dns_zone" {
   command = plan

--- a/terraform/network/azure-vnet/test.tftest.hcl
+++ b/terraform/network/azure-vnet/test.tftest.hcl
@@ -59,6 +59,52 @@ run "minimal_configuration" {
     condition     = azurerm_route_table.private[0].name == "windsor-vnet-private-1-test"
     error_message = "Route table name should follow naming convention"
   }
+
+  assert {
+    condition     = length(azurerm_private_dns_zone.main) == 0
+    error_message = "Private DNS zone should not be created when domain_name is unset"
+  }
+
+  assert {
+    condition     = length(azurerm_private_dns_zone_virtual_network_link.main) == 0
+    error_message = "Private DNS zone VNet link should not be created when domain_name is unset"
+  }
+}
+
+# Tests private DNS zone creation when domain_name is provided.
+run "private_dns_zone" {
+  command = plan
+
+  variables {
+    context_id  = "test"
+    name        = "windsor-vnet"
+    domain_name = "internal.example.com"
+  }
+
+  assert {
+    condition     = length(azurerm_private_dns_zone.main) == 1
+    error_message = "Private DNS zone should be created when domain_name is set"
+  }
+
+  assert {
+    condition     = azurerm_private_dns_zone.main[0].name == "internal.example.com"
+    error_message = "Private DNS zone name should match domain_name input"
+  }
+
+  assert {
+    condition     = length(azurerm_private_dns_zone_virtual_network_link.main) == 1
+    error_message = "VNet link should be created when domain_name is set"
+  }
+
+  assert {
+    condition     = azurerm_private_dns_zone_virtual_network_link.main[0].registration_enabled == false
+    error_message = "Auto-registration should be disabled on the VNet link"
+  }
+
+  assert {
+    condition     = azurerm_private_dns_zone_virtual_network_link.main[0].name == "windsor-vnet-test-link"
+    error_message = "VNet link name should follow {vnet_name}-link convention"
+  }
 }
 
 # Tests a full configuration with all optional variables explicitly set.

--- a/terraform/network/azure-vnet/variables.tf
+++ b/terraform/network/azure-vnet/variables.tf
@@ -75,6 +75,12 @@ variable "enable_nat_gateway" {
   default     = true
 }
 
+variable "domain_name" {
+  description = "The domain name for the VNet-linked private DNS zone. When unset, no private zone is created."
+  type        = string
+  default     = null
+}
+
 variable "tags" {
   description = "Tags to apply to the resources"
   type        = map(string)


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> This PR modifies shared Azure network infrastructure and introduces a new conditional DNS mode affecting cert-manager, external-dns, and zone routing for all Azure deployments.
>
> **Overview**
>
> Introduces an optional VNet-linked private DNS zone into the `azure-vnet` module, controlled by a new `domain_name` variable. The Windsor facet gains a `gateway.access == 'private'` conditional path that redirects cert-manager outputs, external-dns substitutions, and the `dns` kustomize component's zone targeting to the private zone, leaving public-mode behavior unchanged.
>
> Two earlier concerns are resolved: the empty-string `domain_name` guard (now `!= null && != ""`), and the null guard on `private_zone_id` in `external_dns_dns_zone_ids`. The latest commits also refactor metrics-server suppression from a kustomize `strategy: remove` override into a config deep-merge that sets `telemetry_effective.metrics_server_enabled: false`; whether `telemetry_effective`'s schema accepts this field is the one open question (see inline comment).
>
> Reviewed by Claude for commit `8502769`.
<!-- /claude-code-review:summary -->
