### PR TITLE
chore(docs): Kustomize v0.9.0

### DIFF
--- a/.claude/skills/docs-author/SKILL.md
+++ b/.claude/skills/docs-author/SKILL.md
@@ -67,6 +67,7 @@ For each significant stack under `kustomize/` (e.g. dns, pki, gateway), maintain
 - **Chart and image versions.** Pinned in `helm-release.yaml` with renovate markers; that's the source of truth. Mirroring versions in the README means Renovate PRs silently drift the docs.
 - **Generic operations boilerplate.** "Flux retries failed reconciles", "DependencyNotReady means a dependency isn't ready" — applies to every stack, doesn't belong in any single one.
 - **Diagrams as PNG/SVG attachments.** Use Mermaid. The site renders it; binary attachments are fragile through ingest.
+- **Derived facet config as the primary description.** Don't gate components or describe conditions in terms of `gateway_effective.driver`, `telemetry_effective.metrics_enabled`, `talos_common.storage_driver`, `lb_effective.*`, `cni_effective.*`, or any other `*_effective` / `*_common` value. Those are facet-author concerns. Use the user-facing schema field instead — e.g. `gateway.driver`, `telemetry.metrics.enabled`, `cluster.storage.driver`, `network.loadbalancer_driver`. If the derivation logic matters (e.g. docker-desktop overrides), mention it in a brief footnote that points to the facet, not as the primary table entry.
 
 ### Authoring workflow
 

--- a/.claude/skills/docs-author/SKILL.md
+++ b/.claude/skills/docs-author/SKILL.md
@@ -44,21 +44,43 @@ Exact glob roots are finalized with the website `docs:vendor` script; treat the 
 - Generate from modules in this repo with `task docs` (terraform-docs injected between `<!-- BEGIN_TF_DOCS -->` / `<!-- END_TF_DOCS -->` markers in each module's `README.md`). Commit the regenerated `terraform/<module-path>/README.md` (`cluster/talos`, `gitops/flux`, etc.). The site ingest pipeline mirrors these into `docs/reference/terraform/<module-path>/` per the path mapping above; contributors don't write into `docs/reference/` directly.
 - Inputs, outputs, and gotchas belong here; high-level “what is Terraform in Windsor” stays on the site under `/docs/components/terraform`.
 
-## Kustomize stack operator guide (per top-level stack)
+## Kustomize stack reference (per top-level stack)
 
-For each significant stack under `kustomize/` (e.g. dns, csi), maintain **one** operator-oriented README (source location agreed with ingest—often `kustomize/<stack>/README.md` normalized into `docs/reference/kustomize/<stack>.md`, or authored directly under `docs/reference/kustomize/`).
+For each significant stack under `kustomize/` (e.g. dns, pki, gateway), maintain **one** README at `kustomize/<stack>/README.md`, normalized by the website ingest into `docs/reference/blueprints/core/kustomize/<stack>.md`.
 
-Use this section order where applicable:
+**Audience: both blueprint designers and operators.** Designers compose `blueprint.yaml` and need to know which components to wire for which environment. Operators run the stack and need to know what's inside it and how it fails. The format below serves both — recipes and components tables for designers, operations and security for operators.
 
-1. **Purpose** — what this subtree owns.
-2. **Dependencies** — other stacks, CRDs, cloud prereqs.
-3. **Blueprint wiring** — minimal `blueprint.yaml` fragment (`source` pointing at this blueprint, `path`, `components`).
-4. **Substitutions / vars** — table: name, default, required, effect.
-5. **Components** — Kustomize `components/` and when to enable each.
-6. **Operations** — upgrade, rollback, common failures, observability.
-7. **Security** — RBAC, secrets, network policy when relevant.
+### Section order
 
-Align structure with existing kustomize conventions: see `.claude/skills/kustomize-author/SKILL.md`. Terraform module docs should align with `.claude/skills/terraform-style/SKILL.md` where applicable.
+1. **Frontmatter and purpose** — `title` and `description` in frontmatter; one or two sentences below the H1 stating what the stack owns.
+2. **Flow** — Mermaid diagram (` ```mermaid `) showing how the stack's pieces interact. Subgraph the namespaces; show external dependencies (cloud APIs, other stacks) as separate nodes. Mermaid renders natively on GitHub and on the docs site (which uses GFM); ASCII art is too cramped once a stack has more than two flows.
+3. **Recipes** — three to five canonical configurations with copy-pasteable `kustomize:` fragments (e.g. local single-node, AWS production, addon enabled). Each recipe is the **materialized union** of components when multiple facets layer onto the same kustomize entry, not just one facet's contribution. The merge is additive in Windsor — design for that.
+4. **Substitutions** — table with columns `Name`, `Required when`, `Effect and constraints`. Include real constraints (zone ID format, IP-pool membership, SAN coverage), not just "string". Don't add a "Required: yes" column when every row says yes — fold the gating condition into "Required when".
+5. **Components** — exhaustive lookup table, one row per Kustomize component directory. Columns: `Component`, `Enable when`, `Effect`. Group by operator if the stack has more than one (e.g. `coredns/` and `external-dns/`). This is reference material, not first-read material; designers use it to find what `coredns/cilium` actually does.
+6. **Dependencies** — table with `Stack` and `Reason`. Be specific about *why* — "needed for CRDs", "needed for the cluster issuer that signs etcd certs". A weak rationale ("for security") usually means the real reason wasn't traced.
+7. **Operations** — stack-specific failure modes only. Skip generic Flux/Renovate behaviour (`HelmRelease retries 3×`, `Renovate opens PRs`) — that lives at the repo level. Lead with the symptom, then the cause, then the fix. Include a metrics/observability note if the stack exposes Prometheus endpoints.
+8. **Security** — namespace PSA levels, certificate issuance and trust paths, IAM/identity per provider, scope of any cluster-wide policies. Not a checklist of best practices; specific facts about *this* stack.
+9. **See also** — canonical facets (link to `contexts/_template/facets/*.yaml` files that wire the stack), related stacks under `kustomize/`, and the Blueprint schema page on windsorcli.dev.
+
+### What NOT to include
+
+- **Chart and image versions.** Pinned in `helm-release.yaml` with renovate markers; that's the source of truth. Mirroring versions in the README means Renovate PRs silently drift the docs.
+- **Generic operations boilerplate.** "Flux retries failed reconciles", "DependencyNotReady means a dependency isn't ready" — applies to every stack, doesn't belong in any single one.
+- **Diagrams as PNG/SVG attachments.** Use Mermaid. The site renders it; binary attachments are fragile through ingest.
+
+### Authoring workflow
+
+1. Read the canonical facet(s) under `contexts/_template/facets/*.yaml` that wire the stack — they encode dependsOn, conditional component selection, and substitutions. The stack README mirrors that information in human-readable form.
+2. Walk the component tree to confirm directories exist and read the patches to confirm what each component actually does.
+3. Read the helm-release files for namespace, dependsOn at the HelmRelease level, and any inline values that affect described behavior.
+4. Write the README in the section order above.
+5. **Audit before publishing.** Verify every claim against code: each component path exists, each substitution name appears as `${...}` somewhere, each dependency rationale matches the actual reason (a "for X" claim where X isn't in the manifest is a hallucination). Use file:line citations in commit messages or PR descriptions when the claim isn't immediately obvious from the file. Spawning an Explore subagent to audit the README against the code is a reliable way to catch drift; the cost is one extra round-trip and it routinely finds two to four real issues per first draft.
+
+### VS Code preview caveat
+
+VS Code's built-in Markdown preview does not render Mermaid by default. Install `bierner.markdown-mermaid` for local preview. GitHub renders it natively, and the docs site (GFM) renders it via the standard GitHub renderer.
+
+Align structure with existing kustomize conventions: see `.claude/skills/kustomize-author/SKILL.md`. Terraform module docs should align with `.claude/skills/terraform-style/SKILL.md` where applicable. Worked examples: [kustomize/dns/README.md](../../../kustomize/dns/README.md), [kustomize/pki/README.md](../../../kustomize/pki/README.md).
 
 ## Compatibility
 
@@ -68,6 +90,10 @@ Align structure with existing kustomize conventions: see `.claude/skills/kustomi
 
 - [ ] Module or stack behavior that affects operators reflected in `docs/reference/` or stack README.
 - [ ] Generated Terraform docs refreshed if inputs/outputs changed.
+- [ ] Stack README sections in the prescribed order; recipes show materialized component unions, not single-facet fragments.
+- [ ] Diagrams are Mermaid, not ASCII or attached images.
+- [ ] No chart/image version table in stack READMEs.
+- [ ] Every component path, substitution name, and dependency rationale verified against the actual manifests (audit pass before commit).
 - [ ] Links to Blueprint schema/facets point at windsorcli.dev `/docs/blueprints/...`, not duplicate prose.
 - [ ] No slug or path that implies generic blueprint authoring—that belongs on the website repo.
 

--- a/.claude/skills/docs-author/SKILL.md
+++ b/.claude/skills/docs-author/SKILL.md
@@ -41,47 +41,24 @@ Exact glob roots are finalized with the website `docs:vendor` script; treat the 
 
 ## Terraform reference
 
-- Generate from modules in this repo with `task docs` (terraform-docs injected between `<!-- BEGIN_TF_DOCS -->` / `<!-- END_TF_DOCS -->` markers in each module's `README.md`). Commit the regenerated `terraform/<module-path>/README.md` (`cluster/talos`, `gitops/flux`, etc.). The site ingest pipeline mirrors these into `docs/reference/terraform/<module-path>/` per the path mapping above; contributors don't write into `docs/reference/` directly.
+- Generate from modules in this repo (e.g. `terraform-docs` or project script); commit or CI output under `docs/reference/terraform/<module-path>/` mirroring repo paths consumers use in `blueprint.yaml` (`cluster/talos`, `gitops/flux`, etc.).
 - Inputs, outputs, and gotchas belong here; high-level “what is Terraform in Windsor” stays on the site under `/docs/components/terraform`.
 
-## Kustomize stack reference (per top-level stack)
+## Kustomize stack operator guide (per top-level stack)
 
-For each significant stack under `kustomize/` (e.g. dns, pki, gateway), maintain **one** README at `kustomize/<stack>/README.md`, normalized by the website ingest into `docs/reference/blueprints/core/kustomize/<stack>.md`.
+Author under `kustomize/<stack>/README.md` (nested stacks supported). After edits, run **`task docs:reference:kustomize`** or `node scripts/sync-kustomize-reference.mjs` to refresh **`docs/reference/kustomize/**`** (generated; do not hand-edit—change README and re-sync).
 
-**Audience: both blueprint designers and operators.** Designers compose `blueprint.yaml` and need to know which components to wire for which environment. Operators run the stack and need to know what's inside it and how it fails. The format below serves both — recipes and components tables for designers, operations and security for operators.
+Use this section order where applicable:
 
-### Section order
+1. **Purpose** — what this subtree owns.
+2. **Dependencies** — other stacks, CRDs, cloud prereqs.
+3. **Blueprint wiring** — minimal `blueprint.yaml` fragment (`source` pointing at this blueprint, `path`, `components`).
+4. **Substitutions / vars** — table: name, default, required, effect.
+5. **Components** — Kustomize `components/` and when to enable each.
+6. **Operations** — upgrade, rollback, common failures, observability.
+7. **Security** — RBAC, secrets, network policy when relevant.
 
-1. **Frontmatter and purpose** — `title` and `description` in frontmatter; one or two sentences below the H1 stating what the stack owns.
-2. **Flow** — Mermaid diagram (` ```mermaid `) showing how the stack's pieces interact. Subgraph the namespaces; show external dependencies (cloud APIs, other stacks) as separate nodes. Mermaid renders natively on GitHub and on the docs site (which uses GFM); ASCII art is too cramped once a stack has more than two flows.
-3. **Recipes** — three to five canonical configurations with copy-pasteable `kustomize:` fragments (e.g. local single-node, AWS production, addon enabled). Each recipe is the **materialized union** of components when multiple facets layer onto the same kustomize entry, not just one facet's contribution. The merge is additive in Windsor — design for that.
-4. **Substitutions** — table with columns `Name`, `Required when`, `Effect and constraints`. Include real constraints (zone ID format, IP-pool membership, SAN coverage), not just "string". Don't add a "Required: yes" column when every row says yes — fold the gating condition into "Required when".
-5. **Components** — exhaustive lookup table, one row per Kustomize component directory. Columns: `Component`, `Enable when`, `Effect`. Group by operator if the stack has more than one (e.g. `coredns/` and `external-dns/`). This is reference material, not first-read material; designers use it to find what `coredns/cilium` actually does.
-6. **Dependencies** — table with `Stack` and `Reason`. Be specific about *why* — "needed for CRDs", "needed for the cluster issuer that signs etcd certs". A weak rationale ("for security") usually means the real reason wasn't traced.
-7. **Operations** — stack-specific failure modes only. Skip generic Flux/Renovate behaviour (`HelmRelease retries 3×`, `Renovate opens PRs`) — that lives at the repo level. Lead with the symptom, then the cause, then the fix. Include a metrics/observability note if the stack exposes Prometheus endpoints.
-8. **Security** — namespace PSA levels, certificate issuance and trust paths, IAM/identity per provider, scope of any cluster-wide policies. Not a checklist of best practices; specific facts about *this* stack.
-9. **See also** — canonical facets (link to `contexts/_template/facets/*.yaml` files that wire the stack), related stacks under `kustomize/`, and the Blueprint schema page on windsorcli.dev.
-
-### What NOT to include
-
-- **Chart and image versions.** Pinned in `helm-release.yaml` with renovate markers; that's the source of truth. Mirroring versions in the README means Renovate PRs silently drift the docs.
-- **Generic operations boilerplate.** "Flux retries failed reconciles", "DependencyNotReady means a dependency isn't ready" — applies to every stack, doesn't belong in any single one.
-- **Diagrams as PNG/SVG attachments.** Use Mermaid. The site renders it; binary attachments are fragile through ingest.
-- **Derived facet config as the primary description.** Don't gate components or describe conditions in terms of `gateway_effective.driver`, `telemetry_effective.metrics_enabled`, `talos_common.storage_driver`, `lb_effective.*`, `cni_effective.*`, or any other `*_effective` / `*_common` value. Those are facet-author concerns. Use the user-facing schema field instead — e.g. `gateway.driver`, `telemetry.metrics.enabled`, `cluster.storage.driver`, `network.loadbalancer_driver`. If the derivation logic matters (e.g. docker-desktop overrides), mention it in a brief footnote that points to the facet, not as the primary table entry.
-
-### Authoring workflow
-
-1. Read the canonical facet(s) under `contexts/_template/facets/*.yaml` that wire the stack — they encode dependsOn, conditional component selection, and substitutions. The stack README mirrors that information in human-readable form.
-2. Walk the component tree to confirm directories exist and read the patches to confirm what each component actually does.
-3. Read the helm-release files for namespace, dependsOn at the HelmRelease level, and any inline values that affect described behavior.
-4. Write the README in the section order above.
-5. **Audit before publishing.** Verify every claim against code: each component path exists, each substitution name appears as `${...}` somewhere, each dependency rationale matches the actual reason (a "for X" claim where X isn't in the manifest is a hallucination). Use file:line citations in commit messages or PR descriptions when the claim isn't immediately obvious from the file. Spawning an Explore subagent to audit the README against the code is a reliable way to catch drift; the cost is one extra round-trip and it routinely finds two to four real issues per first draft.
-
-### VS Code preview caveat
-
-VS Code's built-in Markdown preview does not render Mermaid by default. Install `bierner.markdown-mermaid` for local preview. GitHub renders it natively, and the docs site (GFM) renders it via the standard GitHub renderer.
-
-Align structure with existing kustomize conventions: see `.claude/skills/kustomize-author/SKILL.md`. Terraform module docs should align with `.claude/skills/terraform-style/SKILL.md` where applicable. Worked examples: [kustomize/dns/README.md](../../../kustomize/dns/README.md), [kustomize/pki/README.md](../../../kustomize/pki/README.md).
+Align structure with existing kustomize conventions: see `.claude/skills/kustomize-author/SKILL.md`. Terraform module docs should align with `.claude/skills/terraform-style/SKILL.md` where applicable.
 
 ## Compatibility
 
@@ -89,15 +66,13 @@ Align structure with existing kustomize conventions: see `.claude/skills/kustomi
 
 ## PR checklist
 
-- [ ] Module or stack behavior that affects operators reflected in `docs/reference/` or stack README.
+- [ ] Module or stack behavior that affects operators reflected in `docs/reference/` or stack README; run `task docs:reference:kustomize` when `kustomize/**/README.md` changed.
 - [ ] Generated Terraform docs refreshed if inputs/outputs changed.
-- [ ] Stack README sections in the prescribed order; recipes show materialized component unions, not single-facet fragments.
-- [ ] Diagrams are Mermaid, not ASCII or attached images.
-- [ ] No chart/image version table in stack READMEs.
-- [ ] Every component path, substitution name, and dependency rationale verified against the actual manifests (audit pass before commit).
 - [ ] Links to Blueprint schema/facets point at windsorcli.dev `/docs/blueprints/...`, not duplicate prose.
 - [ ] No slug or path that implies generic blueprint authoring—that belongs on the website repo.
 
 ## Internal architecture note
 
 [windsorcli.github.io `docs/plan.md` on GitHub](https://github.com/windsorcli/windsorcli.github.io/blob/main/docs/plan.md) — maintainer planning only; not published on windsorcli.dev.
+
+Preview in the website repo from local checkouts: `npm run docs:vendor:local` then `npm run dev` (see website `README.md`; expects `../cli` and `../core` by default).

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,6 +103,40 @@ jobs:
             exit 1
           fi
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # Every kustomize add-on directory must ship a README.md (the source of
+      # truth for the per-add-on reference page).
+      - name: Validate kustomize add-on READMEs
+        run: |
+          missing=0
+          for d in kustomize/*/; do
+            if [ ! -f "$d/README.md" ]; then
+              echo "::error::$d missing README.md"
+              missing=1
+            fi
+          done
+          [ "$missing" -eq 0 ]
+
+      # Regenerate docs/reference/kustomize/ from kustomize/<add-on>/README.md
+      # and fail if the tree drifts.
+      - name: Validate kustomize reference docs
+        run: |
+          task docs:reference:kustomize
+          if ! git diff --quiet docs/reference/kustomize/ || \
+             [ -n "$(git status --porcelain docs/reference/kustomize/)" ]; then
+            echo "::error::docs/reference/kustomize/ is out of sync with kustomize/<add-on>/README.md"
+            echo ""
+            echo "Changed/untracked files:"
+            git status --short docs/reference/kustomize/
+            echo ""
+            echo "Run 'task docs:reference:kustomize' locally and commit the changes."
+            exit 1
+          fi
+
       - name: Checkov GitHub Action
         uses: bridgecrewio/checkov-action@68260132005eaae0e6f84c7a73cc3b1532f678bf # v12.3058.0
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,7 @@ contexts/**/.gcp/
 .cursor/
 .vscode/*.local.*
 
-# Local notes / scratch docs (kept out of source control)
-docs/
+# Local notes / scratch under docs/ (published reference: docs/reference/ is tracked)
+docs/*
+!docs/reference/
+!docs/reference/**

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -87,9 +87,14 @@ tasks:
     cmds:
       - cmd: |
           find terraform -type d -exec test -e '{}/main.tf' -a -e '{}/variables.tf' \; -print | while read -r dir; do
-            if [[ "$dir" == *"/modules/"* ]]; then
-              continue
-            fi
-            echo "Generating docs for $dir"
-            docker run --rm -v "$(pwd):/src" -w "/src/$dir" quay.io/terraform-docs/terraform-docs:0.20.0 markdown table --output-file README.md --output-mode inject .
+          if [[ "$dir" == *"/modules/"* ]]; then
+            continue
+          fi
+          echo "Generating docs for $dir"
+          docker run --rm -v "$(pwd):/src" -w "/src/$dir" quay.io/terraform-docs/terraform-docs:0.20.0 markdown table --output-file README.md --output-mode inject .
           done
+
+  docs:reference:kustomize:
+    desc: Sync kustomize stack READMEs into docs/reference/kustomize (for windsorcli.github.io ingest)
+    cmds:
+      - node scripts/sync-kustomize-reference.mjs

--- a/docs/reference/kustomize/cni.md
+++ b/docs/reference/kustomize/cni.md
@@ -1,0 +1,201 @@
+---
+title: CNI add-on
+description: Cilium as the cluster CNI, bootstrapped via Terraform and adopted by Flux.
+---
+
+# CNI
+
+Cilium is the only CNI driver this blueprint installs. The HelmRelease CR
+lives in `system-cni`; the actual Cilium workloads (DaemonSet, Operator,
+Hubble) deploy into `kube-system` per upstream convention. Other CNIs
+(flannel on docker-desktop, AKS's managed CNI) bypass this add-on entirely
+when `cluster.cni.driver` is not `cilium`.
+
+The defining shape of this add-on is the **bootstrap-then-adopt** pattern.
+Cilium has a chicken-and-egg problem: Flux needs pod networking to
+reconcile, but Flux is normally what installs the CNI. Resolution:
+Terraform installs Cilium first via the Talos API, then Flux adopts the
+running HelmRelease so day-2 changes flow through GitOps.
+
+## Flow
+
+```mermaid
+flowchart LR
+    tf[Terraform<br/>terraform/cni/cilium]
+    flux[Flux helm-controller]
+
+    subgraph systemcni[system-cni]
+        helmrel[HelmRelease cilium]
+    end
+
+    subgraph kubesystem[kube-system _release target_]
+        agent[cilium-agent<br/>DaemonSet]
+        operator[cilium-operator]
+    end
+
+    tf -->|bootstrap via Talos API| helmrel
+    flux -->|adopts and reconciles| helmrel
+    helmrel --> agent
+    helmrel --> operator
+
+    agent -.cilium/gateway.- gw[Gateway API controller]
+    agent -.cilium/l2.- l2[L2 announcer + IPPool]
+    agent -.cilium/hubble.- hubble[Hubble Relay + UI]
+```
+
+The Terraform module sets `privileged: false` and `cgroup_auto_mount:
+false` (Talos forbids privileged pods and mounts cgroups at init);
+`cilium/talos` re-applies the same settings via Helm values so the
+Flux-adopted release does not flap the deployment between reconciles.
+
+## Recipes
+
+This add-on has a single Kustomization (`cni`) with two `when:` variants —
+`talos_enabled` and `eks_enabled`. Each emits a different component set.
+
+The recipes below show the materialized form assuming `policies.enabled:
+true` and `telemetry.metrics.enabled: true` (the platform-base defaults).
+If either is disabled, the corresponding `dependsOn` entry drops and the
+related conditional component (`cilium/prometheus`) is omitted.
+
+### Talos (default `windsor up`)
+
+```yaml
+- name: cni
+  path: cni
+  dependsOn: [policy-resources, telemetry-base]
+  components:
+    - cilium
+    - cilium/talos
+    - cilium/prometheus
+    - cilium/hubble
+    - cilium/l2
+  substitutions:
+    k8s_service_host: 10.5.0.10
+    loadbalancer_start_ip: 10.5.1.10
+    loadbalancer_end_ip: 10.5.1.30
+    cluster_name: local
+    operator_replicas: "2"
+  timeout: 15m
+```
+
+### Talos with Cilium as the gateway driver
+
+Adds the `cilium/gateway` component, which enables Cilium's built-in
+Gateway API controller and ships a Kyverno ClusterPolicy that races-fixes
+LBIPAM IP sharing on Cilium-managed Gateway services.
+
+```yaml
+- name: cni
+  path: cni
+  dependsOn: [policy-resources, telemetry-base, gateway-base]
+  components:
+    - cilium
+    - cilium/talos
+    - cilium/gateway
+    - cilium/prometheus
+    - cilium/hubble
+    - cilium/l2
+  substitutions:
+    k8s_service_host: 10.5.0.10
+    loadbalancer_start_ip: 10.5.1.10
+    loadbalancer_end_ip: 10.5.1.30
+    cluster_name: local
+    operator_replicas: "2"
+```
+
+The `gateway-base` entry in `dependsOn` is contributed by `option-gateway`
+(not `option-cni`): option-gateway patches the `cni` Kustomization to wait
+for `gateway-base` so the Gateway API CRDs are present before
+cilium-operator starts. Without that ordering, cilium-operator initializes
+without the Gateway controller and never reconciles HTTPRoutes.
+
+### EKS
+
+EKS clusters use the AWS-managed control plane; no Talos-specific patches
+and no L2 announcer (EKS provides its own LB via the AWS LB Controller in
+the `lb` add-on). `k8s_service_host` is parsed from the cluster Terraform
+output.
+
+```yaml
+- name: cni
+  path: cni
+  dependsOn: [policy-resources, telemetry-base]
+  components:
+    - cilium
+    - cilium/prometheus
+    - cilium/hubble
+  substitutions:
+    k8s_service_host: <parsed from terraform_output('cluster', 'cluster_endpoint')>
+    cluster_name: prod
+    operator_replicas: "2"
+```
+
+## Substitutions
+
+| Name | Required when | Effect |
+|---|---|---|
+| `k8s_service_host` | always | API server hostname Cilium reaches before its eBPF service rules are active. On Talos resolves to a fixed offset from the cluster CIDR; on EKS parsed from the cluster Terraform output. The user-facing knob is `cluster.endpoint` (or its terraform-derived equivalent on cloud platforms). |
+| `cluster_name` | always | Cilium cluster identity stamped onto Hubble flows, metrics, and (if enabled) ClusterMesh routing. Sourced from the Windsor context name (the top-level `id` field in `values.yaml`). |
+| `operator_replicas` | always | 1 on single-node clusters (avoids pending pods + Lease churn), 2 on HA. Set from `topology` (single-node → 1, otherwise → 2). Defaults to 1 via the kustomize fallback `${operator_replicas:=1}`. |
+| `loadbalancer_start_ip` | `cilium/l2` is enabled (Talos) | Start of the LBIPAM IP pool. Stamped onto `CiliumLoadBalancerIPPool/default`. |
+| `loadbalancer_end_ip` | `cilium/l2` is enabled (Talos) | End of the LBIPAM IP pool. |
+
+## Components
+
+| Component | Enable when | Effect |
+|---|---|---|
+| `cilium` | always | Helm release of Cilium v1.19.3 in `system-cni`, targeting `kube-system`. `kubeProxyReplacement: true`, `ipam.mode: kubernetes`, image pinning, base values. |
+| `cilium/talos` | platform is Talos | Replaces full privileged mode with explicit Linux capabilities (CHOWN, NET_ADMIN, etc.) and disables cgroup auto-mount (Talos already mounted cgroups at boot). |
+| `cilium/gateway` | `gateway.driver: cilium` | Sets `gatewayAPI.enabled: true` (also `enableAlpn`, `enableAppProtocol`) and ships a Kyverno ClusterPolicy that injects LBIPAM sharing annotations onto Cilium-owned Gateway services at admission time. The policy fixes a create-then-patch race in cilium-operator that would otherwise prevent IP sharing on first reconcile. |
+| `cilium/prometheus` | `telemetry.metrics.enabled: true` | Enables Prometheus on the operator and agent and creates a ServiceMonitor for each. |
+| `cilium/hubble` | always | Enables Hubble metrics (dns, drop, port-distribution, tcp, flow, icmp, http), Hubble Relay, Hubble UI, and the cronJob-based TLS rotation method. The Helm `auto.method: cronJob` choice avoids a known bug where `helm` mode re-renders server-secret on every upgrade and trips on newly-enabled Hubble components. |
+| `cilium/l2` | platform is Talos (or any cluster needing in-cluster LB) | Enables `l2announcements` and `externalIPs` on Cilium, then creates `CiliumLoadBalancerIPPool/default` with the configured IP range and `CiliumL2AnnouncementPolicy/default` matching `^eth[0-9]+` and `^ens[0-9]+` interfaces. Replaces kube-vip and MetalLB on Talos clusters. |
+
+## Dependencies
+
+| Add-on | Reason |
+|---|---|
+| `policy-resources` *(when `policies.enabled: true` or `gateway.driver: cilium`)* | Re-rolls Cilium pods after Kyverno's mutation policies are live. When `cilium/gateway` is active, `policy-resources` also provides the Kyverno CRDs the LBIPAM sharing ClusterPolicy depends on — without it the apply would fail on `no matches for kind ClusterPolicy`. |
+| `telemetry-base` *(when `telemetry.metrics.enabled: true` or `telemetry.logs.enabled: true`)* | The `cilium/prometheus` ServiceMonitor and the Hubble ServiceMonitor target Prometheus from the telemetry add-on; without it they have no scrape target. |
+
+The Terraform `cni` module bootstraps Cilium directly via the Talos API
+before Flux exists. Terraform `cni` `dependsOn: cluster` (the cluster must
+be provisioned), and Terraform `gitops` `dependsOn: cni` (Flux must wait
+for pod networking).
+
+Reverse dependencies — add-ons that depend on `cni`:
+
+- `gateway-resources` `dependsOn: cni` when Cilium is the gateway driver. Without ordering, the Kyverno LBIPAM policy may not be in place when cilium-operator creates the gateway Service, and the LB IP won't be shared.
+- `csi` `dependsOn: cni` always. CSI's node-driver-registrar can see transient loopback connectivity drops during eBPF init and crash-loop without this ordering.
+- `observability` adds the `grafana/dashboards/cilium` component when Grafana is the dashboard backend.
+
+## Operations
+
+Add-on-specific failure modes; generic Flux/Renovate behaviour is documented
+at the repo level.
+
+- **Cilium pods crash-looping on Talos with `Operation not permitted`** — the `cilium/talos` component is missing or its capabilities patch didn't apply. Confirm the helm-release values include `securityContext.capabilities.ciliumAgent`. Talos rejects full privileged mode.
+- **`cilium-operator` does not create a Gateway controller on Cilium clusters** — the Gateway API CRDs were not present when the operator started. The reverse dep `cni dependsOn gateway-base` (added by `option-gateway`) prevents this in fresh installs; if it fires post-install, restart `cilium-operator`.
+- **Cilium gateway Service has no LB IP** — the LBIPAM sharing annotations weren't injected. Verify the `cilium-gateway-lbipam-sharing` ClusterPolicy is `Ready` and the `cilium-lbipam-config` ConfigMap in `system-gateway` exists. The policy reads `gatewayIp` from that ConfigMap; without it the mutation fails open.
+- **`HelmRelease/cilium` reports `no matches for kind CiliumLoadBalancerIPPool`** — `cilium/l2` is enabled but the Cilium CRDs aren't ready. The Cilium chart installs them; the bootstrap path (Terraform → Flux adoption) means the CRDs come up with the agent. If this fires, the Flux reconcile is racing the chart install — re-reconcile.
+- **Re-running `windsor up` flaps Cilium between two replica counts** — Terraform `operator_replicas` and the Flux substitution differ. Both must derive from `topology` (single-node → 1, otherwise → 2).
+
+Cilium's metrics ServiceMonitors are scraped by the `telemetry` add-on
+(`release: kube-prometheus-stack` label set by `cilium/prometheus`). Hubble
+flows are accessible via Hubble UI; Hubble Relay exposes a gRPC endpoint
+for `hubble observe`.
+
+## Security
+
+- The `system-cni` namespace has no PSA labels in its manifest (see [namespace.yaml](namespace.yaml)). Cilium workloads live in `kube-system`; the Cilium DaemonSet uses host networking and elevated Linux capabilities (full set on non-Talos, restricted explicit set on Talos via `cilium/talos`).
+- `kubeProxyReplacement: true` means Cilium replaces kube-proxy entirely. Removing the `cni` add-on does not restore kube-proxy automatically.
+- Hubble TLS certificates rotate via an in-cluster CronJob (cert-manager is not required for Hubble).
+- The `cilium-gateway-lbipam-sharing` Kyverno ClusterPolicy mutates Services in `system-gateway` that Cilium creates. Scope is restricted by namespace and by the `io.cilium.gateway/owning-gateway: external` label selector — it does not affect Services outside `system-gateway` or non-Cilium Services.
+
+## See also
+
+- [contexts/_template/facets/option-cni.yaml](../../contexts/_template/facets/option-cni.yaml) — canonical wiring for both Talos and EKS variants, plus reverse-dep injections into `gateway-resources`, `csi`, and `observability`.
+- [terraform/cni/cilium/](../../terraform/cni/cilium/) — Terraform bootstrap module that installs Cilium pre-Flux.
+- Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
+- Related add-ons: [policy](../policy/), [telemetry](../telemetry/), [gateway](../gateway/), [csi](../csi/), [lb](../lb/).

--- a/docs/reference/kustomize/csi.md
+++ b/docs/reference/kustomize/csi.md
@@ -1,0 +1,210 @@
+---
+title: CSI add-on
+description: Persistent storage drivers and StorageClasses — AWS EBS, Azure Disk, OpenEBS host-path, Longhorn distributed.
+---
+
+# CSI
+
+The cluster's persistent-volume layer. Four drivers ship in this add-on, one
+selected per platform:
+
+- **AWS EBS** — uses the EBS CSI driver preinstalled on EKS. This add-on only adds the StorageClass.
+- **Azure Disk** — uses the Azure Disk CSI driver preinstalled on AKS. Same shape: StorageClass only.
+- **OpenEBS host-path** — installs the OpenEBS chart and a `local` StorageClass that allocates from a host directory. Default for local single-node clusters.
+- **Longhorn** — installs the Longhorn chart, a distributed replicated block-storage system. Default for HA clusters on incus / metal.
+
+Single Kustomization (`csi`) — no `base`/`resources` split. Each driver is a
+component group; platform / option facets pick exactly one.
+
+## Flow
+
+```mermaid
+flowchart LR
+    pvc[PersistentVolumeClaim]
+
+    subgraph systemcsi[system-csi]
+        sc[StorageClass<br/>'single' / 'replicated' / 'local']
+        driver{CSI driver}
+    end
+
+    pvc --> sc --> driver
+    driver -->|aws-ebs| ebs[(EBS volume)]
+    driver -->|azure-disk| azdisk[(Azure managed disk)]
+    driver -->|openebs hostpath| hostpath[(Host directory<br/>cluster.storage.local_base_path)]
+    driver -->|longhorn| longhorndist[(Longhorn replicated<br/>block storage)]
+```
+
+The default StorageClass is named `single` regardless of driver — workloads
+that ask for the cluster's default disk get a per-cluster-appropriate
+provisioner without knowing which one is wired. Longhorn HA clusters also
+get a `replicated` StorageClass for explicit multi-replica volumes.
+
+## Recipes
+
+The recipes below show the materialized kustomize entry for typical
+scenarios. Each heading lists the `values.yaml` fields that select this
+shape; the YAML is what the facets compose from those inputs. Conditional
+`dependsOn` entries (e.g. `policy-resources` is gated on `policies.enabled:
+true`) are shown unconditionally for readability — drop them if the gate
+is false. The `cni` entry and the `openebs/single-node` component are
+contributed by sibling facets (`option-cni` and `option-single-node`).
+
+### AWS (EKS)
+
+Selected by `platform: aws`. Uses the EBS CSI driver preinstalled on EKS.
+
+```yaml
+- name: csi
+  path: csi
+  dependsOn: [policy-resources]
+  components:
+    - aws-ebs
+  timeout: 5m
+  substitutions:
+    single_storage_type: gp3
+```
+
+### Azure (AKS)
+
+Selected by `platform: azure`. Uses the Azure Disk CSI driver preinstalled
+on AKS.
+
+```yaml
+- name: csi
+  path: csi
+  dependsOn: [policy-resources]
+  components:
+    - azure-disk
+  timeout: 5m
+  substitutions:
+    single_storage_type: StandardSSD_LRS
+```
+
+### Local single-node with OpenEBS host-path
+
+Selected by `cluster.storage.driver: openebs` (the default on local
+single-node clusters). `cluster.storage.local_base_path` controls the host
+directory (default `/var/mnt/local`).
+
+```yaml
+- name: csi
+  path: csi
+  dependsOn: [policy-resources, cni]
+  components:
+    - openebs
+    - openebs/single-node
+    - openebs/dynamic-localpv
+  timeout: 20m
+  substitutions:
+    local_volume_path: /var/mnt/local
+```
+
+### HA cluster with Longhorn
+
+Selected by `cluster.storage.driver: longhorn` AND `topology: ha`.
+The `longhorn/prometheus` component is added when
+`addons.observability.enabled: true`.
+
+```yaml
+- name: csi
+  path: csi
+  dependsOn: [policy-resources, telemetry-base, cni]
+  components:
+    - longhorn
+    - longhorn/ha
+    - longhorn/prometheus
+  timeout: 20m
+```
+
+### Local Longhorn
+
+Selected by `cluster.storage.driver: longhorn` plus
+`topology: single-node` OR `cluster.controlplanes.schedulable: true`.
+
+```yaml
+- name: csi
+  path: csi
+  dependsOn: [policy-resources, telemetry-base, cni]
+  components:
+    - longhorn
+    - longhorn/single-node
+  timeout: 20m
+```
+
+## Substitutions
+
+| Name | Required when | Effect |
+|---|---|---|
+| `single_storage_type` | `aws-ebs` or `azure-disk` is enabled | Disk type for the cloud StorageClass. Sourced from `cluster.storage.single_storage_type`. AWS values: `gp3` (default), `gp2`, `io1`, etc. Azure values: `StandardSSD_LRS` (default), `Premium_LRS`, etc. |
+| `local_volume_path` | `openebs/dynamic-localpv` is enabled | Host directory the OpenEBS hostpath provisioner allocates from. Sourced from `cluster.storage.local_base_path` (schema default `/var/mnt/local`). The directory must exist on every node before any PVC is created. |
+
+## Components
+
+The base kustomization is empty (`resources: []` after the namespace).
+Drivers are mutually exclusive — pick one per cluster.
+
+### Cloud drivers (StorageClass-only; CSI driver is preinstalled by the cloud)
+
+| Component | Effect |
+|---|---|
+| `aws-ebs` | StorageClass `single` (default class) using `ebs.csi.aws.com`, `WaitForFirstConsumer`, `allowVolumeExpansion: true`, `encrypted: true`, `fsType: ext4`, type from `${single_storage_type}`. |
+| `azure-disk` | StorageClass `single` (default class) using `disk.csi.azure.com`, `WaitForFirstConsumer`, `allowVolumeExpansion: true`, `cachingMode: ReadWrite`, `fsType: ext4`, skuName from `${single_storage_type}`. |
+
+### OpenEBS host-path
+
+| Component | Effect |
+|---|---|
+| `openebs` | Helm release of OpenEBS v4.4.0 in `system-csi`. The chart's `localpv-provisioner.enabled: false` here — it's enabled by the variant components below so single-node clusters can disable leader election. |
+| `openebs/single-node` | Patches the helm release to set `localpv-provisioner.localpv.enableLeaderElection: false`. Used on single-node clusters. |
+| `openebs/dynamic-localpv` | Patches the helm release (presumably to enable the localpv-provisioner) and creates two StorageClasses: `local` and `single` (default), both `openebs.io/local` hostpath, `BasePath: ${local_volume_path}`, `WaitForFirstConsumer`. |
+
+### Longhorn
+
+| Component | Effect |
+|---|---|
+| `longhorn` | Helm release of Longhorn v1.11.1 in `system-csi`, plus a StorageClass `single` (default class) using `driver.longhorn.io` with `numberOfReplicas: "1"`, `volumeBindingMode: Immediate`, `allowVolumeExpansion: true`. |
+| `longhorn/single-node` | Patches the helm release to set `defaultSettings.taintToleration: "node-role.kubernetes.io/control-plane:NoSchedule"` so Longhorn pods can schedule on tainted control planes. Used when `cluster.controlplanes.schedulable: true` OR `topology: single-node`. |
+| `longhorn/ha` | Patches the helm release for HA: `defaultReplicaCount: 3`, `replicaSoftAntiAffinity: false`, `allowVolumeCreationWithDegradedAvailability: false`, `longhornUI.replicas: 2`, CSI sidecar replicas at 3. Adds a second StorageClass `replicated` with `numberOfReplicas: "3"` for explicit multi-replica volumes. Used when `topology: ha`. |
+| `longhorn/prometheus` | ServiceMonitor for `longhorn-manager` metrics on the `manager` port. Used when `addons.observability.enabled: true`. |
+
+## Dependencies
+
+| Add-on | Reason |
+|---|---|
+| `policy-resources` *(when `policies.enabled: true`)* | The `system-csi` namespace runs at PSA `privileged` (storage drivers need host privileges); Kyverno's image-digest policy must be in place before the CSI driver pods are admitted. |
+| `cni` | Added by `option-cni` as a reverse dep. CSI's `node-driver-registrar` sees transient loopback connectivity drops during eBPF init and crash-loops without this ordering. |
+| `telemetry-base` *(longhorn + `telemetry.metrics.enabled` or `telemetry.logs.enabled`)* | The `longhorn/prometheus` ServiceMonitor needs Prometheus to be live. |
+
+## Operations
+
+Add-on-specific failure modes; generic Flux/Renovate behaviour is documented
+at the repo level.
+
+- **PVC stuck `Pending` with `no persistent volumes available`** — the StorageClass's `volumeBindingMode: WaitForFirstConsumer` means the volume is only provisioned when a Pod actually schedules. If the Pod is also `Pending`, no volume gets created. Check the Pod's events first.
+- **OpenEBS PVCs fail with `directory not found`** — the path set by `cluster.storage.local_base_path` doesn't exist on the node that scheduled the Pod. Talos clusters provision the default `/var/mnt/local` via machine config; if you override the path, every node needs the matching directory pre-created.
+- **Longhorn pods crash on Talos with `mount propagation errors`** — Longhorn requires `iscsiadm` and bidirectional mount propagation. Talos clusters need an iSCSI system extension installed in the Talos image config (not in this add-on). Check the cluster's Talos machine config if engine pods fail to start.
+- **Longhorn HA degraded after a node reboot** — `replicaSoftAntiAffinity: false` enforces hard anti-affinity. After a reboot, replicas may need to be manually rebuilt; check `kubectl get volumes.longhorn.io -A`.
+- **Longhorn `single-node` patch absent on a controlplane-only cluster** — without the toleration, longhorn pods don't schedule on tainted control planes and no storage is available. Set `cluster.controlplanes.schedulable: true` (or `topology: single-node`) so the patch is applied.
+- **`HelmRelease/csi` reports `no matches for kind StorageClass`** — usually a race; the StorageClass CRD is built into Kubernetes so this only happens during early bootstrap. Re-reconcile.
+
+Longhorn exposes a UI through the `longhorn-frontend` Service (chart default).
+This add-on does not ship an HTTPRoute for it — add one manually if external
+access is needed.
+
+## Security
+
+- The `system-csi` namespace runs at PSA `privileged`. CSI drivers need access to host devices, mount namespaces, and (for Longhorn) iSCSI tooling.
+- AWS EBS volumes are `encrypted: true` by default — uses the AWS account default KMS key unless overridden.
+- Azure Disk uses `StandardSSD_LRS` (Standard SSD with locally redundant storage) by default. For Premium / zone-redundant variants, override `single_storage_type`.
+- OpenEBS hostpath stores data under the path set by `cluster.storage.local_base_path` on each node. There is no encryption at rest; rely on disk-level encryption from the underlying OS or platform.
+- Longhorn replicas are stored on each node's local disk under `/var/lib/longhorn`. Encryption at rest is not enabled by default; the `defaultSettings.encryption*` fields can be set in a custom patch.
+
+## See also
+
+- [contexts/_template/facets/platform-aws.yaml](../../contexts/_template/facets/platform-aws.yaml) — AWS EBS StorageClass wiring.
+- [contexts/_template/facets/platform-azure.yaml](../../contexts/_template/facets/platform-azure.yaml) — Azure Disk StorageClass wiring.
+- [contexts/_template/facets/option-storage.yaml](../../contexts/_template/facets/option-storage.yaml) — OpenEBS and Longhorn driver selection (resolves `cluster.storage.driver`).
+- [contexts/_template/facets/option-single-node.yaml](../../contexts/_template/facets/option-single-node.yaml) — single-node OpenEBS overlay.
+- [contexts/_template/facets/option-cni.yaml](../../contexts/_template/facets/option-cni.yaml) — adds the `cni` reverse dep.
+- Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
+- Related add-ons: [policy](../policy/), [cni](../cni/), [telemetry](../telemetry/), [observability](../observability/).

--- a/docs/reference/kustomize/database.md
+++ b/docs/reference/kustomize/database.md
@@ -1,0 +1,146 @@
+---
+title: Database add-on
+description: PostgreSQL operator (CloudNativePG) — installs the operator only; tenant Postgres clusters are created by workloads.
+---
+
+# Database
+
+Installs the CloudNativePG operator in `system-database`. The operator
+watches `Cluster` (cnpg.io/v1) resources cluster-wide; tenants create their
+own `Cluster` objects to provision Postgres instances. This add-on does NOT
+ship a tenant Postgres cluster — it only deploys the operator and (on HA
+clusters) makes the operator itself highly available.
+
+`cloudnative-pg` is currently the only supported driver
+(`addons.database.postgres.driver: cloudnativepg`). The add-on is gated on
+`addons.database.postgres.enabled: true` — disabled by default.
+
+## Flow
+
+```mermaid
+flowchart LR
+    cluster[(Cluster cnpg.io/v1<br/>tenant-defined)]
+
+    subgraph systemdatabase[system-database]
+        operator[cloudnative-pg<br/>operator]
+    end
+
+    subgraph tenantns[tenant namespaces]
+        instance[Postgres pods<br/>+ PVCs]
+    end
+
+    cluster -.watched by.-> operator
+    operator -->|reconciles| instance
+    instance -.PVCs.-> csi[(CSI StorageClass)]
+```
+
+The operator runs `clusterWide: true` so a single deployment watches
+`Cluster` resources in every namespace. Tenants do not need to install
+their own operator copies.
+
+## Recipes
+
+### Default (HA topology)
+
+Both `addons.database.postgres.enabled: true` and `topology: ha`.
+The `cloudnativepg/ha` component layers anti-affinity and a
+PodDisruptionBudget onto the operator deployment.
+
+```yaml
+- name: database
+  path: database
+  dependsOn: [csi]
+  components:
+    - cloudnativepg
+    - cloudnativepg/prometheus
+    - cloudnativepg/ha
+  timeout: 15m
+  interval: 10m
+```
+
+### Single-node
+
+`addons.database.postgres.enabled: true` and `topology: single-node`.
+`option-single-node` adds the `cloudnativepg/single-node` component which
+disables the operator's leader election.
+
+```yaml
+- name: database
+  path: database
+  dependsOn: [csi]
+  components:
+    - cloudnativepg
+    - cloudnativepg/single-node
+    - cloudnativepg/prometheus
+  timeout: 15m
+```
+
+### With Grafana dashboard
+
+When `addons.observability.enabled: true` is also on, `addon-database`
+patches the observability add-on to add the CloudNativePG dashboard. Wired
+separately from the database add-on itself:
+
+```yaml
+- name: observability
+  path: observability
+  dependsOn: [telemetry-base]
+  components:
+    - grafana/dashboards/cloudnativepg
+```
+
+## Substitutions
+
+This add-on does not consume any blueprint substitutions. Behavior is
+fully driven by component selection.
+
+## Components
+
+| Component | Enable when | Effect |
+|---|---|---|
+| `cloudnativepg` | `addons.database.postgres.driver: cloudnativepg` | Helm release of `cloudnative-pg` v0.28.0 in `system-database`. Operator image v1.29.0. `clusterWide: true` so the operator watches `Cluster` resources in every namespace. Webhook `failurePolicy: Fail` (admission rejects requests if the webhook is down). Resource requests 250m/256Mi, memory limit 256Mi. |
+| `cloudnativepg/single-node` | `topology: single-node` | Appends `--leader-elect=false` to the operator's `additionalArgs`. The chart unconditionally passes `--leader-elect`; Go's flag parser applies last-wins so the override sticks. |
+| `cloudnativepg/ha` | `topology: ha` | `operator.replicaCount: 2`, hard pod anti-affinity (hostname topology key), PodDisruptionBudget with `minAvailable: 1`, `rollingUpdate.maxUnavailable: 1`. |
+| `cloudnativepg/prometheus` | always (per addon-database) | Adds `monitoring.podMonitorEnabled: true` and labels the PodMonitor with `release: kube-prometheus-stack` so the telemetry add-on's Prometheus picks it up. Adds a Flux `dependsOn` so the operator waits for `kube-prometheus-stack` to be ready. |
+
+## Dependencies
+
+| Add-on | Reason |
+|---|---|
+| `csi` | Tenant `Cluster` resources allocate PVCs for WAL archives and data volumes as soon as the first one is applied. The operator itself doesn't create PVCs, but reconciliation fails immediately if no StorageClass is available. |
+
+The `cloudnativepg/prometheus` component adds an implicit dependency on
+`kube-prometheus-stack` (in the `telemetry` add-on) via Flux's HelmRelease
+`dependsOn`. The `addon-database` facet also patches the observability
+add-on to add the Grafana dashboard, but that's a separate Kustomization
+entry rather than a hard dependency of `database`.
+
+## Operations
+
+Add-on-specific failure modes; generic Flux/Renovate behaviour is documented
+at the repo level.
+
+- **Tenant `Cluster` stuck creating** — usually a CSI / StorageClass issue. Check the tenant's `Cluster` events and confirm a default StorageClass exists. The operator does not create PVCs eagerly; PVCs come up as the operator reconciles tenant Clusters.
+- **Operator pods crashlooping with `failed to acquire lease`** — leader election is on but multiple replicas can't agree on a leader. On single-node clusters confirm `cloudnativepg/single-node` is enabled (it disables election). On HA clusters the lease conflict is usually a CoreDNS / API issue, not a database issue.
+- **Webhook `failurePolicy: Fail` blocks `Cluster` creation when the operator is down** — by design. If you must apply tenant Clusters during an operator outage, temporarily patch the ValidatingWebhookConfiguration to `failurePolicy: Ignore` (and revert when the operator is healthy).
+- **`HelmRelease/cloudnativepg` reports `no matches for kind PodMonitor`** — `cloudnativepg/prometheus` is enabled but the kube-prometheus-stack CRDs aren't ready yet. The Flux `dependsOn` on `kube-prometheus-stack` should prevent this; if it fires, reconcile in the right order.
+
+The operator exposes Prometheus metrics on each pod via the PodMonitor
+created by `cloudnativepg/prometheus`. Tenant `Cluster` resources also
+emit metrics; they're scraped by the same Prometheus when the
+`Cluster.spec.monitoring.enablePodMonitor` field is set.
+
+## Security
+
+- The `system-database` namespace runs at PSA `baseline`. The operator pod uses a restricted security context: `runAsNonRoot: true`, `allowPrivilegeEscalation: false`, all capabilities dropped, `seccompProfile: RuntimeDefault`.
+- Tenant Postgres pods inherit security context from the operator's defaults. Operators creating `Cluster` resources should set explicit `imagePullSecrets`, `serviceAccount`, and resource limits.
+- The webhook configuration is `failurePolicy: Fail` for both mutating and validating webhooks. This is correct for the operator's role (admission must validate `Cluster` specs) but means an operator outage blocks new tenant Clusters until the webhook is back.
+- WAL and data PVCs are encrypted only if the underlying CSI driver provides encryption (AWS EBS defaults to `encrypted: true`; OpenEBS hostpath does not).
+
+## See also
+
+- [contexts/_template/facets/addon-database.yaml](../../contexts/_template/facets/addon-database.yaml) — canonical wiring (operator + dashboard).
+- [contexts/_template/facets/option-single-node.yaml](../../contexts/_template/facets/option-single-node.yaml) — adds the `cloudnativepg/single-node` patch when topology is single-node.
+- Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
+- CloudNativePG operator docs — https://cloudnative-pg.io/docs/
+- Related add-ons: [csi](../csi/), [telemetry](../telemetry/), [observability](../observability/).

--- a/docs/reference/kustomize/demo.md
+++ b/docs/reference/kustomize/demo.md
@@ -1,0 +1,165 @@
+---
+title: Demo add-on
+description: Example workloads (CNPG cluster, live-reload static site, Istio bookinfo) for trying out cluster features.
+---
+
+# Demo
+
+Example workloads — not infrastructure. Use this add-on to confirm the
+cluster's networking, storage, ingress, and database integration paths
+work end-to-end. Each subcomponent is a self-contained sample that runs in
+its own `demo-*` namespace.
+
+`option-demo` gates the whole add-on on `demo.enabled: true`. Inside, three
+independent toggles select which samples to deploy:
+
+- `demo.resources.database: true` — a CNPG `Cluster` (depends on the database add-on).
+- `demo.resources.static: true` — a live-reload Node.js website with PVC, Service, and Ingress.
+- `demo.resources.bookinfo: true` — Istio's bookinfo sample fetched directly from upstream Istio releases.
+
+## Flow
+
+```mermaid
+flowchart LR
+    operator[Operator]
+
+    subgraph demodatabase[demo-database]
+        cnpg[Cluster demo-cluster<br/>2 instances · 1Gi PVC]
+    end
+
+    subgraph demostatic[demo-static]
+        site[website Deployment<br/>+ PVC + Service + Ingress]
+    end
+
+    subgraph demobookinfo[demo-bookinfo]
+        bi[Istio bookinfo<br/>productpage / details / ratings / reviews]
+    end
+
+    operator -.toggles.-> cnpg
+    operator -.toggles.-> site
+    operator -.toggles.-> bi
+```
+
+The samples are independent — each one toggles separately. There is no
+flow between them.
+
+## Recipes
+
+### All samples on (including Ingresses)
+
+The `option-demo` facet emits only the workload components, not the
+`*/ingress` sub-components. Hand-author the recipe to include them.
+
+```yaml
+- name: demo
+  path: demo
+  dependsOn: [database]
+  components:
+    - database
+    - static
+    - static/ingress
+    - bookinfo
+    - bookinfo/ingress
+```
+
+`dependsOn: [database]` is conditional in the facet — it only fires when
+`demo.resources.database: true` is set. Without the database sample, the
+demo add-on has no required `dependsOn`.
+
+### Just the static site (with Ingress)
+
+The `option-demo` facet only emits `static`, not `static/ingress`.
+Hand-author both for the full demo. Without the ingress component, the
+`website` Service is only reachable in-cluster.
+
+```yaml
+- name: demo
+  path: demo
+  components:
+    - static
+    - static/ingress
+  substitutions:
+    REGISTRY_URL: registry.test:5000
+```
+
+### Just the CNPG demo cluster
+
+```yaml
+- name: demo
+  path: demo
+  dependsOn: [database]
+  components:
+    - database
+```
+
+## Substitutions
+
+| Name | Required when | Effect |
+|---|---|---|
+| `REGISTRY_URL` | `static` is enabled | Container registry hostname for the demo image (`${REGISTRY_URL}/demo:1.0.6`). No kustomize fallback — empty produces an invalid image reference. The `option-demo` facet does NOT emit this; operators must supply it via blueprint substitutions or accept that the static demo won't pull. |
+| `DOMAIN` | `static` or `bookinfo` is enabled | Hostname suffix for the Ingress rules (`static.${DOMAIN:-test}`, `bookinfo.${DOMAIN:-test}`). Falls back to `test` via the kustomize default. The facet does not emit this either; on local clusters the fallback is usually correct. |
+
+Both substitutions are uppercase, suggesting they were originally meant
+to come from environment-style substitution rather than the Windsor schema.
+Treat them as operator-supplied; if you need real values flowing through
+the facet, add a `substitutions:` block to your `option-demo` override.
+
+## Components
+
+The base kustomization is empty (`resources: []`). Each sample is a
+component that brings its own namespace, manifests, and any associated
+resources.
+
+### `database/`
+
+| Component | Effect |
+|---|---|
+| `database` | `Namespace/demo-database` (PSA `baseline`) plus `Cluster/demo-cluster` (cnpg.io/v1): 2 instances, 1Gi storage per replica, 100 max_connections, requests 100m/256Mi, memory limit 512Mi, `monitoring.enablePodMonitor: true` with relabelings. Requires the database add-on's CloudNativePG operator to be running first. |
+
+### `static/`
+
+| Component | Effect |
+|---|---|
+| `static` | `Namespace/demo-static` (PSA `restricted`); `Deployment/website` running `${REGISTRY_URL}/demo:1.0.6` on port 8080 with restricted security context (runAsNonRoot, runAsUser 1000, all capabilities dropped, RuntimeDefault seccomp); `Service/website` exposing port 80 → 8080; `PVC/content` requesting 100Mi RWO. **Does not include the Ingress** — that's a separate component (`static/ingress`). |
+| `static/ingress` | Separate Component creating `Ingress/static-ingress` routing `static.${DOMAIN:-test}` to the Service. **Not emitted by `option-demo`** — operators wanting the Ingress must add it to the components list manually. |
+
+### `bookinfo/`
+
+| Component | Effect |
+|---|---|
+| `bookinfo` | `Namespace/demo-bookinfo` (PSA `restricted`) plus the upstream Istio `bookinfo.yaml` (pinned to Istio 1.22.8 via the `https://raw.githubusercontent.com/istio/istio/refs/tags/1.22.8/...` URL — Renovate keeps this version updated via the comment marker). Patches every Deployment to add a restricted security context. The `kustomize` `namespace: demo-bookinfo` directive overrides the namespace of every resource in the upstream YAML. **Does not include the Ingress.** |
+| `bookinfo/ingress` | Separate Component creating `Ingress/productpage-ingress` routing `bookinfo.${DOMAIN:-test}` to the `productpage` Service on port 9080. **Not emitted by `option-demo`** — same pattern as `static/ingress`. |
+
+## Dependencies
+
+| Add-on | Reason |
+|---|---|
+| `database` *(when `demo.resources.database: true`)* | The CNPG operator (in the `database` Kustomization) must be running before the `Cluster/demo-cluster` resource is admitted. Without it, the apply fails on `no matches for kind Cluster.postgresql.cnpg.io/v1`. |
+
+The `static` and `bookinfo` samples have no hard dependencies in the
+facet; they assume:
+- A default StorageClass (for `static`'s PVC) — comes from `csi`.
+- An IngressClass-default Ingress controller — currently this would be the legacy `ingress` add-on, which is not wired by default. The samples use Kubernetes `Ingress` (not Gateway API HTTPRoute), so they do **not** integrate with the modern `gateway` add-on out of the box.
+
+## Operations
+
+Add-on-specific failure modes; generic Flux/Renovate behaviour is documented
+at the repo level.
+
+- **`demo-static` Deployment ImagePullBackoff** — `${REGISTRY_URL}` is empty or the registry is unreachable. The image reference becomes `/demo:1.0.6` if the substitution doesn't resolve. Set `REGISTRY_URL` via a substitution in your `option-demo` override.
+- **Ingress hostnames return 404** — no Ingress controller is running. The samples ship `kind: Ingress` (legacy), not `kind: HTTPRoute`. To use the gateway add-on instead, replace the Ingress objects with HTTPRoutes manually.
+- **CNPG `Cluster/demo-cluster` stuck `Pending`** — usually a StorageClass or PVC issue. The Cluster requests 1Gi per instance; check `kubectl get pvc -n demo-database` and the default StorageClass.
+- **bookinfo upstream YAML version drift** — the URL is pinned to Istio 1.22.8; Renovate updates the version via the `# renovate:` marker comment. If the URL stops resolving, Renovate has likely landed a newer version that doesn't match the comment's regex.
+
+## Security
+
+- `demo-database` runs at PSA `baseline` (CNPG needs minor flexibility for postgres processes).
+- `demo-static` and `demo-bookinfo` run at PSA `restricted`. The static demo's Deployment ships a fully-restricted security context. The bookinfo patch adds the same security context to every upstream Istio Deployment so they pass `restricted` admission.
+- Demo workloads are not gated on Kyverno policies (the `demo-*` namespaces don't have `policy.windsorcli.dev/managed: "true"` labels), so the `require-image-digest` policy doesn't apply. The demo image (`${REGISTRY_URL}/demo:1.0.6`) is not pinned by digest.
+
+## See also
+
+- [contexts/_template/facets/option-demo.yaml](../../contexts/_template/facets/option-demo.yaml) — canonical wiring with the per-sample toggles.
+- [contexts/_template/facets/addon-database.yaml](../../contexts/_template/facets/addon-database.yaml) — required when `demo.resources.database: true` (provides the CNPG operator).
+- Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
+- Related add-ons: [database](../database/), [csi](../csi/), [ingress](../ingress/), [gateway](../gateway/).

--- a/docs/reference/kustomize/dns.md
+++ b/docs/reference/kustomize/dns.md
@@ -1,0 +1,223 @@
+---
+title: DNS add-on
+description: CoreDNS for private zones and external-dns for record automation.
+---
+
+# DNS
+
+Self-hosted DNS for the cluster's private zone, with automatic record
+reconciliation against an in-cluster or cloud provider.
+
+## Flow
+
+```mermaid
+flowchart LR
+    client([Client])
+    sources[Service / Ingress / HTTPRoute]
+
+    subgraph systemdns[system-dns namespace]
+        exposure[LoadBalancer Service<br/>or Gateway TCP/UDPRoute]
+        coredns[CoreDNS]
+        etcd[(etcd)]
+        extdns[external-dns]
+    end
+
+    route53[Route 53]
+    azure[Azure DNS]
+
+    client --> exposure --> coredns
+    coredns -->|reads| etcd
+    sources -.->|watched by| extdns
+    extdns -->|writes| etcd
+    extdns -->|writes| route53
+    extdns -->|writes| azure
+```
+
+The provider that external-dns writes to is selected by the
+`external-dns/providers/*` component (one of `coredns`, `route53`, `azure`).
+
+## Recipes
+
+The shipped facet at [contexts/_template/facets/addon-private-dns.yaml](../../contexts/_template/facets/addon-private-dns.yaml)
+materializes one of the configurations below from blueprint inputs. If you are
+authoring a blueprint by hand, copy the recipe that matches your environment.
+
+### docker-desktop (local dev)
+
+Kyverno rewrites DNS targets to `127.0.0.1` so ingress hostnames resolve to
+the host loopback.
+
+```yaml
+- name: dns
+  path: dns
+  dependsOn: [pki-base, policy-resources]
+  timeout: 20m
+  interval: 5m
+  components:
+    - coredns
+    - coredns/etcd
+    - external-dns
+    - external-dns/providers/coredns
+    - external-dns/localhost
+  substitutions:
+    external_domain: test
+    loadbalancer_start_ip: 127.0.0.1
+```
+
+### Local Cilium VM cluster
+
+Default `windsor up` topology. CoreDNS exposed via a LoadBalancer Service
+sharing the gateway IP through Cilium LBIPAM.
+
+```yaml
+- name: dns
+  path: dns
+  dependsOn: [pki-base, cni]
+  timeout: 20m
+  interval: 5m
+  components:
+    - coredns
+    - coredns/etcd
+    - coredns/loadbalancer
+    - coredns/cilium
+    - external-dns
+    - external-dns/providers/coredns
+    - external-dns/sources/gateway-httproute
+  substitutions:
+    external_domain: example.internal
+    loadbalancer_start_ip: 10.5.0.10
+```
+
+### Envoy gateway
+
+CoreDNS port-53 listeners attached to the edge Gateway via TCPRoute/UDPRoute.
+
+```yaml
+- name: dns
+  path: dns
+  dependsOn: [pki-base, gateway-base]
+  timeout: 20m
+  interval: 5m
+  components:
+    - coredns
+    - coredns/etcd
+    - coredns/gateway
+    - external-dns
+    - external-dns/providers/coredns
+    - external-dns/sources/gateway-httproute
+  substitutions:
+    external_domain: example.internal
+    loadbalancer_start_ip: 10.5.0.10
+```
+
+### AWS production (Route 53)
+
+```yaml
+- name: dns
+  path: dns
+  dependsOn: [pki-base, cni]
+  timeout: 20m
+  interval: 5m
+  components:
+    - coredns
+    - coredns/etcd
+    - coredns/ha
+    - coredns/loadbalancer
+    - coredns/cilium
+    - external-dns
+    - external-dns/providers/route53
+    - external-dns/ha
+    - external-dns/sources/gateway-httproute
+  substitutions:
+    external_domain: prod.example.com
+    loadbalancer_start_ip: 10.0.10.10
+```
+
+### Azure production (Azure DNS)
+
+Same shape as the AWS recipe, swapping the provider component to
+`external-dns/providers/azure`.
+
+## Substitutions
+
+| Name | Default | Effect and constraints |
+|---|---|---|
+| `external_domain` | `test` (fallback in helm-release values) | Private zone served by CoreDNS and the `domainFilters` value passed to external-dns. Records outside this domain will not be reconciled. |
+| `loadbalancer_start_ip` | required | Anchor IP for the CoreDNS LoadBalancer Service. Must sit inside the LBIPAM pool configured by the `cni` add-on on Cilium clusters. Ignored when `coredns/loadbalancer` is not enabled. |
+
+## Components
+
+### `coredns/`
+
+| Component | Enable when | Effect |
+|---|---|---|
+| `coredns` | always | Helm release of CoreDNS in `system-dns`. |
+| `coredns/etcd` | always (record store) | StatefulSet, Service, and mTLS certs for the etcd backing CoreDNS records. |
+| `coredns/ha` | `topology: ha` | Multi-replica deployment with anti-affinity. |
+| `coredns/loadbalancer` | `gateway.driver: cilium` | Switches the CoreDNS Service to type `LoadBalancer`. |
+| `coredns/cilium` | `gateway.driver: cilium` | LBIPAM annotation so CoreDNS shares the gateway IP. |
+| `coredns/gateway` | `gateway.driver: envoy` AND `gateway.enabled: true` | TCPRoute and UDPRoute on port 53 attached to the edge Gateway. |
+
+### `external-dns/`
+
+| Component | Enable when | Effect |
+|---|---|---|
+| `external-dns` | always | Helm release of external-dns in `system-dns`. |
+| `external-dns/providers/coredns` | provider is in-cluster CoreDNS-via-etcd | Wires external-dns to write records into the CoreDNS etcd. |
+| `external-dns/providers/route53` | provider is AWS Route 53 | IRSA-based AWS provider config. |
+| `external-dns/providers/azure` | provider is Azure DNS | Workload-identity-based Azure provider config. |
+| `external-dns/ha` | `topology: ha` | Two replicas with leader election. |
+| `external-dns/localhost` | `workstation.runtime: docker-desktop` | Kyverno ClusterPolicy that mutates Ingress, Gateway, and HTTPRoute objects to set `external-dns.alpha.kubernetes.io/target: 127.0.0.1`. Requires `policy-resources`. |
+| `external-dns/sources/gateway-httproute` | `gateway.enabled: true` | Adds Gateway API HTTPRoute to external-dns sources. Crashloops if enabled without HTTPRoute CRDs present. |
+
+## Dependencies
+
+| Depends on | Reason |
+|---|---|
+| `pki-base` | etcd peer, server, and client certificates are issued by the `private` ClusterIssuer. |
+| `cni` *(Cilium only)* | LoadBalancer Service for CoreDNS uses Cilium LBIPAM. |
+| `gateway-base` *(Envoy only, when gateway enabled)* | TCPRoute/UDPRoute CRDs for the port-53 listeners. |
+| `policy-resources` *(docker-desktop only)* | Kyverno CRDs needed by the `external-dns/localhost` ClusterPolicy. |
+
+## Operations
+
+Add-on-specific failure modes; generic Flux/Renovate behaviour is documented at
+the repo level.
+
+- **`external-dns` crashlooping with `failed to sync HTTPRoute`** — the
+  `external-dns/sources/gateway-httproute` component is enabled but the
+  Gateway API CRDs are not installed. Either install a Gateway controller or
+  drop the component.
+- **`HelmRelease/external-dns` reports `no matches for kind ClusterPolicy`** —
+  the `external-dns/localhost` component is enabled outside docker-desktop or
+  before `policy-resources` (Kyverno) is ready. Confirm the facet still gates
+  this on `workstation.runtime == 'docker-desktop'`.
+- **CoreDNS pods stuck in `Pending`** — the LoadBalancer Service has no IP.
+  On Cilium check the LBIPAM pool covers `loadbalancer_start_ip`; on Envoy
+  confirm `coredns/gateway` is selected instead of `coredns/loadbalancer`.
+- **Records appear in CoreDNS but not in DNS responses** — etcd peer mTLS is
+  failing. Check certificates under [coredns/etcd/certificates.yaml](coredns/etcd/certificates.yaml)
+  and that the cert-manager issuer from `pki-base` is `Ready`.
+
+Metrics are scraped by the `telemetry` add-on. CoreDNS exposes Prometheus
+metrics on port 9153 via the `prometheus` plugin configured in
+[coredns/helm-release.yaml](coredns/helm-release.yaml). external-dns metrics
+follow the chart default.
+
+## Security
+
+- etcd peer, server, and client traffic is mTLS. Certificates are issued by
+  the `private` ClusterIssuer (provided by `pki-base`) and managed under
+  [coredns/etcd/certificates.yaml](coredns/etcd/certificates.yaml).
+- external-dns identity:
+  - Route 53: pod identity (`provider.aws.usePodIdentity: true`) scoped to the hosted zone.
+  - Azure DNS: workload identity scoped to the resource group.
+- The `external-dns/localhost` Kyverno policy mutates Ingress, Gateway, and
+  HTTPRoute objects cluster-wide. It is gated to `docker-desktop` runtime to
+  keep it out of shared clusters.
+
+## See also
+
+- [contexts/_template/facets/addon-private-dns.yaml](../../contexts/_template/facets/addon-private-dns.yaml) — canonical wiring with conditional logic.
+- Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
+- Related add-ons: [pki](../pki/), [gateway](../gateway/), [cni](../cni/), [policy](../policy/), [telemetry](../telemetry/).

--- a/docs/reference/kustomize/gateway.md
+++ b/docs/reference/kustomize/gateway.md
@@ -1,0 +1,238 @@
+---
+title: Gateway add-on
+description: Gateway API entrypoint with Envoy or Cilium controllers and a shared TLS-terminated Gateway resource.
+---
+
+# Gateway
+
+The cluster's traffic entrypoint. A single Gateway resource named `external`
+is rendered into `system-gateway` with HTTP, HTTPS, and (optionally) DNS
+and Flux listeners. Two implementation paths share the same Gateway: Envoy
+Gateway as a separately-deployed controller, or Cilium's built-in Gateway
+API support via the CNI. cert-manager (from the `pki` add-on) issues the TLS
+certificate; HTTPRoutes from any namespace attach to the Gateway.
+
+## Flow
+
+```mermaid
+flowchart LR
+    client([Client])
+    workload[Backend Service]
+
+    subgraph systemgateway[system-gateway]
+        controller{Envoy Gateway<br/>or<br/>Cilium CNI}
+        gw[Gateway: external<br/>HTTPS · HTTP · DNS · Flux]
+        cert[Certificate<br/>external-web-tls]
+        cm[cert-manager]
+    end
+
+    issuer[ClusterIssuer<br/>from pki add-on]
+    routes[HTTPRoute · UDPRoute · TCPRoute]
+
+    client --> controller
+    controller -.implements.-> gw
+    controller --> workload
+    routes -.attach to.-> gw
+
+    cert --> cm --> issuer
+    cm -.writes Secret.-> gw
+```
+
+The Gateway resource is identical across drivers; what changes is which
+controller reconciles it (`gateway.envoyproxy.io/gatewayclass-controller`
+for Envoy, `io.cilium/gateway-controller` for Cilium) and how the data plane
+is exposed (Envoy via a Service of type LoadBalancer or NodePort; Cilium via
+the CNI's own LBIPAM path).
+
+## Recipes
+
+`gateway-base` is rendered when `gateway.enabled: true`. `gateway-resources`
+is rendered alongside it. Platform facets layer cloud-specific patches onto
+`gateway-base` (AWS NLB annotations, Azure SLB internal flip).
+
+### Local Cilium cluster (default `windsor up`)
+
+Cilium provides the Gateway implementation through the CNI; this add-on only
+supplies the GatewayClass and the Gateway/Certificate resources.
+
+```yaml
+- name: gateway-base
+  path: gateway/base
+  dependsOn: [pki-base]
+  components:
+    - cilium
+  timeout: 10m
+
+- name: gateway-resources
+  path: gateway/resources
+  dependsOn: [gateway-base]
+  components:
+    - cilium
+    - lb-address
+    - flux-webhook
+  substitutions:
+    gateway_class_name: cilium
+    gateway_dns_target: 10.5.0.10
+    external_domain: example.internal
+    gateway_cert_issuer: public-selfsigned
+    loadbalancer_start_ip: 10.5.0.10
+```
+
+### Envoy with NodePort (docker-desktop or metal)
+
+```yaml
+- name: gateway-base
+  path: gateway/base
+  dependsOn: [pki-base]
+  components:
+    - envoy
+    - envoy/nodeport
+    - envoy/prometheus
+
+- name: gateway-resources
+  path: gateway/resources
+  dependsOn: [gateway-base]
+  components:
+    - envoy/default-404
+    - flux-webhook
+  substitutions:
+    gateway_class_name: envoy
+    external_domain: example.internal
+    gateway_cert_issuer: public-selfsigned
+```
+
+### Envoy on AWS (NLB)
+
+The AWS Load Balancer Controller (separately installed by `lb-base`)
+provisions an NLB pointed at the Envoy data-plane Service.
+
+```yaml
+- name: gateway-base
+  path: gateway/base
+  dependsOn: [pki-base, lb-base]
+  components:
+    - envoy
+    - envoy/loadbalancer
+    - envoy/loadbalancer/aws-nlb
+    - envoy/prometheus
+
+- name: gateway-resources
+  path: gateway/resources
+  dependsOn: [gateway-base, lb-base]
+  components:
+    - envoy/default-404
+    - envoy/default-404/external-dns
+    - flux-webhook
+  substitutions:
+    gateway_class_name: envoy
+    external_domain: example.com
+    gateway_cert_issuer: public-acme
+```
+
+### Envoy on Azure (private)
+
+```yaml
+- name: gateway-base
+  path: gateway/base
+  dependsOn: [pki-base]
+  components:
+    - envoy
+    - envoy/loadbalancer
+    - envoy/loadbalancer/azure-lb-internal
+    - envoy/prometheus
+
+- name: gateway-resources
+  path: gateway/resources
+  dependsOn: [gateway-base]
+  components:
+    - envoy/default-404
+    - envoy/default-404/external-dns
+    - flux-webhook
+  substitutions:
+    gateway_class_name: envoy
+    external_domain: vpc.example.com
+    gateway_cert_issuer: private
+```
+
+## Substitutions
+
+| Name | Required when | Effect |
+|---|---|---|
+| `gateway_class_name` | always | Drives `Gateway.spec.gatewayClassName`. Must match the GatewayClass installed by the chosen driver (`envoy` or `cilium`). |
+| `external_domain` | always | DNS name (and wildcard) on the Gateway TLS certificate. Switches between `dns.private_domain` and `dns.public_domain` in the upstream facet based on `gateway.access`. |
+| `gateway_cert_issuer` | always | ClusterIssuer name the `external-web-tls` Certificate references. One of `private`, `public-selfsigned`, `public-acme` — must exist (rendered by the `pki` add-on). Renaming the issuer triggers cert-manager reissuance. |
+| `gateway_dns_target` | when external-dns is reconciling Gateway hostnames | IP advertised by external-dns for Gateway-attached hostnames. Stamped onto the Gateway via the `dns` component's annotation. |
+| `loadbalancer_start_ip` | `cilium`, `lb-address`, or any in-cluster LB path | Anchor IP for the Gateway's load balancer. Used by Cilium LBIPAM, the `lb-address` patch, and intended for `envoy/loadbalancer`. Must sit inside the LBIPAM pool (Cilium) or the cluster's MetalLB pool (Envoy). |
+| `lb_scheme` | AWS only, when `gateway.access == 'private'` | AWS LB scheme annotation. Defaults to `internet-facing` when empty (kustomize fallback `${lb_scheme:-internet-facing}`); set to `internal` for VPC-only gateways. |
+
+## Components
+
+### `gateway/base/`
+
+The base kustomization always installs the upstream Gateway API experimental
+CRDs (vendored at `gateway-api-experimental-v1.5.1.yaml`) and the
+`system-gateway` namespace.
+
+| Component | Enable when | Effect |
+|---|---|---|
+| `cilium` | `gateway.driver: cilium` | GatewayClass `cilium` pointing at `io.cilium/gateway-controller`. The Cilium HelmRelease itself is owned by the `cni` add-on. |
+| `envoy` | `gateway.driver: envoy` | Helm release of Envoy Gateway in `system-gateway`, vendored Envoy Gateway CRDs v1.7.1, GatewayClass `envoy`. |
+| `envoy/loadbalancer` | `gateway.driver: envoy` AND `gateway.service_type: LoadBalancer` (or platform default) | Patches the Envoy data-plane Service to type `LoadBalancer`. |
+| `envoy/loadbalancer/aws-nlb` | `platform: aws` AND `gateway.driver: envoy` AND LB mode | AWS LB Controller annotations: `aws-load-balancer-type: external`, `nlb-target-type: ip`, scheme from `${lb_scheme}`, cross-zone enabled. |
+| `envoy/loadbalancer/azure-lb-internal` | `platform: azure` AND `gateway.driver: envoy` AND `gateway.access: private` | Adds `service.beta.kubernetes.io/azure-load-balancer-internal: "true"` to flip the AKS Standard LB to internal. |
+| `envoy/nodeport` | `gateway.driver: envoy` AND `gateway.service_type: NodePort` (or docker-desktop default) | Patches the Envoy data-plane Service to NodePort with hardcoded ports: 80→30080, 443→30443, 53 UDP/TCP→30053, 9292→30292. |
+| `envoy/prometheus` | `gateway.driver: envoy` AND `telemetry.metrics.enabled: true` | ServiceMonitor + PodMonitor for the Envoy controller and proxies. |
+
+### `gateway/resources/`
+
+The base kustomization always renders `Gateway/external` (HTTP/80 +
+HTTPS/443 listeners) and `Certificate/external-web-tls`.
+
+| Component | Enable when | Effect |
+|---|---|---|
+| `cilium` | `gateway.driver: cilium` | LBIPAM annotations on the Gateway (`lbipam.cilium.io/ips`, `sharing-key: external`, `sharing-cross-namespace: "*"`) so the Gateway can share its IP with CoreDNS and other LB consumers. |
+| `dns` | `addons.private_dns.enabled: true` AND `gateway.driver: envoy` | Adds UDP/53 (UDPRoute) and TCP/53 (TCPRoute) listeners so CoreDNS port-53 traffic terminates on the Gateway. |
+| `envoy/default-404` | `gateway.driver: envoy` | Catch-all 404 HTTPRoute using the Envoy-specific `gateway.envoyproxy.io/HTTPRouteFilter` `directResponse`. Cilium clusters don't ship that CRD. |
+| `envoy/default-404/external-dns` | `dns.public_domain` is set OR (`gateway.access: private` AND `dns.private_domain` is set) | Adds `external-dns.alpha.kubernetes.io/hostname: "${external_domain},*.${external_domain}"` to the 404 route so external-dns publishes apex + wildcard records pointing at the Gateway IP. |
+| `flux-webhook` | `gitops.mode: push` (the default) | Adds an HTTP/9292 listener for the Flux notification receiver. |
+| `lb-address` | in-cluster LB is active (`network.loadbalancer_driver` is set on metal/incus, or `gateway.driver: cilium`) | Pins `spec.addresses` on the Gateway to `${loadbalancer_start_ip}`. |
+
+## Dependencies
+
+| Add-on | Reason |
+|---|---|
+| `pki-base` | cert-manager must be running before `Certificate/external-web-tls` is created. |
+| `lb-base` *(`platform: aws`, or `network.loadbalancer_driver` set on metal/incus)* | Provides the AWS Load Balancer Controller (or MetalLB) that the Envoy data-plane Service needs to acquire an external IP. |
+| `dns` *(when `dns.enabled: true`)* | external-dns (in the `dns` add-on) watches Gateway HTTPRoutes for hostname annotations. When the private-DNS addon is also active, the `gateway-resources/dns` component attaches port-53 listeners that route to upstream CoreDNS. |
+| `cni` *(reverse, `gateway.driver: cilium` only)* | When Cilium is the driver, the `cni` add-on `dependsOn` `gateway-base` so the Gateway API CRDs are present before the Cilium HelmRelease is applied — Cilium's operator initializes its Gateway controller at startup and won't pick up CRDs added later. |
+
+## Operations
+
+Add-on-specific failure modes; generic Flux/Renovate behaviour is documented
+at the repo level.
+
+- **`Certificate/external-web-tls` stuck `Issuing`** — the `gateway_cert_issuer` substitution names a ClusterIssuer that the `pki-resources` Kustomization hasn't rendered yet. Confirm the ClusterIssuer exists (`kubectl get clusterissuer`) and matches the substitution. On a switch from `public-selfsigned` to `public-acme`, the Certificate spec changes and cert-manager reissues.
+- **Envoy data-plane Service stuck without an external IP** — the LB controller isn't installed or reachable. On AWS check `lb-base` is healthy and the AWS LB Controller pods are running. On metal/incus check MetalLB.
+- **`gateway-base` reports `no matches for kind GatewayClass`** — the base CRDs (vendored `gateway-api-experimental-v1.5.1.yaml`) didn't apply. Usually a kustomize build failure; reconcile manually with `flux reconcile kustomization gateway-base`.
+- **Cilium clusters: HTTPRoutes attach but never serve traffic** — Cilium's Gateway controller didn't initialize because the CRDs weren't present when cilium-operator started. The reverse `cni dependsOn gateway-base` ordering is meant to prevent this; if it fires, restart `cilium-operator`.
+- **Envoy LB IP appears unset on `envoy/loadbalancer`** — known issue: the `loadBalancerIP` patch references `${loadbalancer_ip_start}` but the actual substitution is `loadbalancer_start_ip`. The patch silently renders an empty value; the cloud LB allocates an arbitrary IP. Either pin via `lb-address` (which uses the correct name) or fix the substitution name in the patch.
+
+The Envoy controller exposes Prometheus metrics through the
+`envoy/prometheus` component (ServiceMonitor + PodMonitor). Cilium's metrics
+are scraped by the `cni` add-on's own ServiceMonitor.
+
+## Security
+
+- The `system-gateway` namespace is PSA `baseline`.
+- The Gateway's `external-web-tls` Certificate is issued by a ClusterIssuer from the `pki` add-on. The Secret is consumed only by the Gateway's TLS listener; it is not mounted by application workloads.
+- HTTPRoute, UDPRoute, TCPRoute resources are accepted from all namespaces (`spec.listeners[*].allowedRoutes.namespaces.from: All`). Tenant isolation, if needed, must come from upstream policy (NetworkPolicy, Kyverno) — the Gateway itself does not gate cross-namespace attachment.
+- AWS NLB target-type is `ip` so traffic flows directly to Envoy pods (kube-proxy is bypassed); the source IP reaches Envoy unmodified for X-Forwarded-For handling.
+- The Azure internal-LB annotation pins the data-plane Service to the VNet — it is not reachable from outside the VNet. Public exposure on Azure requires omitting `envoy/loadbalancer/azure-lb-internal`.
+
+## See also
+
+- [contexts/_template/facets/option-gateway.yaml](../../contexts/_template/facets/option-gateway.yaml) — canonical wiring for both drivers, including the reverse `cni` dep and the cert-issuer fallback logic.
+- [contexts/_template/facets/platform-aws.yaml](../../contexts/_template/facets/platform-aws.yaml) — AWS NLB annotations layered onto `gateway-base`.
+- [contexts/_template/facets/platform-azure.yaml](../../contexts/_template/facets/platform-azure.yaml) — Azure internal-LB conditional layering.
+- Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
+- Related add-ons: [pki](../pki/), [dns](../dns/), [cni](../cni/), [lb](../lb/), [gitops](../gitops/), [telemetry](../telemetry/).

--- a/docs/reference/kustomize/gitops.md
+++ b/docs/reference/kustomize/gitops.md
@@ -1,0 +1,170 @@
+---
+title: GitOps add-on
+description: Flux notification webhook receiver and HTTPRoute. Flux itself is installed by Terraform, not this add-on.
+---
+
+# GitOps
+
+Almost all of the GitOps weight in this blueprint is in the Terraform module
+at [terraform/gitops/flux/](../../terraform/gitops/flux/) — that's what
+installs Flux's controllers, the root `GitRepository`, and the bootstrap
+`Kustomization`. This Kustomize add-on adds the **flux notification
+webhook receiver** on top: a `Receiver` resource the
+notification-controller exposes for HMAC-authenticated push triggers, plus
+an HTTPRoute that lets external git hosts (GitHub, GitLab) reach it.
+
+If `gitops.mode` is `pull`, this add-on renders nothing — Flux polls and no
+inbound webhook is needed.
+
+## Flow
+
+```mermaid
+flowchart LR
+    git[Git host webhook<br/>_GitHub / GitLab_]
+    gateway[Cluster Gateway]
+    gitrepo[(GitRepository<br/>flux-system)]
+
+    subgraph systemgitops[system-gitops]
+        receiver[Receiver flux-webhook<br/>HMAC token]
+        nc[notification-controller]
+    end
+
+    git -->|POST /hook/...| gateway
+    gateway -->|HTTPRoute| nc
+    nc --> receiver
+    receiver -.triggers reconcile.-> gitrepo
+```
+
+The receiver is a `notification.toolkit.fluxcd.io/v1` `Receiver` of `type:
+generic` — the `webhook-token` Secret holds the HMAC the git host signs
+each delivery with. On a valid signature, notification-controller forces a
+reconcile of the named `GitRepository` (`${git_repository_name}`).
+
+## Recipes
+
+`platform-base` emits exactly one of two variants based on whether a
+Gateway is available; both are gated on `(gitops.mode ?? 'push') == 'push'`.
+
+### Push mode without a Gateway
+
+Plain `Receiver` only — no HTTPRoute, so reachability depends on something
+else exposing the notification-controller Service. Useful for clusters
+with no Gateway API controller (rare in this blueprint, since the bootstrap
+flow assumes one).
+
+```yaml
+- name: gitops
+  path: gitops/flux
+  components:
+    - webhook
+  substitutions:
+    git_repository_name: my-repo
+```
+
+### Push mode with Envoy gateway
+
+Webhook plus an HTTPRoute attached to the cluster's `external` Gateway.
+The Gateway has a dedicated `flux-webhook` listener (port 9292) added by
+[gateway-resources/flux-webhook](../gateway/resources/flux-webhook).
+
+```yaml
+- name: gitops
+  path: gitops/flux
+  dependsOn: [gateway-base]
+  components:
+    - webhook
+    - webhook/gateway
+  substitutions:
+    git_repository_name: my-repo
+```
+
+### Push mode with Cilium gateway
+
+Same as Envoy plus a `CiliumNetworkPolicy` permitting ingress from the
+`ingress` entity to the notification-controller pods. The policy is
+required on Cilium clusters where default-deny network policies block
+gateway-originated traffic.
+
+```yaml
+- name: gitops
+  path: gitops/flux
+  dependsOn: [gateway-base]
+  components:
+    - webhook
+    - webhook/gateway
+    - webhook/gateway/cilium
+  substitutions:
+    git_repository_name: my-repo
+```
+
+### Pull mode
+
+Set `gitops.mode: pull`. Both webhook entries' `when:` evaluates false and
+this add-on contributes nothing beyond the namespace already created by
+Terraform.
+
+## Substitutions
+
+| Name | Required when | Effect |
+|---|---|---|
+| `git_repository_name` | always (when push mode) | Name of the `GitRepository` the receiver triggers. Defaults to `"local"` (workstation default); platform facets pass through `gitops.repository.name`. The receiver will accept any payload but will only ever reconcile the named repository. |
+
+The `webhook-token` Secret holding the HMAC is provisioned by the
+Terraform module — not by this add-on. This Kustomization only references
+it (`secretRef.name: webhook-token`).
+
+## Components
+
+The Kustomize add-on has only a webhook subtree. Flux's controllers are
+not in this add-on — they ship from the Terraform module.
+
+| Component | Enable when | Effect |
+|---|---|---|
+| `webhook` | push mode | `Receiver/flux-webhook` of `type: generic`, referencing the `webhook-token` Secret and triggering the `${git_repository_name}` GitRepository. |
+| `webhook/gateway` | push mode AND a Gateway is enabled | HTTPRoute attaching the receiver Service to the cluster Gateway's `web-http` and `flux-webhook` listeners. The `web-http` listener is the standard port-80; `flux-webhook` is a dedicated port-9292 listener (added by [gateway-resources/flux-webhook](../gateway/resources/flux-webhook)). PathPrefix `/hook/` routes to the `webhook-receiver` Service on port 80. |
+| `webhook/gateway/cilium` | push mode + Cilium gateway driver | `CiliumNetworkPolicy` named `allow-gateway-webhooks` that permits ingress traffic from the `ingress` entity to the notification-controller pods (matched by label `app: notification-controller`). |
+
+## Dependencies
+
+The Kustomize add-on has minimal dependencies:
+
+| Add-on | Reason |
+|---|---|
+| `gateway-base` *(when Gateway variant)* | The Gateway API CRDs (HTTPRoute) and the `external` Gateway must exist before `webhook/gateway` is applied. |
+
+Dependencies on the Terraform side are richer:
+
+- `terraform: gitops` `dependsOn: cluster` (every platform).
+- `terraform: gitops` `dependsOn: cni` on platforms where Cilium is the CNI (waits for pod networking).
+- `terraform: gitops` `dependsOn: cluster, cluster-extensions` on AWS (EKS-specific, when applicable).
+
+These are not part of the Kustomize add-on but matter for ordering: Flux
+itself must be running before any Windsor Kustomization (including this
+one) can reconcile.
+
+## Operations
+
+Add-on-specific failure modes; generic Flux/Renovate behaviour is documented
+at the repo level.
+
+- **Webhook returns 401** — the HMAC secret in `webhook-token` doesn't match what the git host is signing with. Inspect `kubectl get secret webhook-token -n system-gitops` and confirm the git host webhook config uses the same value. The Terraform module provisions this; on workstations the default is `${gitops.webhook.token ?? "abcdef123456"}`.
+- **Webhook returns 404** — the HTTPRoute path or listener doesn't match. The route uses `PathPrefix: /hook/` — git hosts must POST to `https://<external_domain>/hook/<receiver-path>` (the suffix is the `webhook-path` from the Receiver status).
+- **Cilium clusters: webhook reachable but reconciles don't trigger** — the `webhook/gateway/cilium` policy isn't applied. Without it, ingress traffic is dropped before reaching notification-controller. Ensure the component is enabled when `gateway.driver: cilium`.
+- **Push mode set but receiver not rendered** — confirm `gitops.mode` is exactly `push` (or unset, which defaults to push). The `when:` clauses use `(gitops.mode ?? 'push') == 'push'` so both work.
+- **GitRepository never reconciles on push** — the receiver references `${git_repository_name}`. If the substitution doesn't match the actual GitRepository name in `system-gitops`, the receiver will accept the webhook but reconcile a non-existent target. Check `kubectl get gitrepository -n system-gitops` and the Receiver's `spec.resources[0].name`.
+
+## Security
+
+- The `system-gitops` namespace has no PSA enforce labels in [namespace.yaml](namespace.yaml). The chart's pod security defaults apply; Flux runs at PSA `restricted` upstream.
+- Authentication on the webhook is HMAC via the `webhook-token` Secret. The Receiver type is `generic` — for git-host-specific verification (e.g. GitHub's `X-Hub-Signature-256`) configure the receiver type accordingly. The shipped `generic` type accepts any signature on any payload as long as the HMAC matches.
+- The Cilium policy permits ingress to notification-controller from `fromEntities: [ingress]` only — pod-to-pod traffic from other namespaces is still blocked by default.
+- Webhook tokens default to `abcdef123456` on workstation contexts via `option-workstation`'s `webhook_token: ${gitops.webhook.token ?? "abcdef123456"}`. Production clusters MUST override this; the default is documented as a placeholder.
+
+## See also
+
+- [terraform/gitops/flux/](../../terraform/gitops/flux/) — the Flux installer, including controllers, GitRepository, root Kustomization, and the `webhook-token` Secret. Most operator concerns about gitops live there, not in this add-on.
+- [contexts/_template/facets/platform-base.yaml](../../contexts/_template/facets/platform-base.yaml) (lines ~491-509) — canonical wiring for both webhook variants.
+- [contexts/_template/facets/option-workstation.yaml](../../contexts/_template/facets/option-workstation.yaml) — workstation-specific Terraform inputs (`concurrency`, `git_username`, `git_password`, `webhook_token`).
+- [contexts/_template/facets/option-cni.yaml](../../contexts/_template/facets/option-cni.yaml) — adds the `cni` Terraform dep so Flux waits for pod networking on Cilium clusters.
+- Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
+- Related add-ons: [gateway](../gateway/), [cni](../cni/).

--- a/docs/reference/kustomize/index.md
+++ b/docs/reference/kustomize/index.md
@@ -1,0 +1,109 @@
+---
+title: Kustomize layer
+description: Index of the cluster add-ons that ship with the Windsor Core blueprint.
+---
+
+# Kustomize
+
+The Kustomize layer of the Windsor Core blueprint. Each subdirectory is an
+add-on — a logically-grouped set of `HelmRelease`, `Certificate`, custom
+resources, and patches that Flux reconciles after the cluster is up.
+
+Add-ons are not applied directly. Facets in
+[contexts/_template/facets/](../contexts/_template/facets/) emit Flux
+`Kustomization` entries that reference these directories (`path:`) and
+select per-cluster components. Multiple facets can contribute to the same
+Kustomization name; the Windsor harness composes them into a single
+materialized entry.
+
+## Layout convention
+
+Most add-ons follow a consistent shape:
+
+```
+kustomize/<add-on>/
+├── namespace.yaml          # Namespace + PSA labels
+├── kustomization.yaml      # Add-on root (often just resources: [namespace.yaml])
+├── <operator>/
+│   ├── kustomization.yaml  # kind: Component
+│   ├── helm-repository.yaml
+│   ├── helm-release.yaml
+│   └── <variant>/          # Patches selected per-cluster
+│       ├── kustomization.yaml  # kind: Component, patches: ...
+│       └── patches/
+└── README.md               # This add-on's reference (per-add-on READMEs)
+```
+
+Some add-ons split into `base/` (operators) and `resources/` (cluster
+state) — pki, lb, gateway, telemetry, object-store. Others have a single
+top-level kustomization — cni, csi, dns, policy, observability, gitops,
+ingress, demo.
+
+See [GUIDELINES.md](GUIDELINES.md) for the timeout / interval rules each
+add-on's facet entries follow, derived from image count and reconcile
+weight.
+
+## Add-ons
+
+### Bootstrap and platform
+
+| Add-on | Owns | Wired by |
+|---|---|---|
+| [cni](cni/) | Cilium CNI (replaces kube-proxy, optional Gateway API + LBIPAM + Hubble). Bootstrapped by Terraform, adopted by Flux. | `option-cni` |
+| [policy](policy/) | Kyverno admission controller and cluster-wide ClusterPolicies (image-digest enforcement, resource limits/requests audit). | `platform-base` |
+| [pki](pki/) | cert-manager and trust-manager. Private and public ClusterIssuers — selfsigned, CA-backed, ACME (Let's Encrypt + Route53 / Azure DNS). | `platform-base`, `platform-aws`, `platform-azure`, `addon-private-ca`, `option-dev` |
+| [telemetry](telemetry/) | Prometheus (kube-prometheus-stack), fluent-operator + fluent-bit, metrics-server. The collection layer; sinks live in `observability`. | `platform-base` |
+| [gitops](gitops/) | Flux notification webhook receiver and HTTPRoute. Flux itself is installed by Terraform. | `platform-base` |
+
+### Networking and traffic
+
+| Add-on | Owns | Wired by |
+|---|---|---|
+| [gateway](gateway/) | Gateway API entrypoint — Envoy Gateway controller or Cilium's built-in Gateway. The shared `external` Gateway and `external-web-tls` Certificate. | `option-gateway`, `platform-aws`, `platform-azure` |
+| [dns](dns/) | CoreDNS for private zones, external-dns for record automation against in-cluster CoreDNS / Route 53 / Azure DNS. | `addon-private-dns`, `platform-aws`, `platform-azure` |
+| [lb](lb/) | AWS LB Controller (cloud) or MetalLB / kube-vip (metal, incus). Provides external IPs for `Service` of type `LoadBalancer`. | `platform-aws`, `platform-metal`, `platform-incus`, `platform-docker` |
+| [ingress](ingress/) | Legacy nginx-ingress controller. **Not wired by current facets** — the gateway add-on is the supported path. Kept for blueprints that explicitly want classic Ingress. | (none — manual wiring) |
+
+### Storage and data
+
+| Add-on | Owns | Wired by |
+|---|---|---|
+| [csi](csi/) | Persistent storage drivers and StorageClasses — AWS EBS, Azure Disk, OpenEBS host-path, Longhorn. | `platform-aws`, `platform-azure`, `option-storage`, `option-single-node` |
+| [database](database/) | CloudNativePG operator. Tenant `Cluster` resources are created by workloads; this add-on only provides the operator. | `addon-database` |
+| [object-store](object-store/) | MinIO operator. The reference tenant under `resources/common` is shipped but not wired by `addon-object-store` — operators add it manually. | `addon-object-store` |
+
+### Observability
+
+| Add-on | Owns | Wired by |
+|---|---|---|
+| [observability](observability/) | Grafana, dashboards, fluentd aggregator, and pluggable log storage (stdout, Quickwit, Elasticsearch + Kibana). The fluentd aggregator is wired by `platform-base` even without the addon; Grafana and storage backends are wired by `addon-observability`. | `platform-base` (fluentd), `addon-observability` (everything else), `option-dev` (`grafana/dev` admin password patch), `option-cni` (Cilium dashboards), `option-storage` (Longhorn dashboards), `addon-database` (CNPG dashboards) |
+
+### Examples
+
+| Add-on | Owns | Wired by |
+|---|---|---|
+| [demo](demo/) | Sample workloads — a CNPG demo cluster, a live-reload static website, the Istio bookinfo app. Each toggleable independently via `demo.resources.*`. | `option-demo` |
+
+## How facets compose
+
+A given Kustomization name (e.g. `observability`, `pki-base`) often
+appears in multiple facet entries. The Windsor harness composes them
+additively — `dependsOn` and `components` lists are unioned, the path
+must agree. This is how `option-cni` adds `grafana/dashboards/cilium` to
+the `observability` Kustomization without redefining it, and how
+`platform-base` ships the fluentd aggregator while `addon-observability`
+layers in Grafana and the storage backend on the same Kustomization.
+
+The recipes in each per-add-on README show the **materialized union** for
+typical scenarios — what the merged Kustomization entry looks like after
+all contributing facets resolve. Conditional `dependsOn` entries (e.g.
+`policy-resources` is gated on `policies.enabled: true`) are typically
+shown unconditionally for readability.
+
+## See also
+
+- [GUIDELINES.md](GUIDELINES.md) — timeout and interval rules.
+- [contexts/_template/facets/](../contexts/_template/facets/) — the facets that wire these add-ons into a blueprint.
+- [contexts/_template/schema.yaml](../contexts/_template/schema.yaml) — user-facing values.yaml schema.
+- [terraform/](../terraform/) — the Terraform layer that provisions the cluster, IAM, networking, and bootstraps Flux and Cilium.
+- Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/

--- a/docs/reference/kustomize/ingress.md
+++ b/docs/reference/kustomize/ingress.md
@@ -1,0 +1,141 @@
+---
+title: Ingress add-on
+description: Legacy nginx-ingress controller. Not wired by current facets — the gateway add-on is the recommended traffic entrypoint.
+---
+
+# Ingress
+
+> **Status:** No shipped facet wires this add-on. The
+> [gateway](../gateway/) add-on is the supported traffic entrypoint
+> (Envoy Gateway or Cilium via Gateway API). The components here remain for
+> blueprint authors who explicitly want a Kubernetes Ingress / nginx-based
+> path. The legacy `ingress.driver` field on the schema is treated as an
+> alias by `platform-base` (`'envoy-gateway'` and `'nginx'` both fold into
+> `gateway.driver: envoy`); see
+> [contexts/_template/facets/platform-base.yaml](../../contexts/_template/facets/platform-base.yaml)
+> around the `gateway_effective.driver` resolution.
+
+## Flow
+
+```mermaid
+flowchart LR
+    client([External traffic])
+    pods[Backend Service]
+
+    subgraph systemingress[system-ingress]
+        nginx[ingress-nginx<br/>controller]
+    end
+
+    upstream[(Cluster Services<br/>Ingress / via TCP-UDP map)]
+
+    client -->|LoadBalancer / NodePort| nginx
+    nginx --> upstream --> pods
+```
+
+ingress-nginx terminates HTTP/HTTPS and (when extra components are layered)
+also TCP/UDP for port 53 (CoreDNS) and 9292 (Flux webhook). The data-plane
+Service is exposed via either LoadBalancer or NodePort depending on which
+service-mode component is enabled.
+
+## Recipes
+
+Hand-authored — no shipped facet emits these entries.
+
+### NodePort (docker-desktop, single-node)
+
+```yaml
+- name: ingress
+  path: ingress
+  components:
+    - nginx
+    - nginx/nodeport
+    - nginx/web
+  timeout: 10m
+  interval: 5m
+```
+
+### LoadBalancer (cloud or in-cluster LB)
+
+```yaml
+- name: ingress
+  path: ingress
+  components:
+    - nginx
+    - nginx/loadbalancer
+    - nginx/web
+  timeout: 10m
+  substitutions:
+    loadbalancer_start_ip: 10.5.0.10
+```
+
+> The `nginx/loadbalancer` patch references `${loadbalancer_ip_start}` (note
+> the swapped wording) instead of the canonical `${loadbalancer_start_ip}`
+> — same typo as `gateway/base/envoy/loadbalancer`. The substitution
+> renders empty and the cloud LB allocates an arbitrary IP. To pin a
+> specific IP, fix the patch's variable name first.
+
+### With CoreDNS pass-through and Flux webhook
+
+```yaml
+- name: ingress
+  path: ingress
+  components:
+    - nginx
+    - nginx/nodeport
+    - nginx/web
+    - nginx/coredns
+    - nginx/flux-webhook
+    - nginx/prometheus
+```
+
+## Substitutions
+
+| Name | Required when | Effect |
+|---|---|---|
+| `loadbalancer_start_ip` | `nginx/loadbalancer` is enabled | Anchor IP for the LoadBalancer Service. Must sit inside the cluster's LB IP pool. **Note:** the patch in [nginx/loadbalancer/patches/helm-release.yaml](nginx/loadbalancer/patches/helm-release.yaml) uses `${loadbalancer_ip_start}` (typo) — the value never threads through unless the patch is fixed. |
+
+## Components
+
+| Component | Effect |
+|---|---|
+| `nginx` | Helm release of ingress-nginx v4.15.1 in `system-ingress`. The Service has `enableHttp: false`, `enableTls: false` until layered with `nginx/web`. The IngressClass is set as default. |
+| `nginx/loadbalancer` | Patches the Service to type `LoadBalancer` with `loadBalancerIP` from `${loadbalancer_ip_start}` (see typo note above). |
+| `nginx/nodeport` | Patches the Service to type `NodePort`. |
+| `nginx/web` | Enables HTTP and TLS on the Service with NodePorts 30080 (HTTP) and 30443 (HTTPS). |
+| `nginx/coredns` | Maps Service UDP/TCP port 53 (NodePort 30053 each) to `system-dns/coredns:53`. Use when ingress-nginx is the path for in-cluster DNS exposure (mirrors the gateway add-on's `coredns/gateway` and `dns` components). |
+| `nginx/flux-webhook` | Maps Service TCP port 9292 (NodePort 30292) to `system-gitops/webhook-receiver:80`. Mirrors the gateway add-on's `gitops/flux/webhook/gateway` route. |
+| `nginx/prometheus` | Enables controller metrics and adds a ServiceMonitor labeled `release: kube-prometheus-stack`. Adds a Flux `dependsOn` so ingress-nginx waits for the Prometheus add-on. |
+
+## Dependencies
+
+This add-on has no platform-emitted dependencies (no facet wires it).
+Hand-authored recipes should add:
+
+| Add-on | When |
+|---|---|
+| `policy-resources` | When `policies.enabled: true`. Without it, ingress-nginx pods may fail Kyverno's image-digest validation on first reconcile. |
+| `pki-base` | When the Ingress consumes a `Certificate` from cert-manager (the `nginx` chart does not ship one — operators add it themselves via `Ingress.spec.tls`). |
+| `lb-base` | When `nginx/loadbalancer` is enabled on AWS or any cluster needing a managed LB controller. |
+| `dns` | When `nginx/coredns` is enabled, since the upstream `system-dns/coredns:53` Service must exist before ingress-nginx forwards to it. |
+
+## Operations
+
+Add-on-specific failure modes; generic Flux/Renovate behaviour is documented
+at the repo level.
+
+- **`nginx/loadbalancer` Service has no IP** — see the typo note above; the patch references the wrong variable name, so `loadBalancerIP` renders empty. Either fix the patch (`loadbalancer_ip_start` → `loadbalancer_start_ip`) or pin via cloud-provider annotations on the Service instead.
+- **`nginx/coredns` doesn't resolve queries** — the `system-dns` Kustomization isn't applied, or the `coredns` Service in that namespace is named differently. The TCP/UDP map points at `system-dns/coredns:53`; verify both the namespace and the Service name with `kubectl get svc -n system-dns`.
+- **Flux pushes don't trigger reconciles via the webhook port** — `nginx/flux-webhook` maps to `system-gitops/webhook-receiver:80`. Without that Service (provisioned by the gitops add-on's `webhook` component), the TCP map dead-ends.
+- **Prometheus metrics missing** — `nginx/prometheus` adds a ServiceMonitor with the `kube-prometheus-stack` release label. If telemetry uses a different Prometheus setup, the label must match.
+
+## Security
+
+- The `system-ingress` namespace runs at PSA `baseline`. ingress-nginx does not need privileged mode.
+- TLS termination is handled by ingress-nginx; certificates come from `Secret` references in each `Ingress` resource. Operators are responsible for creating those Secrets — typically via cert-manager `Certificate` resources from the `pki` add-on.
+
+## See also
+
+- [contexts/_template/facets/platform-base.yaml](../../contexts/_template/facets/platform-base.yaml) — `gateway_effective.driver` resolution that folds the legacy `ingress.driver` field into `gateway.driver`.
+- [../gateway/](../gateway/) — the supported traffic entrypoint add-on. New blueprints should wire that instead.
+- Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
+- Related add-ons: [gateway](../gateway/), [pki](../pki/), [lb](../lb/), [dns](../dns/), [gitops](../gitops/), [telemetry](../telemetry/).

--- a/docs/reference/kustomize/lb.md
+++ b/docs/reference/kustomize/lb.md
@@ -1,0 +1,194 @@
+---
+title: Load balancer add-on
+description: AWS Load Balancer Controller for cloud, MetalLB or kube-vip for bare metal and incus.
+---
+
+# Load balancer
+
+Exposes Kubernetes `Service` of type `LoadBalancer` to clients outside the
+cluster. Two paths share the same `system-lb` namespace and the same
+canonical Kustomization names — which controller is wired depends on the
+platform.
+
+- **Cloud** (AWS): the `aws-load-balancer-controller` reconciles Services
+  and Ingress into AWS NLBs and ALBs.
+- **In-cluster** (metal, incus, docker): MetalLB or kube-vip allocates an IP
+  from a pool defined by the network module and advertises it via ARP/L2.
+
+Azure clusters use the native AKS LB and do not render this add-on.
+
+## Flow
+
+```mermaid
+flowchart LR
+    svc[Service type=LoadBalancer]
+    client([External traffic])
+
+    subgraph systemlb[system-lb]
+        aws[aws-load-balancer-controller]
+        metallb[MetalLB controller<br/>+ speaker DaemonSet]
+        kubevip[kube-vip DaemonSet]
+    end
+
+    nlb[AWS NLB / ALB]
+    pool[(IP from<br/>loadbalancer_ip_range)]
+
+    svc -.watched by.-> aws
+    svc -.watched by.-> metallb
+    svc -.watched by.-> kubevip
+
+    aws -->|reconciles| nlb
+    metallb -->|advertises via ARP| pool
+    kubevip -->|advertises via ARP| pool
+
+    nlb --> client
+    pool --> client
+```
+
+The `system-lb` namespace runs at PSA `privileged` because the in-cluster
+speakers need NET_ADMIN and host networking to send gratuitous ARP. The AWS
+LB Controller does not need privilege but shares the namespace.
+
+## Recipes
+
+`lb-base` and `lb-resources` are conditional. AWS always renders `lb-base`
+(the AWS LB Controller). metal/incus/docker render both when
+`network.loadbalancer_driver` is set. docker-desktop forces no in-cluster
+LB regardless (no routable node network); Azure never renders this add-on
+(uses native AKS LBs).
+
+### AWS (cloud-managed NLB/ALB)
+
+The controller does not allocate IPs itself — it provisions cloud LBs in
+response to `Service` and `Ingress` resources. No `lb-resources` is needed.
+
+```yaml
+- name: lb-base
+  path: lb/base
+  dependsOn: [policy-resources]
+  components:
+    - aws-lb-controller
+  substitutions:
+    cluster_name: <terraform output cluster.cluster_name>
+    vpc_id: <terraform output network.vpc_id>
+    aws_region: us-east-1
+```
+
+### Metal or incus with MetalLB
+
+Set `network.loadbalancer_driver: metallb`. The default is `kube-vip`.
+
+```yaml
+- name: lb-base
+  path: lb/base
+  dependsOn: [policy-resources]
+  components:
+    - metallb
+
+- name: lb-resources
+  path: lb/resources
+  dependsOn: [lb-base]
+  components:
+    - metallb
+    - metallb/arp
+  substitutions:
+    loadbalancer_ip_range: 10.5.1.10-10.5.1.30
+```
+
+### Metal or incus with kube-vip (default driver)
+
+kube-vip is deployed entirely from `lb-resources` — there is no `lb-base`
+component for kube-vip, so `lb-base` only renders the `system-lb` namespace.
+
+```yaml
+- name: lb-base
+  path: lb/base
+  dependsOn: [policy-resources]
+  components: []
+
+- name: lb-resources
+  path: lb/resources
+  dependsOn: [lb-base]
+  components:
+    - kube-vip
+    - kube-vip/arp
+  substitutions:
+    loadbalancer_ip_range: 10.5.1.10-10.5.1.30
+```
+
+## Substitutions
+
+| Name | Required when | Effect |
+|---|---|---|
+| `cluster_name` | `aws-lb-controller` is enabled | AWS LB Controller `clusterName` value. Stamped onto every AWS resource the controller owns; the controller filters reconciliation by this tag, so two clusters in the same account must use distinct names. No fallback — empty fails the helm install loudly. |
+| `vpc_id` | `aws-lb-controller` is enabled | VPC ID passed explicitly so the controller does not fall back to IMDS (worker launch templates set `http_put_response_hop_limit=1`, blocking pod-network IMDS calls). |
+| `aws_region` | `aws-lb-controller` is enabled | AWS region the controller's API calls target. No default — a wrong region silently misses the cluster's VPC and emits confusing "not found" errors. |
+| `loadbalancer_ip_range` | `metallb/arp` or `kube-vip/arp` is enabled | IP range MetalLB or kube-vip allocates LoadBalancer IPs from. Format `start-end` (e.g. `10.5.1.10-10.5.1.30`); sourced from `network.loadbalancer_ips.start` and `network.loadbalancer_ips.end` joined by `-`. |
+
+## Components
+
+### `lb/base/`
+
+The base kustomization always renders the `system-lb` namespace.
+
+| Component | Enable when | Effect |
+|---|---|---|
+| `aws-lb-controller` | platform is AWS | Helm release of `aws-load-balancer-controller` v3.2.2 in `system-lb`. Two replicas with anti-affinity (degrades gracefully on single-node). IRSA / Pod Identity provides the IAM role; `clusterName`, `vpcId`, and `region` are passed through substitutions to avoid IMDS. |
+| `metallb` | `network.loadbalancer_driver: metallb` | Helm release of MetalLB v0.15.3 (controller + speaker) in `system-lb`. CRDs (IPAddressPool, L2Advertisement) ship with the chart. |
+
+### `lb/resources/`
+
+The base kustomization is empty by default. AWS does not render
+`lb-resources` (the controller manages cloud LBs, not in-cluster IPs).
+
+| Component | Enable when | Effect |
+|---|---|---|
+| `metallb` | `network.loadbalancer_driver: metallb` | Empty placeholder Component. The MetalLB controller is installed by `lb-base/metallb`; this exists so the uniform `${driver}` pattern in platform facets resolves to a real path on both driver branches. |
+| `metallb/arp` | metallb + `network.loadbalancer_mode: arp` (default) | Creates `IPAddressPool/metallb-layer2` with `addresses: ${loadbalancer_ip_range}` and `L2Advertisement/metallb-layer2` selecting that pool. |
+| `metallb/layer2` | (deprecated) | Compatibility shim that imports `../arp`. Will be dropped in v0.8.0 — switch to `metallb/arp` directly. |
+| `kube-vip` | `network.loadbalancer_driver: kube-vip` (the default) | Helm release of kube-vip v0.9.8 with service election enabled, plus a sidecar release for the kube-vip cloud-provider that handles IP allocation. |
+| `kube-vip/arp` | kube-vip + `network.loadbalancer_mode: arp` (default) | Patches the kube-vip HelmRelease to set `vip_arp: true` and `vip_routing_table: false` (gratuitous ARP advertisement, no BGP table). |
+
+## Dependencies
+
+| Add-on | Reason |
+|---|---|
+| `policy-resources` | `lb-base` `dependsOn` policy-resources on every platform that wires it. The lb namespace runs at PSA `privileged` and Kyverno policies inspect/exempt it; reconciling the helm release before policy CRDs exist would race. |
+
+`lb-resources` always depends on `lb-base` (the controller must be running
+before any `IPAddressPool` or `L2Advertisement` is created — without the
+MetalLB CRDs the apply fails on `no matches for kind IPAddressPool`).
+
+Reverse dependency: any add-on that owns a `Service` of type `LoadBalancer`
+or an `Ingress` reconciled by the AWS LBC declares `dependsOn: lb-base` so
+destroy ordering puts the controller last. The controller has to be alive
+to clear AWS finalizers (`service.k8s.aws/resources`,
+`elbv2.k8s.aws/resources`) when the consumer Service is deleted; if the
+controller is torn down first, those resources hang.
+
+## Operations
+
+Add-on-specific failure modes; generic Flux/Renovate behaviour is documented
+at the repo level.
+
+- **AWS LB Controller crashlooping with `failed to discover VPC`** — `vpc_id` or `aws_region` substitution didn't resolve. Check `terraform_output('network', 'vpc_id')` returned a value and that the deferred substitution propagated.
+- **AWS LB Controller starts but no AWS resources are created** — `clusterName` doesn't match the EKS / Pod Identity association. The IAM role's trust policy is scoped by cluster name; a mismatch fails silently with permission errors at API call time.
+- **MetalLB Service stuck in `Pending` with no external IP** — `loadbalancer_ip_range` is empty or doesn't cover any unused IPs. Confirm `network.loadbalancer_ips` in the context values resolves to a real range; check `kubectl get ipaddresspool -n system-lb -o yaml`.
+- **MetalLB IP allocated but unreachable** — speakers can't send gratuitous ARP. Usually a CNI / underlay network policy issue; the speaker DaemonSet runs at PSA `privileged` and needs host networking on every node.
+- **`lb-resources` reports `no matches for kind IPAddressPool`** — the MetalLB CRDs aren't ready. Either `lb-base` hasn't reconciled yet, or the chart version is mismatched with the CRD apiVersion (`metallb.io/v1beta1`).
+- **AWS LB stuck on destroy** — a consumer Service was torn down after `lb-base`. Re-reconcile `lb-base`, wait for the controller to come back, then delete the Service / Ingress.
+
+## Security
+
+- The `system-lb` namespace runs at PSA `privileged`. MetalLB speakers and kube-vip require NET_ADMIN and host networking; the AWS LB Controller does not but shares the namespace.
+- AWS LB Controller IAM is provided by IRSA or Pod Identity (the `serviceMutatorWebhook` is disabled — pods are not annotated). The associated IAM role is provisioned by the cluster Terraform module.
+- MetalLB advertises only IPs in `loadbalancer_ip_range`. The pool is namespace-scoped to `system-lb`; a Service requesting a `loadBalancerClass` MetalLB does not own will be ignored.
+
+## See also
+
+- [contexts/_template/facets/platform-aws.yaml](../../contexts/_template/facets/platform-aws.yaml) — AWS LBC wiring with `cluster_name` / `vpc_id` substitutions.
+- [contexts/_template/facets/platform-metal.yaml](../../contexts/_template/facets/platform-metal.yaml) — metal MetalLB wiring.
+- [contexts/_template/facets/platform-incus.yaml](../../contexts/_template/facets/platform-incus.yaml) — incus wiring (supports both metallb and kube-vip drivers).
+- [contexts/_template/facets/platform-base.yaml](../../contexts/_template/facets/platform-base.yaml) — `lb_effective` resolution (the internal config that folds `network.loadbalancer_driver` together with platform-specific overrides like docker-desktop's force-disable).
+- Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
+- Related add-ons: [policy](../policy/), [gateway](../gateway/).

--- a/docs/reference/kustomize/object-store.md
+++ b/docs/reference/kustomize/object-store.md
@@ -1,0 +1,159 @@
+---
+title: Object store add-on
+description: MinIO operator and tenant resources for S3-compatible object storage.
+---
+
+# Object store
+
+S3-compatible object storage backed by the MinIO operator. The operator
+runs in `system-object-store` and watches `Tenant` (minio.min.io/v2)
+resources cluster-wide; tenants instantiate actual MinIO server pools.
+
+The shipped `addon-object-store` facet wires only the operator (the
+`object-store-base` Kustomization). The tenant resources at
+`object-store/resources/common/` — a `Tenant` HelmRelease, mTLS
+certificate, root-credential generation Job, and supporting RBAC — are not
+emitted by any shipped facet. Blueprint authors who want a default tenant
+must wire `object-store/resources` themselves.
+
+`addons.object_store.driver: minio` is currently the only driver wired.
+
+## Flow
+
+```mermaid
+flowchart LR
+    consumer[Consumer pods<br/>S3 API client]
+
+    subgraph systemobjectstore[system-object-store]
+        operator[MinIO operator]
+        tenant[Tenant 'common'<br/>_unwired by addon_]
+        secret[(minio-root-creds Secret)]
+        cert[Certificate minio-private]
+        job[generate-minio-root-creds Job]
+    end
+
+    csi[(CSI PVC)]
+    issuer[ClusterIssuer 'private'<br/>from pki add-on]
+
+    job -->|creates| secret
+    cert -.issued by.-> issuer
+    operator -.reconciles.-> tenant
+    tenant -->|reads| secret
+    tenant -->|TLS from| cert
+    tenant -->|backs to| csi
+
+    consumer -->|S3 over mTLS| tenant
+```
+
+The operator alone is enough to deploy MinIO tenants — workloads can apply
+their own `Tenant` resources in any namespace. The shipped (but unwired)
+`resources/common/` set is a complete reference tenant: it issues a
+`Certificate` from the `private` ClusterIssuer (so the addon-private-ca
+trust path covers it), generates root credentials via a Job, and creates
+a single-pool tenant named `common`.
+
+## Recipes
+
+### Operator only (what `addon-object-store` ships)
+
+Sufficient for blueprints whose workloads define their own `Tenant`
+resources.
+
+```yaml
+- name: object-store-base
+  path: object-store/base
+  dependsOn: [csi]
+  components:
+    - minio
+  timeout: 10m
+  interval: 5m
+```
+
+### With the reference `common` tenant (manual wiring)
+
+Adds a `Tenant` HelmRelease, mTLS certificate, and root-credential Job.
+Single pool, 1 server, 1 volume, 1Gi PVC on the `single` StorageClass.
+
+```yaml
+- name: object-store-base
+  path: object-store/base
+  dependsOn: [csi]
+  components:
+    - minio
+
+- name: object-store-resources
+  path: object-store/resources
+  dependsOn: [object-store-base, pki-resources]
+  components:
+    - common
+  timeout: 10m
+  interval: 5m
+```
+
+The dependency on `pki-resources` is critical: the tenant Certificate
+references `ClusterIssuer/private`, which is created by the
+`addon-private-ca` facet's `pki-resources` entry. Without it, the
+Certificate stays `Pending` and the Tenant never gets a TLS Secret.
+
+## Substitutions
+
+This add-on does not consume any blueprint substitutions. All tenant
+configuration is in the shipped manifests.
+
+## Components
+
+### `object-store/base/`
+
+| Component | Enable when | Effect |
+|---|---|---|
+| `minio` | `addons.object_store.driver: minio` | Helm release of the MinIO operator chart v7.1.1 in `system-object-store`. Operator image v7.1.1, runAsUser 1000, fsGroup 1000. Adds `use-custom-ca: "true"` label to operator pods so trust-manager distributes the private CA bundle when the addon-private-ca path is enabled. |
+
+The base directory also contains a [`git-repository.yaml`](base/minio/git-repository.yaml)
+referencing the upstream MinIO operator git repo. It is **not included** in
+`base/minio/kustomization.yaml` (which lists only `helm-repository.yaml`
+and `helm-release.yaml`) — the file is a stray and currently has no
+effect. The HelmRepository at `https://operator.min.io` is what actually
+sources the operator chart.
+
+### `object-store/resources/`
+
+The base kustomization is empty (`resources: []`). The single subcomponent
+provides a reference tenant.
+
+| Component | Effect |
+|---|---|
+| `common` | Bundle of: `Tenant/common` HelmRelease (1 pool, 1 server, 1 volume, 1Gi PVC on the `single` StorageClass, mountPath `/export`, subPath `/data`); `Certificate/minio-private` issued by the `private` ClusterIssuer with SANs covering `common-hl.system-object-store.svc.cluster.local` and `minio.system-object-store.svc.cluster.local` (plus wildcards); `Job/generate-minio-root-creds` that randomizes a 12-byte access key and 16-byte secret key on first reconcile and stores them in the `minio-root-creds` Secret; supporting `ServiceAccount`, `Role`, `RoleBinding` for the Job. Ingress is disabled — exposure is the consumer's responsibility. |
+
+## Dependencies
+
+| Add-on | Reason |
+|---|---|
+| `csi` | The MinIO operator does not allocate PVCs eagerly, but tenant pools do. The shipped reference tenant requests a 1Gi PVC on StorageClass `single`; without a CSI driver, tenant pods stay `Pending`. |
+| `pki-resources` *(only when wiring `resources/common`)* | The reference tenant's `Certificate` references `ClusterIssuer/private`, which is created by `addon-private-ca`'s `pki-resources` entry. Wiring `object-store/resources` without `addon-private-ca` enabled produces a Certificate stuck `Pending`. |
+
+## Operations
+
+Add-on-specific failure modes; generic Flux/Renovate behaviour is documented
+at the repo level.
+
+- **`Tenant` reconciles but pods stay `Pending`** — PVC scheduling. The reference tenant uses StorageClass `single` and 1 volume per server; check `kubectl get pvc -n system-object-store` and the StorageClass's `volumeBindingMode` (it's `WaitForFirstConsumer` on the cloud paths, so the volume only provisions when the Pod schedules).
+- **Tenant pods crashloop with `tls: bad certificate`** — the Certificate isn't ready or the `minio-private-tls` Secret hasn't been created yet. Confirm `kubectl get certificate -n system-object-store minio-private` shows `READY=True`. The Tenant references `minio-private-tls` via `externalCertSecret` — until cert-manager populates it, the operator can't bring up MinIO over HTTPS.
+- **Root credentials missing** — the `generate-minio-root-creds` Job didn't run or hasn't finished. The Job has `ttlSecondsAfterFinished: 86400` (24h) and the manifest is annotated `kustomize.toolkit.fluxcd.io/force: enabled` so Flux re-applies on every reconcile. Check `kubectl get job -n system-object-store` and the Job's logs.
+- **External clients can't reach the tenant** — by design. The reference tenant has `ingress.api.enabled: false` and `ingress.console.enabled: false`. To expose externally, add an HTTPRoute or Ingress and update the Certificate SANs to cover the external hostname.
+- **`HelmRelease/cluster-tenant` reports `no matches for kind Tenant`** — the operator hasn't installed the Tenant CRD. The CRDs ship with the operator chart; reconcile `object-store-base` before `object-store-resources`.
+
+## Security
+
+- The `system-object-store` namespace runs at PSA `baseline`. The namespace is also labeled `use-custom-ca: "true"`, so trust-manager's Bundle (from `addon-private-ca`) distributes the cluster's private CA to it.
+- The operator pod runs `runAsUser: 1000`, `fsGroup: 1000`. The credential-generation Job runs `runAsNonRoot: true`, drops all capabilities, and uses `seccompProfile: RuntimeDefault`.
+- mTLS for the tenant is enforced via `requestAutoCert: false` + `externalCertSecret` referencing the cert-manager-issued `minio-private-tls`. There is no in-tree certificate generation; everything flows through the `pki` add-on.
+- Root credentials are generated in-cluster (12-byte hex access key, 16-byte hex secret key) by the bootstrap Job. They're stored in the `minio-root-creds` Secret in `system-object-store`. Tenant workloads needing the root credentials must reference this Secret directly; consider rotating before exposing the tenant.
+- Tenant ingress (API and console) is disabled by default. Exposing the tenant externally is the consumer's responsibility — add an HTTPRoute and update the Certificate SANs.
+
+## See also
+
+- [contexts/_template/facets/addon-object-store.yaml](../../contexts/_template/facets/addon-object-store.yaml) — canonical wiring of the operator. Note that `object-store/resources` is NOT wired by this facet.
+- [base/minio/git-repository.yaml](base/minio/git-repository.yaml) — stray file not included in the kustomization. Unused.
+- Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
+- MinIO operator docs — https://min.io/docs/minio/kubernetes/upstream/
+- Related add-ons: [csi](../csi/), [pki](../pki/).

--- a/docs/reference/kustomize/observability.md
+++ b/docs/reference/kustomize/observability.md
@@ -1,0 +1,299 @@
+---
+title: Observability add-on
+description: Grafana, fluentd aggregator, and pluggable log storage (stdout, Quickwit, Elasticsearch+Kibana).
+---
+
+# Observability
+
+Visualization (Grafana) plus the log sink for the telemetry pipeline. The
+`observability` Kustomization is unusual in that it has **no `base/` or
+`resources/` split** — every component lives directly under
+`kustomize/observability/`, and four different facets contribute components
+to the same Kustomization name:
+
+- `platform-base` always emits the fluentd aggregator when `logs_driver == 'fluentd'` (even without `addons.observability.enabled`). Without addon-observability, fluentd runs as a terminal receiver with no output; the pipeline shape stays intact so enabling the addon later doesn't reconfigure telemetry.
+- `addon-observability` (gated on `addons.observability.enabled == true`) adds Grafana, dashboards, the gateway route, and the chosen log-storage backend.
+- `option-cni` adds `grafana/dashboards/cilium` when `dashboards == 'grafana'`.
+- Other facets (`option-storage`, `addon-database`) add their own dashboards the same way.
+
+## Flow
+
+```mermaid
+flowchart LR
+    fb[fluent-bit DaemonSet<br/>_from telemetry stack_]
+
+    subgraph systemobservability[system-observability]
+        fluentd[fluentd aggregator]
+        grafana[Grafana]
+        quickwit[Quickwit]
+        es[Elasticsearch + Kibana]
+    end
+
+    user([Operator])
+    prom[Prometheus<br/>_from telemetry_]
+
+    fb -->|forward 24224| fluentd
+    fluentd -->|stdout| stdout[(container stdout)]
+    fluentd -->|push| quickwit
+    fb -.elasticsearch driver.-> es
+
+    user -->|HTTPRoute via gateway| grafana
+    user -->|HTTPRoute via gateway| es
+    grafana -.queries.-> prom
+    grafana -.queries.-> quickwit
+```
+
+`platform-base` is responsible for fluentd; `addon-observability` is
+responsible for Grafana and the storage backend. Choosing
+`logs_driver: elasticsearch` is special — it replaces `telemetry-base` and
+`telemetry-resources` entirely, swapping fluent-bit for filebeat (which
+ships directly to Elasticsearch and bypasses fluentd).
+
+## Recipes
+
+`addons.observability.enabled` toggles the Grafana / storage path. Even with
+the addon off, fluentd still runs from `platform-base` if
+`telemetry.logs.driver` is `fluentd` (the default).
+
+### Default (addon enabled, no external log store)
+
+Grafana plus fluentd as a terminal receiver. Logs are buffered and dropped;
+useful for trying observability without committing storage.
+
+```yaml
+- name: observability
+  path: observability
+  dependsOn: [telemetry-base, dns]
+  components:
+    - grafana
+    - grafana/prometheus
+    - grafana/dashboards/node
+    - grafana/dashboards/kubernetes
+    - grafana/dashboards/flux
+    - grafana/dashboards/cert-manager
+    - grafana/dashboards/fluent-bit
+    - grafana/dashboards/fluentd
+    - fluentd
+    - fluentd/filters/otel
+    - fluentd/prometheus
+    - fluentd/filters/log-level/info
+  substitutions:
+    external_domain: example.internal
+    timezone: UTC
+    date_full: "YYYY-MM-DD HH:mm:ss"
+```
+
+### With Gateway HTTPRoute
+
+When the cluster has a Gateway, layer in the `grafana/gateway` HTTPRoute and
+(on Envoy) the envoy dashboards.
+
+```yaml
+- name: observability
+  path: observability
+  dependsOn: [telemetry-base, dns, gateway-resources]
+  components:
+    - grafana
+    - grafana/prometheus
+    - grafana/gateway
+    - grafana/dashboards/envoy
+    # ... plus the dashboards from the previous recipe
+    - fluentd
+    - fluentd/filters/otel
+    - fluentd/prometheus
+    - fluentd/filters/log-level/info
+  substitutions:
+    external_domain: example.internal
+```
+
+### Quickwit logs
+
+Set `addons.observability.logs_driver: quickwit`. Full sink add-on with a
+PVC-backed staging directory; depends on a CSI driver.
+
+```yaml
+- name: observability
+  path: observability
+  dependsOn: [telemetry-base, dns, csi, telemetry-resources]
+  components:
+    - grafana
+    - grafana/prometheus
+    - grafana/quickwit
+    - grafana/dashboards/logs/quickwit
+    - fluentd
+    - fluentd/outputs/quickwit
+    - fluentd/filters/otel
+    - fluentd/prometheus
+    - quickwit
+    - quickwit/pvc
+    - quickwit/prometheus
+```
+
+### Elasticsearch + Kibana
+
+`addons.observability.logs_driver: elasticsearch`. This recipe **replaces**
+`telemetry-base` and `telemetry-resources` (filebeat → Elasticsearch directly,
+no fluent-bit, no fluentd). Requires a Gateway for Kibana's HTTPRoute.
+
+```yaml
+- name: telemetry-base
+  path: telemetry/base
+  strategy: replace
+  components:
+    - prometheus
+    - prometheus/flux
+    - filebeat
+
+- name: telemetry-resources
+  path: telemetry/resources
+  strategy: replace
+  dependsOn: [telemetry-base]
+  components:
+    - metrics-server
+    - prometheus
+    - prometheus/flux
+
+- name: observability
+  path: observability
+  dependsOn: [telemetry-base, dns, csi, gateway-resources]
+  components:
+    - grafana
+    - grafana/prometheus
+    - elasticsearch
+    - kibana
+    - kibana/gateway
+  substitutions:
+    external_domain: example.com
+```
+
+Talos clusters running Elasticsearch must apply
+`vm.max_map_count: 262144` in machine config; see
+[elasticsearch/README.md](elasticsearch/README.md).
+
+## Substitutions
+
+| Name | Required when | Effect |
+|---|---|---|
+| `external_domain` | always | Hostname (and wildcard) on the Grafana / Kibana HTTPRoutes. Resolved from `dns.public_domain` if set, otherwise `dns.private_domain`. |
+| `timezone` | always | Grafana default timezone (`grafana.ini` → `default.timezone`). Stamped from the context-level `timezone` value; falls back to `utc`. |
+| `date_full`, `date_interval_*` | always (with fallbacks) | Grafana date format strings, switched between 12h and 24h based on the context-level `time_format`. Each has a kustomize fallback so dropping the substitution doesn't break panels. |
+| `admin_password` | optional | Grafana admin password. Falls back to `grafana` (the `option-dev` default). Production should set this via secret-mgr. |
+
+## Components
+
+The component tree is large. Components group by subsystem:
+
+### `grafana/`
+
+| Component | Effect |
+|---|---|
+| `grafana` | Helm release of Grafana v10.5.15 in `system-observability`. Image v13.0.1. Sidecars import dashboards from labeled ConfigMaps. |
+| `grafana/dev` | Patches the helm release to set `adminPassword: ${admin_password:-grafana}` for dev clusters. |
+| `grafana/prometheus` | Configures the Prometheus datasource pointing at the kube-prometheus-stack instance in `system-telemetry`. |
+| `grafana/quickwit` | Configures the Quickwit datasource (only when logs_driver=quickwit). |
+| `grafana/gateway` | HTTPRoute on the cluster's Gateway exposing Grafana at `grafana.${external_domain}`. |
+| `grafana/ingress` | Plain Kubernetes Ingress (alternative to gateway when no Gateway API controller is installed). |
+| `grafana/cert-manager` | Datasource / config for the cert-manager dashboard. |
+| `grafana/cloudnativepg` | Datasource for the CloudNativePG dashboard. |
+| `grafana/flux` | Datasource for the Flux dashboard. |
+| `grafana/kubernetes` | Datasource for the Kubernetes overview dashboards. |
+| `grafana/nginx` | Datasource for the nginx-ingress dashboard. |
+| `grafana/node` | Datasource for the node-exporter dashboard. |
+
+### `grafana/dashboards/`
+
+Each subdirectory is a ConfigMap dashboard (Grafana's sidecar imports them by
+label). Always-on dashboards are wired from `addon-observability`; the rest
+are added by their respective owner facets.
+
+| Component | Wired by | Effect |
+|---|---|---|
+| `grafana/dashboards/node` | addon-observability | Standard node-exporter dashboard. |
+| `grafana/dashboards/kubernetes` | addon-observability | Multi-cluster Kubernetes overview. |
+| `grafana/dashboards/flux` | addon-observability | Flux controllers and reconciliation status. |
+| `grafana/dashboards/cert-manager` | addon-observability | cert-manager controller / certificate health. |
+| `grafana/dashboards/fluent-bit` | addon-observability | fluent-bit metrics. |
+| `grafana/dashboards/fluentd` | addon-observability | fluentd aggregator metrics. |
+| `grafana/dashboards/envoy` | addon-observability (Envoy gateway only) | Envoy data-plane metrics. |
+| `grafana/dashboards/cilium` | option-cni (when dashboards=grafana) | Cilium agent and operator metrics. |
+| `grafana/dashboards/cloudnativepg` | addon-database | CloudNativePG cluster health. |
+| `grafana/dashboards/longhorn` | option-storage | Longhorn volumes / replicas. |
+| `grafana/dashboards/logs/quickwit` | addon-observability (logs_driver=quickwit) | Logs panel populated from the Quickwit datasource. |
+| `grafana/dashboards/nginx` | *(unwired)* | nginx ingress metrics. Available for manual blueprint wiring; not in any shipped facet. |
+| `grafana/dashboards/prometheus` | *(unwired)* | Prometheus self-monitoring. Available for manual blueprint wiring; not in any shipped facet. |
+| `grafana/dashboards/quickwit` | *(unwired)* | Quickwit operator metrics. Exists on disk but not in any shipped facet — `addon-observability` pulls in `grafana/dashboards/logs/quickwit` (the logs panel) but not this one. |
+| `grafana/dashboards/logs` | *(unwired)* | Logs panel framework. Exists on disk but not referenced by any facet. |
+
+### `fluentd/`
+
+| Component | Wired by | Effect |
+|---|---|---|
+| `fluentd` | platform-base (when logs_driver=fluentd) | `Fluentd` CR (replicas: 1) in `system-observability` listening on TCP 24224 for forward protocol. ClusterFluentdConfig selects all configs labeled `config.fluentd.fluent.io/enabled: "true"`. |
+| `fluentd/prometheus` | platform-base (when `telemetry.metrics.enabled: true`) | ServiceMonitor for fluentd's own metrics. |
+| `fluentd/filters/otel` | platform-base | OpenTelemetry filter normalizing fields. |
+| `fluentd/filters/log-level/{debug,info,warn,error}` | platform-base (one chosen by `log_level`) | Drops records below the configured severity. `log_level: 'trace'` skips this component entirely (passes everything). |
+| `fluentd/outputs/stdout` | addon-observability (logs_driver=stdout) | ClusterOutput writing to fluentd's container stdout. |
+| `fluentd/outputs/quickwit` | addon-observability (logs_driver=quickwit) | ClusterOutput pushing to Quickwit's ingest API. |
+
+### `quickwit/`
+
+| Component | Wired by | Effect |
+|---|---|---|
+| `quickwit` | addon-observability (logs_driver=quickwit) | Helm release of Quickwit. |
+| `quickwit/pvc` | addon-observability (logs_driver=quickwit) | PVC for Quickwit's staging / index data. Requires a `csi` driver. |
+| `quickwit/prometheus` | addon-observability (logs_driver=quickwit) | ServiceMonitor for Quickwit. |
+
+### `elasticsearch/` and `kibana/`
+
+| Component | Wired by | Effect |
+|---|---|---|
+| `elasticsearch` | addon-observability (logs_driver=elasticsearch) | Helm release of Elasticsearch. Talos requires `vm.max_map_count: 262144` in machine sysctls — see [elasticsearch/README.md](elasticsearch/README.md). |
+| `kibana` | addon-observability (logs_driver=elasticsearch) | Helm release of Kibana. |
+| `kibana/gateway` | addon-observability (logs_driver=elasticsearch) | HTTPRoute exposing Kibana via the cluster Gateway. Required because Kibana has no other path out. |
+| `kibana/ingress` | (consumer-wired) | Plain Ingress alternative to the Gateway route. |
+
+## Dependencies
+
+`observability` is contributed to by multiple facets, so dependencies vary
+per facet entry. Common patterns:
+
+| Add-on | Reason |
+|---|---|
+| `telemetry-base` | Grafana points at the Prometheus instance from telemetry; fluentd inherits CRDs from fluent-operator (also installed by telemetry-base). |
+| `dns` | Conditional. Grafana's HTTPRoute hostname is reconciled via external-dns; without `dns` the record never publishes. |
+| `gateway-resources` | When wiring `grafana/gateway` or `kibana/gateway`. The Gateway must exist before the HTTPRoute is applied. |
+| `csi` | When wiring `quickwit/pvc` or `elasticsearch` — both need persistent volumes. |
+| `telemetry-resources` | When `logs_driver` is stdout or quickwit — fluentd outputs reference fluent-bit's ClusterFluentdConfig from telemetry-resources. |
+
+## Operations
+
+Add-on-specific failure modes; generic Flux/Renovate behaviour is documented
+at the repo level.
+
+- **Grafana panels show "no data" but Prometheus has metrics** — the `grafana/prometheus` datasource isn't configured or points at the wrong service. Check the Grafana ConfigMap with the datasource definition.
+- **Logs reach fluentd but disappear** — no ClusterOutput is configured. When `addons.observability.enabled` is false but `logs_driver: fluentd`, fluentd runs as a terminal receiver and buffers. Set `addons.observability.logs_driver` to `stdout` (cheapest) to emit somewhere.
+- **`quickwit/pvc` stuck `Pending`** — CSI driver isn't ready. Check `csi` Kustomization status and the StorageClass referenced by the PVC.
+- **Elasticsearch pods crash on Talos with `max virtual memory areas vm.max_map_count too low`** — required Talos sysctl missing. Apply `vm.max_map_count: 262144` in the machine config; see [elasticsearch/README.md](elasticsearch/README.md). This is a Talos-only requirement.
+- **Switching between log drivers leaves stale ClusterOutputs** — fluentd's selectors are label-based, so an unmatched ClusterOutput is harmless. To clean up, delete the resource by hand (Flux removes it on the next reconcile after the component is dropped).
+- **Kibana HTTPRoute returns 404** — `kibana/gateway` was applied before `gateway-resources` finished. Reconcile order should prevent this; if it fires, re-reconcile `observability`.
+
+Grafana exposes its own metrics at `/metrics` on the same port as the UI;
+node-exporter, kube-state-metrics, and Prometheus itself feed into the
+default dashboards.
+
+## Security
+
+- `system-observability` runs at PSA `baseline` and is labeled `use-custom-ca: "true"`. The label opts the namespace into the trust-manager Bundle from `addon-private-ca` so Grafana / Kibana / Elasticsearch trust the private CA when issued certs from it.
+- Grafana admin credentials default to `admin/grafana` via `grafana/dev`. Production blueprints should override `admin_password` from a secret store (the helm release values use `${admin_password:-grafana}` so the substitution wins when set).
+- Kibana exposes Elasticsearch query / config UI; the HTTPRoute relies on the Gateway TLS cert from `pki` for transport security but does not enforce auth. If exposing publicly, layer authentication in front.
+- fluentd's forward port (24224) is namespace-scoped; only fluent-bit pods (in `system-telemetry`) reach it via the cluster network. No external listener.
+- Quickwit's ingest API is internal only by default — if exposing to other clusters, add an HTTPRoute and authentication.
+
+## See also
+
+- [contexts/_template/facets/addon-observability.yaml](../../contexts/_template/facets/addon-observability.yaml) — Grafana, dashboards, log-driver branching, and the Elasticsearch telemetry replacement.
+- [contexts/_template/facets/platform-base.yaml](../../contexts/_template/facets/platform-base.yaml) (lines ~462-473) — fluentd aggregator wiring, runs even without the addon when logs_driver=fluentd.
+- [contexts/_template/facets/option-cni.yaml](../../contexts/_template/facets/option-cni.yaml) — example of a sibling facet patching dashboards into observability.
+- [elasticsearch/README.md](elasticsearch/README.md) — Talos sysctl prerequisite for Elasticsearch.
+- Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
+- Related add-ons: [telemetry](../telemetry/), [pki](../pki/), [gateway](../gateway/), [dns](../dns/), [csi](../csi/), [database](../database/).

--- a/docs/reference/kustomize/observability/elasticsearch.md
+++ b/docs/reference/kustomize/observability/elasticsearch.md
@@ -1,0 +1,14 @@
+---
+title: "Elasticsearch Configuration Requirements"
+description: "Operator notes from kustomize/observability/elasticsearch (generated; edit README in kustomize/)."
+---
+
+# Elasticsearch Configuration Requirements
+
+For Elasticsearch to work properly on Talos Linux nodes, the following sysctl configuration must be applied in the Talos machine configuration:
+
+```
+"machine":
+  "sysctls":
+    "vm.max_map_count": 262144
+```

--- a/docs/reference/kustomize/pki.md
+++ b/docs/reference/kustomize/pki.md
@@ -1,0 +1,252 @@
+---
+title: PKI add-on
+description: cert-manager and trust-manager operators with private and public ClusterIssuers.
+---
+
+# PKI
+
+cert-manager issues TLS certificates from one or more ClusterIssuers. trust-manager
+distributes the private CA bundle to opted-in namespaces. The add-on is split into
+two kustomizations so the operators (`pki/base`) bootstrap before any issuer
+(`pki/resources`) tries to create CRD instances.
+
+## Flow
+
+```mermaid
+flowchart LR
+    cert[Certificate resource]
+    workload[Gateway / Workload]
+
+    subgraph systempki[system-pki / system-pki-trust]
+        cm[cert-manager]
+        issuers{ClusterIssuer<br/>private<br/>public-selfsigned<br/>public-acme}
+        secret[(TLS Secret)]
+        ca[(private-ca-cert)]
+        tm[trust-manager Bundle]
+    end
+
+    dns01[Route 53 / Azure DNS]
+    cmap[ConfigMap private-ca<br/>in labeled namespaces]
+
+    cert --> cm --> issuers --> secret
+    secret -.->|mounted by| workload
+    issuers -.DNS-01.-> dns01
+    issuers -.signs with.-> ca
+    ca --> tm --> cmap
+```
+
+cert-manager runs in `system-pki` (PSA baseline). trust-manager runs in
+`system-pki-trust` (PSA restricted). The DNS-01 path is only exercised by the
+`public-acme` issuer; the CA distribution path is only exercised when the
+private-ca addon is enabled.
+
+## Recipes
+
+`pki-base` is always rendered (cert-manager is required by every other add-on
+that issues certs). `pki-resources` is rendered conditionally — platform and
+context-level facets contribute one issuer per cluster, and `addon-private-ca`
+adds another. Multiple facets can contribute components to the same `pki-base`
+and `pki-resources` entries; the materialized component list is the union.
+
+The recipes below show that materialized union for common combinations.
+
+### Single-node local dev (no private-CA addon)
+
+Set `addons.private_ca.enabled: false` if you don't want the trust-manager
+distribution path. Otherwise see the addon-private-ca recipe at the bottom.
+
+```yaml
+- name: pki-base
+  path: pki/base
+  components:
+    - cert-manager
+    - cert-manager/single-node
+
+- name: pki-resources
+  path: pki/resources
+  dependsOn: [pki-base]
+  components:
+    - public-issuer/selfsigned
+```
+
+### AWS without a public domain
+
+Bootstrap mode. The gateway gets a self-signed cert from `public-selfsigned`;
+browsers warn but the cluster is reachable. Setting `dns.public_domain` later
+flips the issuer to `public-acme` and cert-manager re-issues automatically.
+
+```yaml
+- name: pki-base
+  path: pki/base
+  dependsOn: [policy-resources, telemetry-base]
+  components:
+    - cert-manager
+    - cert-manager/prometheus
+  timeout: 20m
+
+- name: pki-resources
+  path: pki/resources
+  dependsOn: [pki-base, policy-resources]
+  components:
+    - public-issuer/selfsigned
+```
+
+### AWS with a public domain
+
+Let's Encrypt via Route 53 DNS-01. The cluster module provisions IAM (Pod
+Identity, Route 53 zone permissions) so cert-manager can write TXT records.
+
+```yaml
+- name: pki-resources
+  path: pki/resources
+  dependsOn: [pki-base, policy-resources]
+  components:
+    - public-issuer/acme/route53
+  substitutions:
+    acme_server: https://acme-v02.api.letsencrypt.org/directory
+    acme_email: ops@example.com
+    acme_dns_zone: example.com
+    acme_region: us-east-1
+    acme_hosted_zone_id: Z1234567890ABC
+```
+
+### Azure with a public domain
+
+Same as AWS but the cert-manager pod uses Azure workload identity (added by
+the `cert-manager/azure-workload-identity` component) and DNS-01 runs against
+Azure DNS.
+
+```yaml
+- name: pki-base
+  path: pki/base
+  components:
+    - cert-manager
+    - cert-manager/prometheus
+    - cert-manager/azure-workload-identity
+  substitutions:
+    cert_manager_client_id: <UAMI client id>
+    cert_manager_tenant_id: <tenant id>
+
+- name: pki-resources
+  path: pki/resources
+  dependsOn: [pki-base, policy-resources]
+  components:
+    - public-issuer/acme/azuredns
+  substitutions:
+    acme_server: https://acme-v02.api.letsencrypt.org/directory
+    acme_email: ops@example.com
+    acme_dns_zone: example.com
+    acme_dns_zone_resource_group: dns-rg
+    acme_dns_zone_subscription_id: <sub id>
+    cert_manager_client_id: <UAMI client id>
+```
+
+### addon-private-ca on top of any of the above
+
+Adds trust-manager and a CA-backed `private` ClusterIssuer. Layers on top of
+the platform's existing `pki-base` and `pki-resources`, adding components
+rather than replacing them.
+
+```yaml
+- name: pki-base
+  path: pki/base
+  components:
+    - trust-manager
+
+- name: pki-resources
+  path: pki/resources
+  dependsOn: [pki-base, policy-resources]
+  components:
+    - private-issuer/ca
+```
+
+## Substitutions
+
+| Name | Required when | Effect |
+|---|---|---|
+| `cert_manager_client_id` | `cert-manager/azure-workload-identity` is enabled | UAMI client ID stamped onto the cert-manager ServiceAccount and the ACME issuer's `managedIdentity.clientID`. |
+| `cert_manager_tenant_id` | `cert-manager/azure-workload-identity` is enabled | Azure tenant ID stamped onto the cert-manager ServiceAccount. |
+| `acme_server` | `public-issuer/acme/*` is enabled | ACME directory URL. Use staging in dev to avoid Let's Encrypt rate limits. |
+| `acme_email` | `public-issuer/acme/*` is enabled | Account email Let's Encrypt registers against; required by the ACME protocol. |
+| `acme_dns_zone` | `public-issuer/acme/*` is enabled | DNS zone the DNS-01 solver writes TXT records into. |
+| `acme_region` | `public-issuer/acme/route53` is enabled | AWS region for the Route 53 API call. |
+| `acme_hosted_zone_id` | `public-issuer/acme/route53` is enabled | Route 53 hosted zone ID; locks the solver to one zone. |
+| `acme_dns_zone_resource_group` | `public-issuer/acme/azuredns` is enabled | Azure resource group containing the DNS zone. |
+| `acme_dns_zone_subscription_id` | `public-issuer/acme/azuredns` is enabled | Azure subscription ID containing the DNS zone. |
+
+## Components
+
+### `pki/base/`
+
+| Component | Enable when | Effect |
+|---|---|---|
+| `cert-manager` | always (default platform path) | Helm release of cert-manager in `system-pki`. CRDs enabled. |
+| `cert-manager/single-node` | `topology: single-node` | Disables leader election on the controller and cainjector. |
+| `cert-manager/prometheus` | `telemetry.metrics.enabled: true` | Enables the chart's ServiceMonitor with the `kube-prometheus-stack` release label, and adds a Flux `dependsOn` so cert-manager waits for kube-prometheus-stack to be ready. |
+| `cert-manager/azure-workload-identity` | platform is Azure with a public domain | Adds Azure workload-identity labels and annotations to the cert-manager ServiceAccount and pods. |
+| `trust-manager` | `addons.private_ca.enabled == true` | Helm release of trust-manager in `system-pki-trust`. Flux waits for cert-manager. |
+| `trust-manager/single-node` | single-node + private-ca | Disables leader election on trust-manager. |
+
+### `pki/resources/`
+
+Each component creates exactly one ClusterIssuer (and supporting resources for
+the CA path). Components are mutually exclusive within their family — pick
+one private-issuer/* if any, and one public-issuer/* if any.
+
+| Component | ClusterIssuer name | Effect |
+|---|---|---|
+| `private-issuer/selfsigned` | `private` (selfSigned) | Bare self-signed issuer; useful for private-mode gateways without the full CA distribution. |
+| `private-issuer/ca` | `private` (CA) | Self-signed root + intermediate Certificate, trust-manager Bundle distributing the CA to namespaces labeled `use-custom-ca=true`, and a Kyverno ClusterPolicy that mounts the bundle into pods labeled `use-custom-ca=true`. |
+| `public-issuer/selfsigned` | `public-selfsigned` (selfSigned) | Self-signed public issuer; used as the initial bootstrap before a real public domain is configured. |
+| `public-issuer/acme/route53` | `public-acme` (ACME, DNS-01 via Route 53) | Let's Encrypt issuer that solves DNS-01 against a Route 53 hosted zone. |
+| `public-issuer/acme/azuredns` | `public-acme` (ACME, DNS-01 via Azure DNS) | Let's Encrypt issuer that solves DNS-01 against an Azure DNS zone. |
+
+`private-issuer/selfsigned` and `private-issuer/ca` both create a ClusterIssuer
+named `private` and conflict if both are enabled — pick one. The two
+`public-issuer/*` variants emit distinct names (`public-selfsigned` and
+`public-acme`) and can coexist, though typically only one is wired. The
+distinct public names are deliberate: swapping between them shows up to
+cert-manager as a Certificate spec change and triggers reissuance, where
+mutating one shared `public` issuer in place would not.
+
+## Dependencies
+
+| Add-on | Reason |
+|---|---|
+| `policy-resources` *(when policies enabled)* | `private-issuer/ca` ships a Kyverno ClusterPolicy that mounts the CA bundle into opted-in pods. Flux fails the apply on `no matches for kind ClusterPolicy` if Kyverno's CRDs aren't installed. |
+| `telemetry-base` *(when `telemetry.metrics.enabled: true` or `telemetry.logs.enabled: true`)* | `cert-manager/prometheus` enables a ServiceMonitor with `release: kube-prometheus-stack`; without telemetry-base the ServiceMonitor has no Prometheus to register against. |
+
+`pki-resources` always depends on `pki-base` (the operators must be running before any ClusterIssuer is created).
+
+## Operations
+
+Add-on-specific failure modes; generic Flux/Renovate behaviour is documented
+at the repo level.
+
+- **`Certificate` stuck in `Issuing` for the ACME issuer** — DNS-01 challenge isn't solving. For Route 53 confirm Pod Identity is bound to the cert-manager ServiceAccount and the IAM policy covers the hosted zone. For Azure DNS confirm the UAMI client ID matches `cert_manager_client_id` and the role assignment on the resource group is in place.
+- **`HelmRelease/trust-manager` reports `no matches for kind Bundle`** — trust-manager hasn't installed or its CRDs aren't ready yet. Check the cert-manager Flux `dependsOn` chain (trust-manager waits for cert-manager).
+- **`HelmRelease/pki-resources` reports `no matches for kind ClusterPolicy`** — `private-issuer/ca` is enabled but `policy-resources` (Kyverno) hasn't installed. The hard `dependsOn` in `addon-private-ca` should prevent this; if it fires, confirm policies are not disabled.
+- **Switching from `public-selfsigned` to `public-acme` doesn't reissue** — cert-manager only reissues on Certificate spec changes. The Gateway cert references `gateway_cert_issuer`, which option-gateway switches based on `dns.public_domain`. If the substitution isn't flowing through, the spec doesn't change and the cert stays on the old issuer.
+
+cert-manager exposes Prometheus metrics when `cert-manager/prometheus` is
+enabled; a ServiceMonitor with `release: kube-prometheus-stack` registers it
+with the telemetry add-on.
+
+## Security
+
+- cert-manager runs in `system-pki` with PSA `baseline`. trust-manager runs in `system-pki-trust` with PSA `restricted`.
+- The `private-ca` Certificate is self-signed (root) with `isCA: true`, 1-year duration and 30-day renewBefore. The signing key lives in the `private-ca-cert` Secret in `system-pki`.
+- The trust-manager Bundle distributes the CA only to namespaces labeled `use-custom-ca=true`. Workloads in unlabeled namespaces never see the bundle.
+- The `inject-private-ca` Kyverno ClusterPolicy only matches Pods labeled `use-custom-ca=true` and operates as a `mutate` rule — it does not block other workloads.
+- ACME identity:
+  - Route 53: Pod Identity association created by the cluster module, scoped to the hosted zone via `acme_hosted_zone_id`.
+  - Azure DNS: workload identity (UAMI), scoped to the resource group via `acme_dns_zone_resource_group`.
+
+## See also
+
+- [contexts/_template/facets/platform-base.yaml](../../contexts/_template/facets/platform-base.yaml) — base wiring of `pki-base`.
+- [contexts/_template/facets/addon-private-ca.yaml](../../contexts/_template/facets/addon-private-ca.yaml) — private-CA addon (trust-manager + private-issuer/ca).
+- [contexts/_template/facets/platform-aws.yaml](../../contexts/_template/facets/platform-aws.yaml) — AWS public-issuer wiring.
+- [contexts/_template/facets/platform-azure.yaml](../../contexts/_template/facets/platform-azure.yaml) — Azure public-issuer wiring.
+- Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
+- Related add-ons: [policy](../policy/), [telemetry](../telemetry/), [gateway](../gateway/), [dns](../dns/).

--- a/docs/reference/kustomize/policy.md
+++ b/docs/reference/kustomize/policy.md
@@ -1,0 +1,181 @@
+---
+title: Policy add-on
+description: Kyverno admission policies for image digest enforcement, resource limits, and the controllers that back them.
+---
+
+# Policy
+
+Kyverno is the cluster's admission policy engine. The `policy-base`
+Kustomization installs the Kyverno controllers; `policy-resources` applies
+the ClusterPolicy resources that enforce or audit cluster-wide rules.
+
+This add-on is depended on by nearly every other add-on — the namespace runs
+at PSA `baseline` and the cluster's mutation policies (private-CA injection,
+LBIPAM IP sharing on Cilium gateways, docker-desktop DNS rewriting) all
+require Kyverno's CRDs to apply.
+
+## Flow
+
+```mermaid
+flowchart LR
+    request[Pod / Service create or update]
+    api[K8s API server]
+    crds[(ClusterPolicy / Policy<br/>resources)]
+    reportcrds[(PolicyReport)]
+    cleanupcrd[(CleanupPolicy)]
+
+    subgraph systempolicy[system-policy]
+        admission[admission-controller]
+        bg[background-controller]
+        reports[reports-controller<br/>optional]
+        cleanup[cleanup-controller<br/>optional]
+    end
+
+    request --> api
+    api -.AdmissionReview.-> admission
+    admission -->|reads| crds
+    admission -->|allow / deny / mutate| api
+    bg -.periodic re-eval.-> crds
+    reports -.writes.-> reportcrds
+    cleanup -.cron.-> cleanupcrd
+```
+
+The `admission-controller` and `background-controller` always run when
+`policy-base` is installed. The `reports-controller` and `cleanup-controller`
+are off by default — they ship with the chart but are toggled on by
+`kyverno/reports` and `kyverno/cleanup` components when the operator opts in.
+
+## Recipes
+
+`policy-base` and `policy-resources` are gated on `policies.enabled` (default
+`true`). Setting `policies.enabled: false` skips both Kustomizations entirely;
+this is the opt-out for clusters that don't want admission control. It will
+break add-ons that depend on `policy-resources` to install ClusterPolicies, so
+review consumers before disabling.
+
+### Default (admission + background only)
+
+Most clusters land here. `require-image-digest` enforces SHA256 digests on
+all pods in `system-*` namespaces; `resource-limits-requests` audits.
+
+```yaml
+- name: policy-base
+  path: policy/base
+  components:
+    - kyverno
+  timeout: 30m
+  interval: 5m
+
+- name: policy-resources
+  path: policy/resources
+  dependsOn: [policy-base]
+  components:
+    - kyverno/resource-limits-requests
+    - kyverno/require-image-digest
+  timeout: 5m
+  interval: 5m
+  retryInterval: 1m
+```
+
+### With reports and cleanup controllers
+
+Layer in the optional controllers when the operator wants
+PolicyReport / ClusterPolicyReport visibility (`policies.reporting: enabled`)
+or CleanupPolicy / ClusterCleanupPolicy CRD execution
+(`policies.cleanup: enabled`).
+
+```yaml
+- name: policy-base
+  path: policy/base
+  components:
+    - kyverno
+    - kyverno/reports
+    - kyverno/cleanup
+
+- name: policy-resources
+  path: policy/resources
+  dependsOn: [policy-base]
+  components:
+    - kyverno/resource-limits-requests
+    - kyverno/require-image-digest
+```
+
+### Disabling individual policies
+
+Keep Kyverno installed but skip a specific ClusterPolicy by setting
+`policies.resource_limits_requests: disabled` or
+`policies.require_image_digest: disabled` in the context values; the facet
+drops the corresponding component from `policy-resources.components`.
+
+## Substitutions
+
+This add-on does not consume any blueprint substitutions. Policy bodies are
+hardcoded; gating happens at the component-selection layer in
+`platform-base`.
+
+## Components
+
+### `policy/base/`
+
+| Component | Enable when | Effect |
+|---|---|---|
+| `kyverno` | `policies.enabled` | Helm release of Kyverno v3.8.0 in `system-policy`. Installs admission-controller and background-controller. CRDs migrate via the chart's migration job. cleanup-controller and reports-controller are present but disabled (`enabled: false` in values). |
+| `kyverno/cleanup` | `policies.cleanup == 'enabled'` | Patches the kyverno HelmRelease to set `cleanupController.enabled: true`. The controller stays idle until CleanupPolicy / ClusterCleanupPolicy resources are created. |
+| `kyverno/reports` | `policies.reporting == 'enabled'` | Patches the kyverno HelmRelease to set `reportsController.enabled: true`. Adds background scans and emits PolicyReport / ClusterPolicyReport resources. Admission enforcement is unaffected. |
+
+### `policy/resources/`
+
+The base kustomization is empty by default — every policy is its own
+component. Ordering is irrelevant since each ClusterPolicy is independent.
+
+| Component | Enable when | Effect |
+|---|---|---|
+| `kyverno/require-image-digest` | `policies.require_image_digest != 'disabled'` | `ClusterPolicy/require-image-digest` (Enforce, background-on). Validates that every container image in `system-*` namespaces or namespaces labeled `policy.windsorcli.dev/managed: "true"` is pinned by `@sha256:digest`. Excludes namespaces labeled `policy.windsorcli.dev/managed: "false"`. |
+| `kyverno/resource-limits-requests` | `policies.resource_limits_requests != 'disabled'` | `ClusterPolicy/resource-limits-requests` (Audit, background-off). Checks every Pod in `system-*` namespaces has CPU and memory `requests` and `limits`. `kube-system` is excluded via `preconditions`. Audit means failures are logged via PolicyReport but do not block admission. |
+
+## Dependencies
+
+`policy-base` has no `dependsOn` — it must come up before nearly everything
+else. The Kyverno admission webhook intercepts every Pod creation, so any
+add-on that depends on `policy-resources` is also implicitly waiting for
+admission webhooks to be ready (Flux's `dependsOn` on a Kustomization waits
+for the contained HelmRelease to reconcile, which waits for the chart's own
+readiness checks).
+
+`policy-resources` depends on `policy-base` (the Kyverno CRDs must exist
+before any ClusterPolicy is applied).
+
+Add-ons that depend on `policy-resources`:
+
+- `pki-base` — when policies are enabled, pki-base waits so cert-manager pods come up after Kyverno admission is enforcing image-digest pinning (otherwise cert-manager pods would be admitted without digests on first reconcile and rejected on rollout).
+- `pki-resources` — `addon-private-ca` ships an `inject-private-ca` ClusterPolicy; without `policy-resources` the Kyverno CRDs aren't ready and the apply fails on `no matches for kind ClusterPolicy`.
+- `dns` — `addon-private-dns` ships `external-dns/localhost`'s ClusterPolicy on docker-desktop runtime.
+- `cni` — re-rolls Cilium pods after Kyverno admission is live; when Cilium is the gateway driver, also depends on policy-resources for the LBIPAM sharing ClusterPolicy in `cilium/gateway`.
+- `lb-base` — every platform that wires lb-base lists policy-resources as a dependency. The `system-lb` namespace runs at PSA `privileged` and Kyverno needs to be aware of it.
+- `csi` — `option-storage` lists policy-resources as a dependency so CSI's node-driver-registrar Pod admits cleanly under image-digest enforcement.
+
+## Operations
+
+Add-on-specific failure modes; generic Flux/Renovate behaviour is documented
+at the repo level.
+
+- **Pod creation failing with `image must include @sha256 digest`** — `require-image-digest` is enforcing on a workload that doesn't pin its image. Either pin the image (preferred) or label the workload's namespace `policy.windsorcli.dev/managed: "false"` to opt out. Renovate's `# renovate: datasource=docker depName=...` markers above the `tag:` value let Renovate maintain pinned `tag@sha256:...` entries automatically.
+- **`HelmRelease/<anything>` reports `no matches for kind ClusterPolicy` or `Bundle`** — the consuming add-on's `dependsOn` on `policy-resources` is missing or `policies.enabled` is false. Either restore the dep or accept that the dependent add-on won't apply.
+- **PolicyReports not appearing despite policies on** — the `reports-controller` is off by default. Set `policies.reporting: enabled` to layer in the `kyverno/reports` component.
+- **Kyverno webhook causes API requests to time out** — the admission-controller is unhealthy. Check `kubectl get validatingwebhookconfiguration kyverno-resource-validating-webhook-cfg`; if the webhook is `failurePolicy: Fail` and Kyverno is down, every API write blocks. The Windsor helm-release values do not override `failurePolicy`; whatever the upstream chart and individual policies set applies. Review the per-policy `failurePolicy` carefully before adding new policies in `Enforce` mode.
+
+## Security
+
+- The `system-policy` namespace runs at PSA `baseline`.
+- Kyverno's controllers run with the chart's default RBAC: cluster-wide read on most resources (to evaluate policies), write on PolicyReport/ClusterPolicyReport (when reports-controller is on), and the validating/mutating admission webhooks are cluster-scoped.
+- Policy scope is gated on namespace labels:
+  - In-scope: namespaces matching `system-*` or labeled `policy.windsorcli.dev/managed: "true"`.
+  - Out-of-scope: namespaces labeled `policy.windsorcli.dev/managed: "false"` (explicit opt-out, takes precedence over inclusion).
+- All container images in `system-*` namespaces (every Windsor-managed system add-on) must be `@sha256:` pinned. Renovate handles this automatically through the `# renovate:` markers in helm-release values.
+
+## See also
+
+- [contexts/_template/facets/platform-base.yaml](../../contexts/_template/facets/platform-base.yaml) — canonical wiring of `policy-base` and `policy-resources`, including conditional toggles for the optional controllers and per-policy gates.
+- [contexts/_template/facets/addon-private-ca.yaml](../../contexts/_template/facets/addon-private-ca.yaml) — example of an add-on that ships a ClusterPolicy and `dependsOn: policy-resources`.
+- Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
+- Related add-ons: [pki](../pki/), [cni](../cni/), [lb](../lb/), [dns](../dns/), [gateway](../gateway/).

--- a/docs/reference/kustomize/telemetry.md
+++ b/docs/reference/kustomize/telemetry.md
@@ -1,0 +1,197 @@
+---
+title: Telemetry add-on
+description: Cluster-wide metrics and log collection — Prometheus, fluent-bit, metrics-server.
+---
+
+# Telemetry
+
+The cluster's metrics and logs collection layer. Two parallel pipelines, both
+managed from `system-telemetry`:
+
+- **Metrics**: kube-prometheus-stack runs Prometheus, kube-state-metrics, and
+  node-exporter. Scrape targets across all add-ons register via ServiceMonitor
+  and PodMonitor resources.
+- **Logs**: fluent-operator manages a fluent-bit DaemonSet that reads
+  container logs and (on Talos) the systemd journal. Logs are forwarded to a
+  sink owned by the **observability** add-on (`fluentd` aggregator by default,
+  Elasticsearch when the alternative driver is selected).
+
+Grafana is intentionally not in this add-on — it lives in `observability`,
+which is also responsible for the log sink. Telemetry collects; observability
+visualizes and stores.
+
+## Flow
+
+```mermaid
+flowchart LR
+    pods[Pod logs<br/>+ systemd journal]
+    targets[ServiceMonitors / PodMonitors<br/>cluster-wide]
+
+    subgraph systemtelemetry[system-telemetry]
+        prom[Prometheus<br/>via kube-prometheus-stack]
+        ksm[kube-state-metrics]
+        ne[node-exporter]
+        fb[fluent-bit DaemonSet<br/>via fluent-operator]
+        ms[metrics-server]
+    end
+
+    sink[fluentd or Elasticsearch<br/>_owned by observability_]
+    api[K8s metrics API]
+
+    targets --> prom
+    ksm --> prom
+    ne --> prom
+    pods --> fb
+    fb --> sink
+    ms --> api
+```
+
+`telemetry-base` installs the operators (Prometheus operator,
+fluent-operator). `telemetry-resources` adds the configuration that turns
+those operators into a working pipeline: a `FluentBit` CR with
+`ClusterFluentBitConfig`, fluent-bit `ClusterInput` / `ClusterFilter` /
+`ClusterOutput` resources for each log source and parser, a `metrics-server`
+release, and Prometheus scrape extras.
+
+## Recipes
+
+`telemetry-base` and `telemetry-resources` are gated on
+`telemetry.metrics.enabled` or `telemetry.logs.enabled`. Both default to
+`true`.
+
+### Default (both pipelines on, fluentd logs driver)
+
+```yaml
+- name: telemetry-base
+  path: telemetry/base
+  components:
+    - prometheus
+    - prometheus/flux
+    - fluentbit
+  timeout: 30m
+  interval: 10m
+
+- name: telemetry-resources
+  path: telemetry/resources
+  dependsOn: [telemetry-base]
+  components:
+    - metrics-server
+    - prometheus
+    - prometheus/flux
+    - fluentbit
+    - fluentbit/containerd
+    - fluentbit/kubernetes
+    - fluentbit/parser
+    - fluentbit/systemd
+    - fluentbit/prometheus
+    - fluentbit/fluentd
+  timeout: 10m
+  interval: 5m
+```
+
+### Metrics-only (`telemetry.logs.enabled: false`)
+
+```yaml
+- name: telemetry-base
+  path: telemetry/base
+  components:
+    - prometheus
+    - prometheus/flux
+
+- name: telemetry-resources
+  path: telemetry/resources
+  dependsOn: [telemetry-base]
+  components:
+    - metrics-server
+    - prometheus
+    - prometheus/flux
+```
+
+### AKS (managed metrics-server)
+
+On `platform: azure`, the `metrics-server` component is dropped because
+AKS ships metrics-server as a built-in addon. Same shape as the default
+recipe minus `metrics-server`.
+
+### Logs-only / Elasticsearch sink
+
+When `addon-observability` selects `logs_driver: elasticsearch`, the
+`fluentbit/fluentd` ClusterOutput is dropped and addon-observability layers
+in `filebeat` (in `telemetry-base`) for direct Elasticsearch shipping. See
+`addon-observability` for the full layering.
+
+## Substitutions
+
+This add-on does not consume any blueprint substitutions. The two
+platform-base globals (`private_domain`, `public_domain`) are exposed to
+every Kustomization but are not referenced inside any telemetry manifest.
+
+## Components
+
+### `telemetry/base/`
+
+| Component | Enable when | Effect |
+|---|---|---|
+| `prometheus` | `telemetry.metrics.enabled` | Helm release of `kube-prometheus-stack` v84.5.0 in `system-telemetry`. Includes Prometheus, prometheus-operator, kube-state-metrics, node-exporter. Grafana is disabled here (lives in `observability`). All `*SelectorNilUsesHelmValues` are set to `false` so cluster-wide ServiceMonitors and PodMonitors are picked up. |
+| `prometheus/flux` | `telemetry.metrics.enabled` | Patches kube-prometheus-stack to add kube-state-metrics RBAC and `customResourceState` config for Flux's CRDs (GitRepository, Kustomization, HelmRelease, etc.) so they show up in metrics. |
+| `fluentbit` | `telemetry.logs.enabled` | Helm release of `fluent-operator` v4.0.0 in `system-telemetry` with `containerRuntime: containerd`. The chart installs the operator and the FluentBit/FluentD CRDs; `fluentd.enable: false` and `fluentbit.enable: false` so no instances are created at this layer (instances come from `telemetry-resources`). |
+| `filebeat` | (only via `addon-observability` for the Elasticsearch sink) | Helm release of filebeat for direct Elasticsearch shipping. Not wired by `platform-base`. |
+
+### `telemetry/resources/`
+
+The base kustomization is empty; every component contributes its own
+manifests.
+
+| Component | Enable when | Effect |
+|---|---|---|
+| `metrics-server` | `telemetry.metrics.enabled` AND `metrics_server_enabled != false` | Helm release of `metrics-server`. Skipped on AKS (managed). |
+| `metrics-server/skip-tls` | (opt-in patch) | Patches metrics-server to add `--kubelet-insecure-tls`. Not wired by platform-base; available for clusters where kubelet certs aren't trusted by metrics-server. |
+| `prometheus` | `telemetry.metrics.enabled` | Patches kube-state-metrics RBAC to read Flux CRDs and adds a `customResourceState` config for them, so Flux resource state shows up as metrics. |
+| `prometheus/flux` | `telemetry.metrics.enabled` | Helm release of `flux2` v2.18.3 named `flux-pod-monitor` in `system-gitops`. All controllers are `create: false`; only the `prometheus.podMonitor` is created — a PodMonitor for scraping Flux's controller pods. The chart-as-PodMonitor-shim trick avoids hand-writing a PodMonitor against Flux's labels. |
+| `fluentbit` | `telemetry.logs.enabled` | Creates the `FluentBit` CR (DaemonSet) with `nodeAffinity` excluding nodes labeled `node-role.kubernetes.io/edge`, host-path positionDB at `/var/lib/fluent-bit/`, and a `ClusterFluentBitConfig` selecting all input / filter / output resources labeled `fluentbit.fluent.io/enabled: "true"`. |
+| `fluentbit/containerd` | `telemetry.logs.enabled` | Systemd journal ClusterInput reading from `/var/log/journal` filtered to `containerd.service` and `kubelet.service` (tagged `service.*`), plus a Lua ClusterFilter that processes the CRI line format on `kube.*` records. |
+| `fluentbit/kubernetes` | `telemetry.logs.enabled` | Tail ClusterInput on `/var/log/containers/*.log` using the `cri` parser (tagged `kube.*`), plus a kubernetes ClusterFilter that enriches each record with pod metadata (namespace, pod name, container) using the in-cluster service account. |
+| `fluentbit/parser` | `telemetry.logs.enabled` | Aggregate component bundling parsers for coredns, JSON-structured, klog, logfmt, nginx-access, rust-tracing, zerolog, plus service-name extraction, suppress filter, fallback parser, and a generic gRPC parser. Each parser is a ClusterFilter with a Lua script. |
+| `fluentbit/systemd` | `telemetry.logs.enabled` | Lua ClusterFilter for `service.*` tagged records (the systemd journal entries captured by `fluentbit/containerd`). Adds an ISO 8601 timestamp and maps systemd fields (`_HOSTNAME`, `SYSLOG_IDENTIFIER`) into a kubernetes-shaped record so downstream processing matches the format from the kubernetes filter. |
+| `fluentbit/prometheus` | `telemetry.logs.enabled` AND `telemetry.metrics.enabled` | ServiceMonitor for fluent-bit's own `/metrics` endpoint. |
+| `fluentbit/fluentd` | `telemetry.logs.enabled` AND `telemetry.logs.driver: fluentd` (the default) | ClusterOutput shipping all enriched logs to the fluentd aggregator (in the `observability` namespace). |
+
+## Dependencies
+
+`telemetry-base` has no `dependsOn` — it is foundational and installs early.
+
+`telemetry-resources` `dependsOn: telemetry-base` (the operator CRDs must
+exist before any FluentBit CR or ServiceMonitor is created).
+
+Add-ons that depend on `telemetry-base`:
+
+- `pki-base` — when telemetry metrics or logs are enabled, pki-base waits so cert-manager's ServiceMonitor has a working Prometheus target from creation.
+- `cni` — same reason: cilium/prometheus and cilium/hubble ServiceMonitors need Prometheus to be live.
+- `observability` — depends on telemetry-base because grafana / fluentd / elasticsearch all need the operators or the log shipper this add-on provides.
+
+## Operations
+
+Add-on-specific failure modes; generic Flux/Renovate behaviour is documented
+at the repo level.
+
+- **No metrics in Grafana despite Prometheus running** — ServiceMonitor / PodMonitor resources aren't being picked up. The `*SelectorNilUsesHelmValues: false` settings in `prometheus/helm-release.yaml` mean an empty selector matches everything; if Prometheus is filtering, check the Prometheus CR's `serviceMonitorSelector` for unintended overrides.
+- **fluent-bit DaemonSet not running on edge nodes** — the FluentBit CR's nodeAffinity excludes nodes labeled `node-role.kubernetes.io/edge`. If you want logs from edge nodes, remove the affinity or relabel the nodes. This is intentional — edge nodes are typically resource-constrained.
+- **Logs collected but never delivered** — the fluent-bit → fluentd ClusterOutput is missing. Check the `fluentbit/fluentd` component is enabled (it requires `telemetry.logs.driver: fluentd`, which is the default). When `telemetry.logs.driver: none`, fluent-bit runs without an output and buffers indefinitely.
+- **`HelmRelease/kube-prometheus-stack` reports `no matches for kind ServiceMonitor`** — the kube-prometheus-stack CRDs haven't installed yet. The chart installs them; if the apply is racing, re-reconcile.
+- **fluent-operator pods crash with `cannot create ConfigMap`** — RBAC issue. The operator needs to write the rendered fluent-bit config; check `system-telemetry`'s ServiceAccount and ClusterRole.
+- **node-exporter DaemonSet missing pods** — node taints. node-exporter's chart values set `replicas: 1` which is misleading (it's a DaemonSet); check that tolerations cover the cluster's taints.
+
+## Security
+
+- The `system-telemetry` namespace runs at PSA `privileged`. fluent-bit needs host paths (`/var/lib/fluent-bit/` for the position DB, `/var/log/containers/` for container logs, `/var/log/journal` for the systemd journal) and node-exporter needs host PID and host network.
+- kube-state-metrics is granted RBAC to read Flux's CRDs (GitRepository, Kustomization, HelmRelease, etc.) so Flux resource state is exposed as Prometheus metrics. The grant is read-only (`list`, `watch`).
+- The `flux-pod-monitor` release lives in `system-gitops` (not `system-telemetry`) — only a PodMonitor object is created, no controllers, so no additional permissions are granted to telemetry.
+- fluent-bit reads container logs from `/var/log/containers/*.log` (kubernetes input) and the systemd journal at `/var/log/journal` (containerd input). Pod logs may contain secrets if applications log them; consider this when configuring downstream sinks.
+
+## See also
+
+- [contexts/_template/facets/platform-base.yaml](../../contexts/_template/facets/platform-base.yaml) — canonical wiring of `telemetry-base` and `telemetry-resources`, including the `telemetry_effective` internal config that folds `telemetry.*` values together with addon-observability overrides.
+- [contexts/_template/facets/addon-observability.yaml](../../contexts/_template/facets/addon-observability.yaml) — log sink (fluentd / quickwit / elasticsearch + filebeat) layered on top of telemetry.
+- [contexts/_template/facets/platform-azure.yaml](../../contexts/_template/facets/platform-azure.yaml) — `metrics_server_enabled: false` override for AKS.
+- Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
+- Related add-ons: [observability](../observability/), [pki](../pki/), [cni](../cni/), [policy](../policy/).

--- a/kustomize/README.md
+++ b/kustomize/README.md
@@ -1,0 +1,109 @@
+---
+title: Kustomize layer
+description: Index of the cluster add-ons that ship with the Windsor Core blueprint.
+---
+
+# Kustomize
+
+The Kustomize layer of the Windsor Core blueprint. Each subdirectory is an
+add-on — a logically-grouped set of `HelmRelease`, `Certificate`, custom
+resources, and patches that Flux reconciles after the cluster is up.
+
+Add-ons are not applied directly. Facets in
+[contexts/_template/facets/](../contexts/_template/facets/) emit Flux
+`Kustomization` entries that reference these directories (`path:`) and
+select per-cluster components. Multiple facets can contribute to the same
+Kustomization name; the Windsor harness composes them into a single
+materialized entry.
+
+## Layout convention
+
+Most add-ons follow a consistent shape:
+
+```
+kustomize/<add-on>/
+├── namespace.yaml          # Namespace + PSA labels
+├── kustomization.yaml      # Add-on root (often just resources: [namespace.yaml])
+├── <operator>/
+│   ├── kustomization.yaml  # kind: Component
+│   ├── helm-repository.yaml
+│   ├── helm-release.yaml
+│   └── <variant>/          # Patches selected per-cluster
+│       ├── kustomization.yaml  # kind: Component, patches: ...
+│       └── patches/
+└── README.md               # This add-on's reference (per-add-on READMEs)
+```
+
+Some add-ons split into `base/` (operators) and `resources/` (cluster
+state) — pki, lb, gateway, telemetry, object-store. Others have a single
+top-level kustomization — cni, csi, dns, policy, observability, gitops,
+ingress, demo.
+
+See [GUIDELINES.md](GUIDELINES.md) for the timeout / interval rules each
+add-on's facet entries follow, derived from image count and reconcile
+weight.
+
+## Add-ons
+
+### Bootstrap and platform
+
+| Add-on | Owns | Wired by |
+|---|---|---|
+| [cni](cni/) | Cilium CNI (replaces kube-proxy, optional Gateway API + LBIPAM + Hubble). Bootstrapped by Terraform, adopted by Flux. | `option-cni` |
+| [policy](policy/) | Kyverno admission controller and cluster-wide ClusterPolicies (image-digest enforcement, resource limits/requests audit). | `platform-base` |
+| [pki](pki/) | cert-manager and trust-manager. Private and public ClusterIssuers — selfsigned, CA-backed, ACME (Let's Encrypt + Route53 / Azure DNS). | `platform-base`, `platform-aws`, `platform-azure`, `addon-private-ca`, `option-dev` |
+| [telemetry](telemetry/) | Prometheus (kube-prometheus-stack), fluent-operator + fluent-bit, metrics-server. The collection layer; sinks live in `observability`. | `platform-base` |
+| [gitops](gitops/) | Flux notification webhook receiver and HTTPRoute. Flux itself is installed by Terraform. | `platform-base` |
+
+### Networking and traffic
+
+| Add-on | Owns | Wired by |
+|---|---|---|
+| [gateway](gateway/) | Gateway API entrypoint — Envoy Gateway controller or Cilium's built-in Gateway. The shared `external` Gateway and `external-web-tls` Certificate. | `option-gateway`, `platform-aws`, `platform-azure` |
+| [dns](dns/) | CoreDNS for private zones, external-dns for record automation against in-cluster CoreDNS / Route 53 / Azure DNS. | `addon-private-dns`, `platform-aws`, `platform-azure` |
+| [lb](lb/) | AWS LB Controller (cloud) or MetalLB / kube-vip (metal, incus). Provides external IPs for `Service` of type `LoadBalancer`. | `platform-aws`, `platform-metal`, `platform-incus`, `platform-docker` |
+| [ingress](ingress/) | Legacy nginx-ingress controller. **Not wired by current facets** — the gateway add-on is the supported path. Kept for blueprints that explicitly want classic Ingress. | (none — manual wiring) |
+
+### Storage and data
+
+| Add-on | Owns | Wired by |
+|---|---|---|
+| [csi](csi/) | Persistent storage drivers and StorageClasses — AWS EBS, Azure Disk, OpenEBS host-path, Longhorn. | `platform-aws`, `platform-azure`, `option-storage`, `option-single-node` |
+| [database](database/) | CloudNativePG operator. Tenant `Cluster` resources are created by workloads; this add-on only provides the operator. | `addon-database` |
+| [object-store](object-store/) | MinIO operator. The reference tenant under `resources/common` is shipped but not wired by `addon-object-store` — operators add it manually. | `addon-object-store` |
+
+### Observability
+
+| Add-on | Owns | Wired by |
+|---|---|---|
+| [observability](observability/) | Grafana, dashboards, fluentd aggregator, and pluggable log storage (stdout, Quickwit, Elasticsearch + Kibana). The fluentd aggregator is wired by `platform-base` even without the addon; Grafana and storage backends are wired by `addon-observability`. | `platform-base` (fluentd), `addon-observability` (everything else), `option-dev` (`grafana/dev` admin password patch), `option-cni` (Cilium dashboards), `option-storage` (Longhorn dashboards), `addon-database` (CNPG dashboards) |
+
+### Examples
+
+| Add-on | Owns | Wired by |
+|---|---|---|
+| [demo](demo/) | Sample workloads — a CNPG demo cluster, a live-reload static website, the Istio bookinfo app. Each toggleable independently via `demo.resources.*`. | `option-demo` |
+
+## How facets compose
+
+A given Kustomization name (e.g. `observability`, `pki-base`) often
+appears in multiple facet entries. The Windsor harness composes them
+additively — `dependsOn` and `components` lists are unioned, the path
+must agree. This is how `option-cni` adds `grafana/dashboards/cilium` to
+the `observability` Kustomization without redefining it, and how
+`platform-base` ships the fluentd aggregator while `addon-observability`
+layers in Grafana and the storage backend on the same Kustomization.
+
+The recipes in each per-add-on README show the **materialized union** for
+typical scenarios — what the merged Kustomization entry looks like after
+all contributing facets resolve. Conditional `dependsOn` entries (e.g.
+`policy-resources` is gated on `policies.enabled: true`) are typically
+shown unconditionally for readability.
+
+## See also
+
+- [GUIDELINES.md](GUIDELINES.md) — timeout and interval rules.
+- [contexts/_template/facets/](../contexts/_template/facets/) — the facets that wire these add-ons into a blueprint.
+- [contexts/_template/schema.yaml](../contexts/_template/schema.yaml) — user-facing values.yaml schema.
+- [terraform/](../terraform/) — the Terraform layer that provisions the cluster, IAM, networking, and bootstraps Flux and Cilium.
+- Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/

--- a/kustomize/cni/README.md
+++ b/kustomize/cni/README.md
@@ -1,5 +1,5 @@
 ---
-title: CNI stack
+title: CNI add-on
 description: Cilium as the cluster CNI, bootstrapped via Terraform and adopted by Flux.
 ---
 
@@ -8,10 +8,10 @@ description: Cilium as the cluster CNI, bootstrapped via Terraform and adopted b
 Cilium is the only CNI driver this blueprint installs. The HelmRelease CR
 lives in `system-cni`; the actual Cilium workloads (DaemonSet, Operator,
 Hubble) deploy into `kube-system` per upstream convention. Other CNIs
-(flannel on docker-desktop, AKS's managed CNI) bypass this stack entirely
+(flannel on docker-desktop, AKS's managed CNI) bypass this add-on entirely
 when `cluster.cni.driver` is not `cilium`.
 
-The defining shape of this stack is the **bootstrap-then-adopt** pattern.
+The defining shape of this add-on is the **bootstrap-then-adopt** pattern.
 Cilium has a chicken-and-egg problem: Flux needs pod networking to
 reconcile, but Flux is normally what installs the CNI. Resolution:
 Terraform installs Cilium first via the Talos API, then Flux adopts the
@@ -50,7 +50,7 @@ Flux-adopted release does not flap the deployment between reconciles.
 
 ## Recipes
 
-This stack has a single Kustomization (`cni`) with two `when:` variants —
+This add-on has a single Kustomization (`cni`) with two `when:` variants —
 `talos_enabled` and `eks_enabled`. Each emits a different component set.
 
 The recipes below show the materialized form assuming `policies.enabled:
@@ -114,7 +114,7 @@ without the Gateway controller and never reconciles HTTPRoutes.
 
 EKS clusters use the AWS-managed control plane; no Talos-specific patches
 and no L2 announcer (EKS provides its own LB via the AWS LB Controller in
-the `lb` stack). `k8s_service_host` is parsed from the cluster Terraform
+the `lb` add-on). `k8s_service_host` is parsed from the cluster Terraform
 output.
 
 ```yaml
@@ -154,17 +154,17 @@ output.
 
 ## Dependencies
 
-| Stack | Reason |
+| Add-on | Reason |
 |---|---|
 | `policy-resources` *(when `policies.enabled: true` or `gateway.driver: cilium`)* | Re-rolls Cilium pods after Kyverno's mutation policies are live. When `cilium/gateway` is active, `policy-resources` also provides the Kyverno CRDs the LBIPAM sharing ClusterPolicy depends on — without it the apply would fail on `no matches for kind ClusterPolicy`. |
-| `telemetry-base` *(when `telemetry.metrics.enabled: true` or `telemetry.logs.enabled: true`)* | The `cilium/prometheus` ServiceMonitor and the Hubble ServiceMonitor target Prometheus from the telemetry stack; without it they have no scrape target. |
+| `telemetry-base` *(when `telemetry.metrics.enabled: true` or `telemetry.logs.enabled: true`)* | The `cilium/prometheus` ServiceMonitor and the Hubble ServiceMonitor target Prometheus from the telemetry add-on; without it they have no scrape target. |
 
 The Terraform `cni` module bootstraps Cilium directly via the Talos API
 before Flux exists. Terraform `cni` `dependsOn: cluster` (the cluster must
 be provisioned), and Terraform `gitops` `dependsOn: cni` (Flux must wait
 for pod networking).
 
-Reverse dependencies — stacks that depend on `cni`:
+Reverse dependencies — add-ons that depend on `cni`:
 
 - `gateway-resources` `dependsOn: cni` when Cilium is the gateway driver. Without ordering, the Kyverno LBIPAM policy may not be in place when cilium-operator creates the gateway Service, and the LB IP won't be shared.
 - `csi` `dependsOn: cni` always. CSI's node-driver-registrar can see transient loopback connectivity drops during eBPF init and crash-loop without this ordering.
@@ -172,7 +172,7 @@ Reverse dependencies — stacks that depend on `cni`:
 
 ## Operations
 
-Stack-specific failure modes; generic Flux/Renovate behaviour is documented
+Add-on-specific failure modes; generic Flux/Renovate behaviour is documented
 at the repo level.
 
 - **Cilium pods crash-looping on Talos with `Operation not permitted`** — the `cilium/talos` component is missing or its capabilities patch didn't apply. Confirm the helm-release values include `securityContext.capabilities.ciliumAgent`. Talos rejects full privileged mode.
@@ -181,7 +181,7 @@ at the repo level.
 - **`HelmRelease/cilium` reports `no matches for kind CiliumLoadBalancerIPPool`** — `cilium/l2` is enabled but the Cilium CRDs aren't ready. The Cilium chart installs them; the bootstrap path (Terraform → Flux adoption) means the CRDs come up with the agent. If this fires, the Flux reconcile is racing the chart install — re-reconcile.
 - **Re-running `windsor up` flaps Cilium between two replica counts** — Terraform `operator_replicas` and the Flux substitution differ. Both must derive from `topology` (single-node → 1, otherwise → 2).
 
-Cilium's metrics ServiceMonitors are scraped by the `telemetry` stack
+Cilium's metrics ServiceMonitors are scraped by the `telemetry` add-on
 (`release: kube-prometheus-stack` label set by `cilium/prometheus`). Hubble
 flows are accessible via Hubble UI; Hubble Relay exposes a gRPC endpoint
 for `hubble observe`.
@@ -189,7 +189,7 @@ for `hubble observe`.
 ## Security
 
 - The `system-cni` namespace has no PSA labels in its manifest (see [namespace.yaml](namespace.yaml)). Cilium workloads live in `kube-system`; the Cilium DaemonSet uses host networking and elevated Linux capabilities (full set on non-Talos, restricted explicit set on Talos via `cilium/talos`).
-- `kubeProxyReplacement: true` means Cilium replaces kube-proxy entirely. Removing the `cni` stack does not restore kube-proxy automatically.
+- `kubeProxyReplacement: true` means Cilium replaces kube-proxy entirely. Removing the `cni` add-on does not restore kube-proxy automatically.
 - Hubble TLS certificates rotate via an in-cluster CronJob (cert-manager is not required for Hubble).
 - The `cilium-gateway-lbipam-sharing` Kyverno ClusterPolicy mutates Services in `system-gateway` that Cilium creates. Scope is restricted by namespace and by the `io.cilium.gateway/owning-gateway: external` label selector — it does not affect Services outside `system-gateway` or non-Cilium Services.
 
@@ -198,4 +198,4 @@ for `hubble observe`.
 - [contexts/_template/facets/option-cni.yaml](../../contexts/_template/facets/option-cni.yaml) — canonical wiring for both Talos and EKS variants, plus reverse-dep injections into `gateway-resources`, `csi`, and `observability`.
 - [terraform/cni/cilium/](../../terraform/cni/cilium/) — Terraform bootstrap module that installs Cilium pre-Flux.
 - Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
-- Related stacks: [policy](../policy/), [telemetry](../telemetry/), [gateway](../gateway/), [csi](../csi/), [lb](../lb/).
+- Related add-ons: [policy](../policy/), [telemetry](../telemetry/), [gateway](../gateway/), [csi](../csi/), [lb](../lb/).

--- a/kustomize/cni/README.md
+++ b/kustomize/cni/README.md
@@ -9,7 +9,7 @@ Cilium is the only CNI driver this blueprint installs. The HelmRelease CR
 lives in `system-cni`; the actual Cilium workloads (DaemonSet, Operator,
 Hubble) deploy into `kube-system` per upstream convention. Other CNIs
 (flannel on docker-desktop, AKS's managed CNI) bypass this stack entirely
-when `cni_effective.driver != 'cilium'`.
+when `cluster.cni.driver` is not `cilium`.
 
 The defining shape of this stack is the **bootstrap-then-adopt** pattern.
 Cilium has a chicken-and-egg problem: Flux needs pod networking to
@@ -53,8 +53,8 @@ Flux-adopted release does not flap the deployment between reconciles.
 This stack has a single Kustomization (`cni`) with two `when:` variants —
 `talos_enabled` and `eks_enabled`. Each emits a different component set.
 
-The recipes below show the materialized form assuming `policies.enabled` and
-`telemetry_effective.metrics_enabled` are on (the platform-base defaults).
+The recipes below show the materialized form assuming `policies.enabled:
+true` and `telemetry.metrics.enabled: true` (the platform-base defaults).
 If either is disabled, the corresponding `dependsOn` entry drops and the
 related conditional component (`cilium/prometheus`) is omitted.
 
@@ -135,9 +135,9 @@ output.
 
 | Name | Required when | Effect |
 |---|---|---|
-| `k8s_service_host` | always | API server hostname Cilium reaches before its eBPF service rules are active. On Talos comes from `talos_common.k8s_service_host` (cidrhost offset 10); on EKS parsed from the cluster Terraform output. |
-| `cluster_name` | always | Cilium cluster identity stamped onto Hubble flows, metrics, and (if enabled) ClusterMesh routing. The Windsor context name. |
-| `operator_replicas` | always | 1 on single-node clusters (avoids pending pods + Lease churn), 2 on HA. Defaults to 1 via the kustomize fallback `${operator_replicas:=1}`. |
+| `k8s_service_host` | always | API server hostname Cilium reaches before its eBPF service rules are active. On Talos resolves to a fixed offset from the cluster CIDR; on EKS parsed from the cluster Terraform output. The user-facing knob is `cluster.endpoint` (or its terraform-derived equivalent on cloud platforms). |
+| `cluster_name` | always | Cilium cluster identity stamped onto Hubble flows, metrics, and (if enabled) ClusterMesh routing. Sourced from the Windsor context name (the top-level `id` field in `values.yaml`). |
+| `operator_replicas` | always | 1 on single-node clusters (avoids pending pods + Lease churn), 2 on HA. Set from `cluster.topology` (single-node → 1, otherwise → 2). Defaults to 1 via the kustomize fallback `${operator_replicas:=1}`. |
 | `loadbalancer_start_ip` | `cilium/l2` is enabled (Talos) | Start of the LBIPAM IP pool. Stamped onto `CiliumLoadBalancerIPPool/default`. |
 | `loadbalancer_end_ip` | `cilium/l2` is enabled (Talos) | End of the LBIPAM IP pool. |
 
@@ -147,8 +147,8 @@ output.
 |---|---|---|
 | `cilium` | always | Helm release of Cilium v1.19.3 in `system-cni`, targeting `kube-system`. `kubeProxyReplacement: true`, `ipam.mode: kubernetes`, image pinning, base values. |
 | `cilium/talos` | platform is Talos | Replaces full privileged mode with explicit Linux capabilities (CHOWN, NET_ADMIN, etc.) and disables cgroup auto-mount (Talos already mounted cgroups at boot). |
-| `cilium/gateway` | Cilium is the Gateway driver | Sets `gatewayAPI.enabled: true` (also `enableAlpn`, `enableAppProtocol`) and ships a Kyverno ClusterPolicy that injects LBIPAM sharing annotations onto Cilium-owned Gateway services at admission time. The policy fixes a create-then-patch race in cilium-operator that would otherwise prevent IP sharing on first reconcile. |
-| `cilium/prometheus` | telemetry metrics enabled | Enables Prometheus on the operator and agent and creates a ServiceMonitor for each. |
+| `cilium/gateway` | `gateway.driver: cilium` | Sets `gatewayAPI.enabled: true` (also `enableAlpn`, `enableAppProtocol`) and ships a Kyverno ClusterPolicy that injects LBIPAM sharing annotations onto Cilium-owned Gateway services at admission time. The policy fixes a create-then-patch race in cilium-operator that would otherwise prevent IP sharing on first reconcile. |
+| `cilium/prometheus` | `telemetry.metrics.enabled: true` | Enables Prometheus on the operator and agent and creates a ServiceMonitor for each. |
 | `cilium/hubble` | always | Enables Hubble metrics (dns, drop, port-distribution, tcp, flow, icmp, http), Hubble Relay, Hubble UI, and the cronJob-based TLS rotation method. The Helm `auto.method: cronJob` choice avoids a known bug where `helm` mode re-renders server-secret on every upgrade and trips on newly-enabled Hubble components. |
 | `cilium/l2` | platform is Talos (or any cluster needing in-cluster LB) | Enables `l2announcements` and `externalIPs` on Cilium, then creates `CiliumLoadBalancerIPPool/default` with the configured IP range and `CiliumL2AnnouncementPolicy/default` matching `^eth[0-9]+` and `^ens[0-9]+` interfaces. Replaces kube-vip and MetalLB on Talos clusters. |
 
@@ -156,8 +156,8 @@ output.
 
 | Stack | Reason |
 |---|---|
-| `policy-resources` *(when policies enabled, or Cilium is the gateway driver)* | Re-rolls Cilium pods after Kyverno's mutation policies are live. When `cilium/gateway` is active, `policy-resources` also provides the Kyverno CRDs the LBIPAM sharing ClusterPolicy depends on — without it the apply would fail on `no matches for kind ClusterPolicy`. |
-| `telemetry-base` *(when telemetry metrics or logs enabled)* | The `cilium/prometheus` ServiceMonitor and the Hubble ServiceMonitor target Prometheus from the telemetry stack; without it they have no scrape target. |
+| `policy-resources` *(when `policies.enabled: true` or `gateway.driver: cilium`)* | Re-rolls Cilium pods after Kyverno's mutation policies are live. When `cilium/gateway` is active, `policy-resources` also provides the Kyverno CRDs the LBIPAM sharing ClusterPolicy depends on — without it the apply would fail on `no matches for kind ClusterPolicy`. |
+| `telemetry-base` *(when `telemetry.metrics.enabled: true` or `telemetry.logs.enabled: true`)* | The `cilium/prometheus` ServiceMonitor and the Hubble ServiceMonitor target Prometheus from the telemetry stack; without it they have no scrape target. |
 
 The Terraform `cni` module bootstraps Cilium directly via the Talos API
 before Flux exists. Terraform `cni` `dependsOn: cluster` (the cluster must
@@ -179,7 +179,7 @@ at the repo level.
 - **`cilium-operator` does not create a Gateway controller on Cilium clusters** — the Gateway API CRDs were not present when the operator started. The reverse dep `cni dependsOn gateway-base` (added by `option-gateway`) prevents this in fresh installs; if it fires post-install, restart `cilium-operator`.
 - **Cilium gateway Service has no LB IP** — the LBIPAM sharing annotations weren't injected. Verify the `cilium-gateway-lbipam-sharing` ClusterPolicy is `Ready` and the `cilium-lbipam-config` ConfigMap in `system-gateway` exists. The policy reads `gatewayIp` from that ConfigMap; without it the mutation fails open.
 - **`HelmRelease/cilium` reports `no matches for kind CiliumLoadBalancerIPPool`** — `cilium/l2` is enabled but the Cilium CRDs aren't ready. The Cilium chart installs them; the bootstrap path (Terraform → Flux adoption) means the CRDs come up with the agent. If this fires, the Flux reconcile is racing the chart install — re-reconcile.
-- **Re-running `windsor up` flaps Cilium between two replica counts** — Terraform `operator_replicas` and the Flux substitution differ. Both must derive from `topology_effective` (1 for single-node, 2 otherwise).
+- **Re-running `windsor up` flaps Cilium between two replica counts** — Terraform `operator_replicas` and the Flux substitution differ. Both must derive from `cluster.topology` (single-node → 1, otherwise → 2).
 
 Cilium's metrics ServiceMonitors are scraped by the `telemetry` stack
 (`release: kube-prometheus-stack` label set by `cilium/prometheus`). Hubble

--- a/kustomize/cni/README.md
+++ b/kustomize/cni/README.md
@@ -137,7 +137,7 @@ output.
 |---|---|---|
 | `k8s_service_host` | always | API server hostname Cilium reaches before its eBPF service rules are active. On Talos resolves to a fixed offset from the cluster CIDR; on EKS parsed from the cluster Terraform output. The user-facing knob is `cluster.endpoint` (or its terraform-derived equivalent on cloud platforms). |
 | `cluster_name` | always | Cilium cluster identity stamped onto Hubble flows, metrics, and (if enabled) ClusterMesh routing. Sourced from the Windsor context name (the top-level `id` field in `values.yaml`). |
-| `operator_replicas` | always | 1 on single-node clusters (avoids pending pods + Lease churn), 2 on HA. Set from `cluster.topology` (single-node → 1, otherwise → 2). Defaults to 1 via the kustomize fallback `${operator_replicas:=1}`. |
+| `operator_replicas` | always | 1 on single-node clusters (avoids pending pods + Lease churn), 2 on HA. Set from `topology` (single-node → 1, otherwise → 2). Defaults to 1 via the kustomize fallback `${operator_replicas:=1}`. |
 | `loadbalancer_start_ip` | `cilium/l2` is enabled (Talos) | Start of the LBIPAM IP pool. Stamped onto `CiliumLoadBalancerIPPool/default`. |
 | `loadbalancer_end_ip` | `cilium/l2` is enabled (Talos) | End of the LBIPAM IP pool. |
 
@@ -179,7 +179,7 @@ at the repo level.
 - **`cilium-operator` does not create a Gateway controller on Cilium clusters** — the Gateway API CRDs were not present when the operator started. The reverse dep `cni dependsOn gateway-base` (added by `option-gateway`) prevents this in fresh installs; if it fires post-install, restart `cilium-operator`.
 - **Cilium gateway Service has no LB IP** — the LBIPAM sharing annotations weren't injected. Verify the `cilium-gateway-lbipam-sharing` ClusterPolicy is `Ready` and the `cilium-lbipam-config` ConfigMap in `system-gateway` exists. The policy reads `gatewayIp` from that ConfigMap; without it the mutation fails open.
 - **`HelmRelease/cilium` reports `no matches for kind CiliumLoadBalancerIPPool`** — `cilium/l2` is enabled but the Cilium CRDs aren't ready. The Cilium chart installs them; the bootstrap path (Terraform → Flux adoption) means the CRDs come up with the agent. If this fires, the Flux reconcile is racing the chart install — re-reconcile.
-- **Re-running `windsor up` flaps Cilium between two replica counts** — Terraform `operator_replicas` and the Flux substitution differ. Both must derive from `cluster.topology` (single-node → 1, otherwise → 2).
+- **Re-running `windsor up` flaps Cilium between two replica counts** — Terraform `operator_replicas` and the Flux substitution differ. Both must derive from `topology` (single-node → 1, otherwise → 2).
 
 Cilium's metrics ServiceMonitors are scraped by the `telemetry` stack
 (`release: kube-prometheus-stack` label set by `cilium/prometheus`). Hubble

--- a/kustomize/cni/README.md
+++ b/kustomize/cni/README.md
@@ -1,0 +1,201 @@
+---
+title: CNI stack
+description: Cilium as the cluster CNI, bootstrapped via Terraform and adopted by Flux.
+---
+
+# CNI
+
+Cilium is the only CNI driver this blueprint installs. The HelmRelease CR
+lives in `system-cni`; the actual Cilium workloads (DaemonSet, Operator,
+Hubble) deploy into `kube-system` per upstream convention. Other CNIs
+(flannel on docker-desktop, AKS's managed CNI) bypass this stack entirely
+when `cni_effective.driver != 'cilium'`.
+
+The defining shape of this stack is the **bootstrap-then-adopt** pattern.
+Cilium has a chicken-and-egg problem: Flux needs pod networking to
+reconcile, but Flux is normally what installs the CNI. Resolution:
+Terraform installs Cilium first via the Talos API, then Flux adopts the
+running HelmRelease so day-2 changes flow through GitOps.
+
+## Flow
+
+```mermaid
+flowchart LR
+    tf[Terraform<br/>terraform/cni/cilium]
+    flux[Flux helm-controller]
+
+    subgraph systemcni[system-cni]
+        helmrel[HelmRelease cilium]
+    end
+
+    subgraph kubesystem[kube-system _release target_]
+        agent[cilium-agent<br/>DaemonSet]
+        operator[cilium-operator]
+    end
+
+    tf -->|bootstrap via Talos API| helmrel
+    flux -->|adopts and reconciles| helmrel
+    helmrel --> agent
+    helmrel --> operator
+
+    agent -.cilium/gateway.- gw[Gateway API controller]
+    agent -.cilium/l2.- l2[L2 announcer + IPPool]
+    agent -.cilium/hubble.- hubble[Hubble Relay + UI]
+```
+
+The Terraform module sets `privileged: false` and `cgroup_auto_mount:
+false` (Talos forbids privileged pods and mounts cgroups at init);
+`cilium/talos` re-applies the same settings via Helm values so the
+Flux-adopted release does not flap the deployment between reconciles.
+
+## Recipes
+
+This stack has a single Kustomization (`cni`) with two `when:` variants —
+`talos_enabled` and `eks_enabled`. Each emits a different component set.
+
+The recipes below show the materialized form assuming `policies.enabled` and
+`telemetry_effective.metrics_enabled` are on (the platform-base defaults).
+If either is disabled, the corresponding `dependsOn` entry drops and the
+related conditional component (`cilium/prometheus`) is omitted.
+
+### Talos (default `windsor up`)
+
+```yaml
+- name: cni
+  path: cni
+  dependsOn: [policy-resources, telemetry-base]
+  components:
+    - cilium
+    - cilium/talos
+    - cilium/prometheus
+    - cilium/hubble
+    - cilium/l2
+  substitutions:
+    k8s_service_host: 10.5.0.10
+    loadbalancer_start_ip: 10.5.1.10
+    loadbalancer_end_ip: 10.5.1.30
+    cluster_name: local
+    operator_replicas: "2"
+  timeout: 15m
+```
+
+### Talos with Cilium as the gateway driver
+
+Adds the `cilium/gateway` component, which enables Cilium's built-in
+Gateway API controller and ships a Kyverno ClusterPolicy that races-fixes
+LBIPAM IP sharing on Cilium-managed Gateway services.
+
+```yaml
+- name: cni
+  path: cni
+  dependsOn: [policy-resources, telemetry-base, gateway-base]
+  components:
+    - cilium
+    - cilium/talos
+    - cilium/gateway
+    - cilium/prometheus
+    - cilium/hubble
+    - cilium/l2
+  substitutions:
+    k8s_service_host: 10.5.0.10
+    loadbalancer_start_ip: 10.5.1.10
+    loadbalancer_end_ip: 10.5.1.30
+    cluster_name: local
+    operator_replicas: "2"
+```
+
+The `gateway-base` entry in `dependsOn` is contributed by `option-gateway`
+(not `option-cni`): option-gateway patches the `cni` Kustomization to wait
+for `gateway-base` so the Gateway API CRDs are present before
+cilium-operator starts. Without that ordering, cilium-operator initializes
+without the Gateway controller and never reconciles HTTPRoutes.
+
+### EKS
+
+EKS clusters use the AWS-managed control plane; no Talos-specific patches
+and no L2 announcer (EKS provides its own LB via the AWS LB Controller in
+the `lb` stack). `k8s_service_host` is parsed from the cluster Terraform
+output.
+
+```yaml
+- name: cni
+  path: cni
+  dependsOn: [policy-resources, telemetry-base]
+  components:
+    - cilium
+    - cilium/prometheus
+    - cilium/hubble
+  substitutions:
+    k8s_service_host: <parsed from terraform_output('cluster', 'cluster_endpoint')>
+    cluster_name: prod
+    operator_replicas: "2"
+```
+
+## Substitutions
+
+| Name | Required when | Effect |
+|---|---|---|
+| `k8s_service_host` | always | API server hostname Cilium reaches before its eBPF service rules are active. On Talos comes from `talos_common.k8s_service_host` (cidrhost offset 10); on EKS parsed from the cluster Terraform output. |
+| `cluster_name` | always | Cilium cluster identity stamped onto Hubble flows, metrics, and (if enabled) ClusterMesh routing. The Windsor context name. |
+| `operator_replicas` | always | 1 on single-node clusters (avoids pending pods + Lease churn), 2 on HA. Defaults to 1 via the kustomize fallback `${operator_replicas:=1}`. |
+| `loadbalancer_start_ip` | `cilium/l2` is enabled (Talos) | Start of the LBIPAM IP pool. Stamped onto `CiliumLoadBalancerIPPool/default`. |
+| `loadbalancer_end_ip` | `cilium/l2` is enabled (Talos) | End of the LBIPAM IP pool. |
+
+## Components
+
+| Component | Enable when | Effect |
+|---|---|---|
+| `cilium` | always | Helm release of Cilium v1.19.3 in `system-cni`, targeting `kube-system`. `kubeProxyReplacement: true`, `ipam.mode: kubernetes`, image pinning, base values. |
+| `cilium/talos` | platform is Talos | Replaces full privileged mode with explicit Linux capabilities (CHOWN, NET_ADMIN, etc.) and disables cgroup auto-mount (Talos already mounted cgroups at boot). |
+| `cilium/gateway` | Cilium is the Gateway driver | Sets `gatewayAPI.enabled: true` (also `enableAlpn`, `enableAppProtocol`) and ships a Kyverno ClusterPolicy that injects LBIPAM sharing annotations onto Cilium-owned Gateway services at admission time. The policy fixes a create-then-patch race in cilium-operator that would otherwise prevent IP sharing on first reconcile. |
+| `cilium/prometheus` | telemetry metrics enabled | Enables Prometheus on the operator and agent and creates a ServiceMonitor for each. |
+| `cilium/hubble` | always | Enables Hubble metrics (dns, drop, port-distribution, tcp, flow, icmp, http), Hubble Relay, Hubble UI, and the cronJob-based TLS rotation method. The Helm `auto.method: cronJob` choice avoids a known bug where `helm` mode re-renders server-secret on every upgrade and trips on newly-enabled Hubble components. |
+| `cilium/l2` | platform is Talos (or any cluster needing in-cluster LB) | Enables `l2announcements` and `externalIPs` on Cilium, then creates `CiliumLoadBalancerIPPool/default` with the configured IP range and `CiliumL2AnnouncementPolicy/default` matching `^eth[0-9]+` and `^ens[0-9]+` interfaces. Replaces kube-vip and MetalLB on Talos clusters. |
+
+## Dependencies
+
+| Stack | Reason |
+|---|---|
+| `policy-resources` *(when policies enabled, or Cilium is the gateway driver)* | Re-rolls Cilium pods after Kyverno's mutation policies are live. When `cilium/gateway` is active, `policy-resources` also provides the Kyverno CRDs the LBIPAM sharing ClusterPolicy depends on — without it the apply would fail on `no matches for kind ClusterPolicy`. |
+| `telemetry-base` *(when telemetry metrics or logs enabled)* | The `cilium/prometheus` ServiceMonitor and the Hubble ServiceMonitor target Prometheus from the telemetry stack; without it they have no scrape target. |
+
+The Terraform `cni` module bootstraps Cilium directly via the Talos API
+before Flux exists. Terraform `cni` `dependsOn: cluster` (the cluster must
+be provisioned), and Terraform `gitops` `dependsOn: cni` (Flux must wait
+for pod networking).
+
+Reverse dependencies — stacks that depend on `cni`:
+
+- `gateway-resources` `dependsOn: cni` when Cilium is the gateway driver. Without ordering, the Kyverno LBIPAM policy may not be in place when cilium-operator creates the gateway Service, and the LB IP won't be shared.
+- `csi` `dependsOn: cni` always. CSI's node-driver-registrar can see transient loopback connectivity drops during eBPF init and crash-loop without this ordering.
+- `observability` adds the `grafana/dashboards/cilium` component when Grafana is the dashboard backend.
+
+## Operations
+
+Stack-specific failure modes; generic Flux/Renovate behaviour is documented
+at the repo level.
+
+- **Cilium pods crash-looping on Talos with `Operation not permitted`** — the `cilium/talos` component is missing or its capabilities patch didn't apply. Confirm the helm-release values include `securityContext.capabilities.ciliumAgent`. Talos rejects full privileged mode.
+- **`cilium-operator` does not create a Gateway controller on Cilium clusters** — the Gateway API CRDs were not present when the operator started. The reverse dep `cni dependsOn gateway-base` (added by `option-gateway`) prevents this in fresh installs; if it fires post-install, restart `cilium-operator`.
+- **Cilium gateway Service has no LB IP** — the LBIPAM sharing annotations weren't injected. Verify the `cilium-gateway-lbipam-sharing` ClusterPolicy is `Ready` and the `cilium-lbipam-config` ConfigMap in `system-gateway` exists. The policy reads `gatewayIp` from that ConfigMap; without it the mutation fails open.
+- **`HelmRelease/cilium` reports `no matches for kind CiliumLoadBalancerIPPool`** — `cilium/l2` is enabled but the Cilium CRDs aren't ready. The Cilium chart installs them; the bootstrap path (Terraform → Flux adoption) means the CRDs come up with the agent. If this fires, the Flux reconcile is racing the chart install — re-reconcile.
+- **Re-running `windsor up` flaps Cilium between two replica counts** — Terraform `operator_replicas` and the Flux substitution differ. Both must derive from `topology_effective` (1 for single-node, 2 otherwise).
+
+Cilium's metrics ServiceMonitors are scraped by the `telemetry` stack
+(`release: kube-prometheus-stack` label set by `cilium/prometheus`). Hubble
+flows are accessible via Hubble UI; Hubble Relay exposes a gRPC endpoint
+for `hubble observe`.
+
+## Security
+
+- The `system-cni` namespace has no PSA labels in its manifest (see [namespace.yaml](namespace.yaml)). Cilium workloads live in `kube-system`; the Cilium DaemonSet uses host networking and elevated Linux capabilities (full set on non-Talos, restricted explicit set on Talos via `cilium/talos`).
+- `kubeProxyReplacement: true` means Cilium replaces kube-proxy entirely. Removing the `cni` stack does not restore kube-proxy automatically.
+- Hubble TLS certificates rotate via an in-cluster CronJob (cert-manager is not required for Hubble).
+- The `cilium-gateway-lbipam-sharing` Kyverno ClusterPolicy mutates Services in `system-gateway` that Cilium creates. Scope is restricted by namespace and by the `io.cilium.gateway/owning-gateway: external` label selector — it does not affect Services outside `system-gateway` or non-Cilium Services.
+
+## See also
+
+- [contexts/_template/facets/option-cni.yaml](../../contexts/_template/facets/option-cni.yaml) — canonical wiring for both Talos and EKS variants, plus reverse-dep injections into `gateway-resources`, `csi`, and `observability`.
+- [terraform/cni/cilium/](../../terraform/cni/cilium/) — Terraform bootstrap module that installs Cilium pre-Flux.
+- Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
+- Related stacks: [policy](../policy/), [telemetry](../telemetry/), [gateway](../gateway/), [csi](../csi/), [lb](../lb/).

--- a/kustomize/csi/README.md
+++ b/kustomize/csi/README.md
@@ -1,14 +1,14 @@
 ---
-title: CSI stack
+title: CSI add-on
 description: Persistent storage drivers and StorageClasses — AWS EBS, Azure Disk, OpenEBS host-path, Longhorn distributed.
 ---
 
 # CSI
 
-The cluster's persistent-volume layer. Four drivers ship in this stack, one
+The cluster's persistent-volume layer. Four drivers ship in this add-on, one
 selected per platform:
 
-- **AWS EBS** — uses the EBS CSI driver preinstalled on EKS. This stack only adds the StorageClass.
+- **AWS EBS** — uses the EBS CSI driver preinstalled on EKS. This add-on only adds the StorageClass.
 - **Azure Disk** — uses the Azure Disk CSI driver preinstalled on AKS. Same shape: StorageClass only.
 - **OpenEBS host-path** — installs the OpenEBS chart and a `local` StorageClass that allocates from a host directory. Default for local single-node clusters.
 - **Longhorn** — installs the Longhorn chart, a distributed replicated block-storage system. Default for HA clusters on incus / metal.
@@ -169,7 +169,7 @@ Drivers are mutually exclusive — pick one per cluster.
 
 ## Dependencies
 
-| Stack | Reason |
+| Add-on | Reason |
 |---|---|
 | `policy-resources` *(when `policies.enabled: true`)* | The `system-csi` namespace runs at PSA `privileged` (storage drivers need host privileges); Kyverno's image-digest policy must be in place before the CSI driver pods are admitted. |
 | `cni` | Added by `option-cni` as a reverse dep. CSI's `node-driver-registrar` sees transient loopback connectivity drops during eBPF init and crash-loops without this ordering. |
@@ -177,18 +177,18 @@ Drivers are mutually exclusive — pick one per cluster.
 
 ## Operations
 
-Stack-specific failure modes; generic Flux/Renovate behaviour is documented
+Add-on-specific failure modes; generic Flux/Renovate behaviour is documented
 at the repo level.
 
 - **PVC stuck `Pending` with `no persistent volumes available`** — the StorageClass's `volumeBindingMode: WaitForFirstConsumer` means the volume is only provisioned when a Pod actually schedules. If the Pod is also `Pending`, no volume gets created. Check the Pod's events first.
 - **OpenEBS PVCs fail with `directory not found`** — the path set by `cluster.storage.local_base_path` doesn't exist on the node that scheduled the Pod. Talos clusters provision the default `/var/mnt/local` via machine config; if you override the path, every node needs the matching directory pre-created.
-- **Longhorn pods crash on Talos with `mount propagation errors`** — Longhorn requires `iscsiadm` and bidirectional mount propagation. Talos clusters need an iSCSI system extension installed in the Talos image config (not in this stack). Check the cluster's Talos machine config if engine pods fail to start.
+- **Longhorn pods crash on Talos with `mount propagation errors`** — Longhorn requires `iscsiadm` and bidirectional mount propagation. Talos clusters need an iSCSI system extension installed in the Talos image config (not in this add-on). Check the cluster's Talos machine config if engine pods fail to start.
 - **Longhorn HA degraded after a node reboot** — `replicaSoftAntiAffinity: false` enforces hard anti-affinity. After a reboot, replicas may need to be manually rebuilt; check `kubectl get volumes.longhorn.io -A`.
 - **Longhorn `single-node` patch absent on a controlplane-only cluster** — without the toleration, longhorn pods don't schedule on tainted control planes and no storage is available. Set `cluster.controlplanes.schedulable: true` (or `topology: single-node`) so the patch is applied.
 - **`HelmRelease/csi` reports `no matches for kind StorageClass`** — usually a race; the StorageClass CRD is built into Kubernetes so this only happens during early bootstrap. Re-reconcile.
 
 Longhorn exposes a UI through the `longhorn-frontend` Service (chart default).
-This stack does not ship an HTTPRoute for it — add one manually if external
+This add-on does not ship an HTTPRoute for it — add one manually if external
 access is needed.
 
 ## Security
@@ -207,4 +207,4 @@ access is needed.
 - [contexts/_template/facets/option-single-node.yaml](../../contexts/_template/facets/option-single-node.yaml) — single-node OpenEBS overlay.
 - [contexts/_template/facets/option-cni.yaml](../../contexts/_template/facets/option-cni.yaml) — adds the `cni` reverse dep.
 - Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
-- Related stacks: [policy](../policy/), [cni](../cni/), [telemetry](../telemetry/), [observability](../observability/).
+- Related add-ons: [policy](../policy/), [cni](../cni/), [telemetry](../telemetry/), [observability](../observability/).

--- a/kustomize/csi/README.md
+++ b/kustomize/csi/README.md
@@ -1,0 +1,210 @@
+---
+title: CSI stack
+description: Persistent storage drivers and StorageClasses — AWS EBS, Azure Disk, OpenEBS host-path, Longhorn distributed.
+---
+
+# CSI
+
+The cluster's persistent-volume layer. Four drivers ship in this stack, one
+selected per platform:
+
+- **AWS EBS** — uses the EBS CSI driver preinstalled on EKS. This stack only adds the StorageClass.
+- **Azure Disk** — uses the Azure Disk CSI driver preinstalled on AKS. Same shape: StorageClass only.
+- **OpenEBS host-path** — installs the OpenEBS chart and a `local` StorageClass that allocates from a host directory. Default for local single-node clusters.
+- **Longhorn** — installs the Longhorn chart, a distributed replicated block-storage system. Default for HA clusters on incus / metal.
+
+Single Kustomization (`csi`) — no `base`/`resources` split. Each driver is a
+component group; platform / option facets pick exactly one.
+
+## Flow
+
+```mermaid
+flowchart LR
+    pvc[PersistentVolumeClaim]
+
+    subgraph systemcsi[system-csi]
+        sc[StorageClass<br/>'single' / 'replicated' / 'local']
+        driver{CSI driver}
+    end
+
+    pvc --> sc --> driver
+    driver -->|aws-ebs| ebs[(EBS volume)]
+    driver -->|azure-disk| azdisk[(Azure managed disk)]
+    driver -->|openebs hostpath| hostpath[(Host directory<br/>cluster.storage.local_base_path)]
+    driver -->|longhorn| longhorndist[(Longhorn replicated<br/>block storage)]
+```
+
+The default StorageClass is named `single` regardless of driver — workloads
+that ask for the cluster's default disk get a per-cluster-appropriate
+provisioner without knowing which one is wired. Longhorn HA clusters also
+get a `replicated` StorageClass for explicit multi-replica volumes.
+
+## Recipes
+
+The recipes below show the materialized kustomize entry for typical
+scenarios. Each heading lists the `values.yaml` fields that select this
+shape; the YAML is what the facets compose from those inputs. Conditional
+`dependsOn` entries (e.g. `policy-resources` is gated on `policies.enabled:
+true`) are shown unconditionally for readability — drop them if the gate
+is false. The `cni` entry and the `openebs/single-node` component are
+contributed by sibling facets (`option-cni` and `option-single-node`).
+
+### AWS (EKS)
+
+Selected by `platform: aws`. Uses the EBS CSI driver preinstalled on EKS.
+
+```yaml
+- name: csi
+  path: csi
+  dependsOn: [policy-resources]
+  components:
+    - aws-ebs
+  timeout: 5m
+  substitutions:
+    single_storage_type: gp3
+```
+
+### Azure (AKS)
+
+Selected by `platform: azure`. Uses the Azure Disk CSI driver preinstalled
+on AKS.
+
+```yaml
+- name: csi
+  path: csi
+  dependsOn: [policy-resources]
+  components:
+    - azure-disk
+  timeout: 5m
+  substitutions:
+    single_storage_type: StandardSSD_LRS
+```
+
+### Local single-node with OpenEBS host-path
+
+Selected by `cluster.storage.driver: openebs` (the default on local
+single-node clusters). `cluster.storage.local_base_path` controls the host
+directory (default `/var/mnt/local`).
+
+```yaml
+- name: csi
+  path: csi
+  dependsOn: [policy-resources, cni]
+  components:
+    - openebs
+    - openebs/single-node
+    - openebs/dynamic-localpv
+  timeout: 20m
+  substitutions:
+    local_volume_path: /var/mnt/local
+```
+
+### HA cluster with Longhorn
+
+Selected by `cluster.storage.driver: longhorn` AND `cluster.topology: ha`.
+The `longhorn/prometheus` component is added when
+`addons.observability.enabled: true`.
+
+```yaml
+- name: csi
+  path: csi
+  dependsOn: [policy-resources, telemetry-base, cni]
+  components:
+    - longhorn
+    - longhorn/ha
+    - longhorn/prometheus
+  timeout: 20m
+```
+
+### Local Longhorn
+
+Selected by `cluster.storage.driver: longhorn` plus
+`cluster.topology: single-node` OR `cluster.controlplanes.schedulable: true`.
+
+```yaml
+- name: csi
+  path: csi
+  dependsOn: [policy-resources, telemetry-base, cni]
+  components:
+    - longhorn
+    - longhorn/single-node
+  timeout: 20m
+```
+
+## Substitutions
+
+| Name | Required when | Effect |
+|---|---|---|
+| `single_storage_type` | `aws-ebs` or `azure-disk` is enabled | Disk type for the cloud StorageClass. Sourced from `cluster.storage.single_storage_type`. AWS values: `gp3` (default), `gp2`, `io1`, etc. Azure values: `StandardSSD_LRS` (default), `Premium_LRS`, etc. |
+| `local_volume_path` | `openebs/dynamic-localpv` is enabled | Host directory the OpenEBS hostpath provisioner allocates from. Sourced from `cluster.storage.local_base_path` (schema default `/var/mnt/local`). The directory must exist on every node before any PVC is created. |
+
+## Components
+
+The base kustomization is empty (`resources: []` after the namespace).
+Drivers are mutually exclusive — pick one per cluster.
+
+### Cloud drivers (StorageClass-only; CSI driver is preinstalled by the cloud)
+
+| Component | Effect |
+|---|---|
+| `aws-ebs` | StorageClass `single` (default class) using `ebs.csi.aws.com`, `WaitForFirstConsumer`, `allowVolumeExpansion: true`, `encrypted: true`, `fsType: ext4`, type from `${single_storage_type}`. |
+| `azure-disk` | StorageClass `single` (default class) using `disk.csi.azure.com`, `WaitForFirstConsumer`, `allowVolumeExpansion: true`, `cachingMode: ReadWrite`, `fsType: ext4`, skuName from `${single_storage_type}`. |
+
+### OpenEBS host-path
+
+| Component | Effect |
+|---|---|
+| `openebs` | Helm release of OpenEBS v4.4.0 in `system-csi`. The chart's `localpv-provisioner.enabled: false` here — it's enabled by the variant components below so single-node clusters can disable leader election. |
+| `openebs/single-node` | Patches the helm release to set `localpv-provisioner.localpv.enableLeaderElection: false`. Used on single-node clusters. |
+| `openebs/dynamic-localpv` | Patches the helm release (presumably to enable the localpv-provisioner) and creates two StorageClasses: `local` and `single` (default), both `openebs.io/local` hostpath, `BasePath: ${local_volume_path}`, `WaitForFirstConsumer`. |
+
+### Longhorn
+
+| Component | Effect |
+|---|---|
+| `longhorn` | Helm release of Longhorn v1.11.1 in `system-csi`, plus a StorageClass `single` (default class) using `driver.longhorn.io` with `numberOfReplicas: "1"`, `volumeBindingMode: Immediate`, `allowVolumeExpansion: true`. |
+| `longhorn/single-node` | Patches the helm release to set `defaultSettings.taintToleration: "node-role.kubernetes.io/control-plane:NoSchedule"` so Longhorn pods can schedule on tainted control planes. Used when `cluster.controlplanes.schedulable: true` OR `cluster.topology: single-node`. |
+| `longhorn/ha` | Patches the helm release for HA: `defaultReplicaCount: 3`, `replicaSoftAntiAffinity: false`, `allowVolumeCreationWithDegradedAvailability: false`, `longhornUI.replicas: 2`, CSI sidecar replicas at 3. Adds a second StorageClass `replicated` with `numberOfReplicas: "3"` for explicit multi-replica volumes. Used when `cluster.topology: ha`. |
+| `longhorn/prometheus` | ServiceMonitor for `longhorn-manager` metrics on the `manager` port. Used when `addons.observability.enabled: true`. |
+
+## Dependencies
+
+| Stack | Reason |
+|---|---|
+| `policy-resources` *(when `policies.enabled: true`)* | The `system-csi` namespace runs at PSA `privileged` (storage drivers need host privileges); Kyverno's image-digest policy must be in place before the CSI driver pods are admitted. |
+| `cni` | Added by `option-cni` as a reverse dep. CSI's `node-driver-registrar` sees transient loopback connectivity drops during eBPF init and crash-loops without this ordering. |
+| `telemetry-base` *(longhorn + `telemetry.metrics.enabled` or `telemetry.logs.enabled`)* | The `longhorn/prometheus` ServiceMonitor needs Prometheus to be live. |
+
+## Operations
+
+Stack-specific failure modes; generic Flux/Renovate behaviour is documented
+at the repo level.
+
+- **PVC stuck `Pending` with `no persistent volumes available`** — the StorageClass's `volumeBindingMode: WaitForFirstConsumer` means the volume is only provisioned when a Pod actually schedules. If the Pod is also `Pending`, no volume gets created. Check the Pod's events first.
+- **OpenEBS PVCs fail with `directory not found`** — the path set by `cluster.storage.local_base_path` doesn't exist on the node that scheduled the Pod. Talos clusters provision the default `/var/mnt/local` via machine config; if you override the path, every node needs the matching directory pre-created.
+- **Longhorn pods crash on Talos with `mount propagation errors`** — Longhorn requires `iscsiadm` and bidirectional mount propagation. Talos clusters need an iSCSI system extension installed in the Talos image config (not in this stack). Check the cluster's Talos machine config if engine pods fail to start.
+- **Longhorn HA degraded after a node reboot** — `replicaSoftAntiAffinity: false` enforces hard anti-affinity. After a reboot, replicas may need to be manually rebuilt; check `kubectl get volumes.longhorn.io -A`.
+- **Longhorn `single-node` patch absent on a controlplane-only cluster** — without the toleration, longhorn pods don't schedule on tainted control planes and no storage is available. Set `cluster.controlplanes.schedulable: true` (or `cluster.topology: single-node`) so the patch is applied.
+- **`HelmRelease/csi` reports `no matches for kind StorageClass`** — usually a race; the StorageClass CRD is built into Kubernetes so this only happens during early bootstrap. Re-reconcile.
+
+Longhorn exposes a UI through the `longhorn-frontend` Service (chart default).
+This stack does not ship an HTTPRoute for it — add one manually if external
+access is needed.
+
+## Security
+
+- The `system-csi` namespace runs at PSA `privileged`. CSI drivers need access to host devices, mount namespaces, and (for Longhorn) iSCSI tooling.
+- AWS EBS volumes are `encrypted: true` by default — uses the AWS account default KMS key unless overridden.
+- Azure Disk uses `StandardSSD_LRS` (Standard SSD with locally redundant storage) by default. For Premium / zone-redundant variants, override `single_storage_type`.
+- OpenEBS hostpath stores data under the path set by `cluster.storage.local_base_path` on each node. There is no encryption at rest; rely on disk-level encryption from the underlying OS or platform.
+- Longhorn replicas are stored on each node's local disk under `/var/lib/longhorn`. Encryption at rest is not enabled by default; the `defaultSettings.encryption*` fields can be set in a custom patch.
+
+## See also
+
+- [contexts/_template/facets/platform-aws.yaml](../../contexts/_template/facets/platform-aws.yaml) — AWS EBS StorageClass wiring.
+- [contexts/_template/facets/platform-azure.yaml](../../contexts/_template/facets/platform-azure.yaml) — Azure Disk StorageClass wiring.
+- [contexts/_template/facets/option-storage.yaml](../../contexts/_template/facets/option-storage.yaml) — OpenEBS and Longhorn driver selection (resolves `cluster.storage.driver`).
+- [contexts/_template/facets/option-single-node.yaml](../../contexts/_template/facets/option-single-node.yaml) — single-node OpenEBS overlay.
+- [contexts/_template/facets/option-cni.yaml](../../contexts/_template/facets/option-cni.yaml) — adds the `cni` reverse dep.
+- Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
+- Related stacks: [policy](../policy/), [cni](../cni/), [telemetry](../telemetry/), [observability](../observability/).

--- a/kustomize/csi/README.md
+++ b/kustomize/csi/README.md
@@ -101,7 +101,7 @@ directory (default `/var/mnt/local`).
 
 ### HA cluster with Longhorn
 
-Selected by `cluster.storage.driver: longhorn` AND `cluster.topology: ha`.
+Selected by `cluster.storage.driver: longhorn` AND `topology: ha`.
 The `longhorn/prometheus` component is added when
 `addons.observability.enabled: true`.
 
@@ -119,7 +119,7 @@ The `longhorn/prometheus` component is added when
 ### Local Longhorn
 
 Selected by `cluster.storage.driver: longhorn` plus
-`cluster.topology: single-node` OR `cluster.controlplanes.schedulable: true`.
+`topology: single-node` OR `cluster.controlplanes.schedulable: true`.
 
 ```yaml
 - name: csi
@@ -163,8 +163,8 @@ Drivers are mutually exclusive — pick one per cluster.
 | Component | Effect |
 |---|---|
 | `longhorn` | Helm release of Longhorn v1.11.1 in `system-csi`, plus a StorageClass `single` (default class) using `driver.longhorn.io` with `numberOfReplicas: "1"`, `volumeBindingMode: Immediate`, `allowVolumeExpansion: true`. |
-| `longhorn/single-node` | Patches the helm release to set `defaultSettings.taintToleration: "node-role.kubernetes.io/control-plane:NoSchedule"` so Longhorn pods can schedule on tainted control planes. Used when `cluster.controlplanes.schedulable: true` OR `cluster.topology: single-node`. |
-| `longhorn/ha` | Patches the helm release for HA: `defaultReplicaCount: 3`, `replicaSoftAntiAffinity: false`, `allowVolumeCreationWithDegradedAvailability: false`, `longhornUI.replicas: 2`, CSI sidecar replicas at 3. Adds a second StorageClass `replicated` with `numberOfReplicas: "3"` for explicit multi-replica volumes. Used when `cluster.topology: ha`. |
+| `longhorn/single-node` | Patches the helm release to set `defaultSettings.taintToleration: "node-role.kubernetes.io/control-plane:NoSchedule"` so Longhorn pods can schedule on tainted control planes. Used when `cluster.controlplanes.schedulable: true` OR `topology: single-node`. |
+| `longhorn/ha` | Patches the helm release for HA: `defaultReplicaCount: 3`, `replicaSoftAntiAffinity: false`, `allowVolumeCreationWithDegradedAvailability: false`, `longhornUI.replicas: 2`, CSI sidecar replicas at 3. Adds a second StorageClass `replicated` with `numberOfReplicas: "3"` for explicit multi-replica volumes. Used when `topology: ha`. |
 | `longhorn/prometheus` | ServiceMonitor for `longhorn-manager` metrics on the `manager` port. Used when `addons.observability.enabled: true`. |
 
 ## Dependencies
@@ -184,7 +184,7 @@ at the repo level.
 - **OpenEBS PVCs fail with `directory not found`** — the path set by `cluster.storage.local_base_path` doesn't exist on the node that scheduled the Pod. Talos clusters provision the default `/var/mnt/local` via machine config; if you override the path, every node needs the matching directory pre-created.
 - **Longhorn pods crash on Talos with `mount propagation errors`** — Longhorn requires `iscsiadm` and bidirectional mount propagation. Talos clusters need an iSCSI system extension installed in the Talos image config (not in this stack). Check the cluster's Talos machine config if engine pods fail to start.
 - **Longhorn HA degraded after a node reboot** — `replicaSoftAntiAffinity: false` enforces hard anti-affinity. After a reboot, replicas may need to be manually rebuilt; check `kubectl get volumes.longhorn.io -A`.
-- **Longhorn `single-node` patch absent on a controlplane-only cluster** — without the toleration, longhorn pods don't schedule on tainted control planes and no storage is available. Set `cluster.controlplanes.schedulable: true` (or `cluster.topology: single-node`) so the patch is applied.
+- **Longhorn `single-node` patch absent on a controlplane-only cluster** — without the toleration, longhorn pods don't schedule on tainted control planes and no storage is available. Set `cluster.controlplanes.schedulable: true` (or `topology: single-node`) so the patch is applied.
 - **`HelmRelease/csi` reports `no matches for kind StorageClass`** — usually a race; the StorageClass CRD is built into Kubernetes so this only happens during early bootstrap. Re-reconcile.
 
 Longhorn exposes a UI through the `longhorn-frontend` Service (chart default).

--- a/kustomize/database/README.md
+++ b/kustomize/database/README.md
@@ -1,0 +1,146 @@
+---
+title: Database stack
+description: PostgreSQL operator (CloudNativePG) — installs the operator only; tenant Postgres clusters are created by workloads.
+---
+
+# Database
+
+Installs the CloudNativePG operator in `system-database`. The operator
+watches `Cluster` (cnpg.io/v1) resources cluster-wide; tenants create their
+own `Cluster` objects to provision Postgres instances. This stack does NOT
+ship a tenant Postgres cluster — it only deploys the operator and (on HA
+clusters) makes the operator itself highly available.
+
+`cloudnative-pg` is currently the only supported driver
+(`addons.database.postgres.driver: cloudnativepg`). The stack is gated on
+`addons.database.postgres.enabled: true` — disabled by default.
+
+## Flow
+
+```mermaid
+flowchart LR
+    cluster[(Cluster cnpg.io/v1<br/>tenant-defined)]
+
+    subgraph systemdatabase[system-database]
+        operator[cloudnative-pg<br/>operator]
+    end
+
+    subgraph tenantns[tenant namespaces]
+        instance[Postgres pods<br/>+ PVCs]
+    end
+
+    cluster -.watched by.-> operator
+    operator -->|reconciles| instance
+    instance -.PVCs.-> csi[(CSI StorageClass)]
+```
+
+The operator runs `clusterWide: true` so a single deployment watches
+`Cluster` resources in every namespace. Tenants do not need to install
+their own operator copies.
+
+## Recipes
+
+### Default (HA topology)
+
+Both `addons.database.postgres.enabled: true` and `topology: ha`.
+The `cloudnativepg/ha` component layers anti-affinity and a
+PodDisruptionBudget onto the operator deployment.
+
+```yaml
+- name: database
+  path: database
+  dependsOn: [csi]
+  components:
+    - cloudnativepg
+    - cloudnativepg/prometheus
+    - cloudnativepg/ha
+  timeout: 15m
+  interval: 10m
+```
+
+### Single-node
+
+`addons.database.postgres.enabled: true` and `topology: single-node`.
+`option-single-node` adds the `cloudnativepg/single-node` component which
+disables the operator's leader election.
+
+```yaml
+- name: database
+  path: database
+  dependsOn: [csi]
+  components:
+    - cloudnativepg
+    - cloudnativepg/single-node
+    - cloudnativepg/prometheus
+  timeout: 15m
+```
+
+### With Grafana dashboard
+
+When `addons.observability.enabled: true` is also on, `addon-database`
+patches the observability stack to add the CloudNativePG dashboard. Wired
+separately from the database stack itself:
+
+```yaml
+- name: observability
+  path: observability
+  dependsOn: [telemetry-base]
+  components:
+    - grafana/dashboards/cloudnativepg
+```
+
+## Substitutions
+
+This stack does not consume any blueprint substitutions. Behavior is
+fully driven by component selection.
+
+## Components
+
+| Component | Enable when | Effect |
+|---|---|---|
+| `cloudnativepg` | `addons.database.postgres.driver: cloudnativepg` | Helm release of `cloudnative-pg` v0.28.0 in `system-database`. Operator image v1.29.0. `clusterWide: true` so the operator watches `Cluster` resources in every namespace. Webhook `failurePolicy: Fail` (admission rejects requests if the webhook is down). Resource requests 250m/256Mi, memory limit 256Mi. |
+| `cloudnativepg/single-node` | `topology: single-node` | Appends `--leader-elect=false` to the operator's `additionalArgs`. The chart unconditionally passes `--leader-elect`; Go's flag parser applies last-wins so the override sticks. |
+| `cloudnativepg/ha` | `topology: ha` | `operator.replicaCount: 2`, hard pod anti-affinity (hostname topology key), PodDisruptionBudget with `minAvailable: 1`, `rollingUpdate.maxUnavailable: 1`. |
+| `cloudnativepg/prometheus` | always (per addon-database) | Adds `monitoring.podMonitorEnabled: true` and labels the PodMonitor with `release: kube-prometheus-stack` so the telemetry stack's Prometheus picks it up. Adds a Flux `dependsOn` so the operator waits for `kube-prometheus-stack` to be ready. |
+
+## Dependencies
+
+| Stack | Reason |
+|---|---|
+| `csi` | Tenant `Cluster` resources allocate PVCs for WAL archives and data volumes as soon as the first one is applied. The operator itself doesn't create PVCs, but reconciliation fails immediately if no StorageClass is available. |
+
+The `cloudnativepg/prometheus` component adds an implicit dependency on
+`kube-prometheus-stack` (in the `telemetry` stack) via Flux's HelmRelease
+`dependsOn`. The `addon-database` facet also patches the observability
+stack to add the Grafana dashboard, but that's a separate Kustomization
+entry rather than a hard dependency of `database`.
+
+## Operations
+
+Stack-specific failure modes; generic Flux/Renovate behaviour is documented
+at the repo level.
+
+- **Tenant `Cluster` stuck creating** — usually a CSI / StorageClass issue. Check the tenant's `Cluster` events and confirm a default StorageClass exists. The operator does not create PVCs eagerly; PVCs come up as the operator reconciles tenant Clusters.
+- **Operator pods crashlooping with `failed to acquire lease`** — leader election is on but multiple replicas can't agree on a leader. On single-node clusters confirm `cloudnativepg/single-node` is enabled (it disables election). On HA clusters the lease conflict is usually a CoreDNS / API issue, not a database issue.
+- **Webhook `failurePolicy: Fail` blocks `Cluster` creation when the operator is down** — by design. If you must apply tenant Clusters during an operator outage, temporarily patch the ValidatingWebhookConfiguration to `failurePolicy: Ignore` (and revert when the operator is healthy).
+- **`HelmRelease/cloudnativepg` reports `no matches for kind PodMonitor`** — `cloudnativepg/prometheus` is enabled but the kube-prometheus-stack CRDs aren't ready yet. The Flux `dependsOn` on `kube-prometheus-stack` should prevent this; if it fires, reconcile in the right order.
+
+The operator exposes Prometheus metrics on each pod via the PodMonitor
+created by `cloudnativepg/prometheus`. Tenant `Cluster` resources also
+emit metrics; they're scraped by the same Prometheus when the
+`Cluster.spec.monitoring.enablePodMonitor` field is set.
+
+## Security
+
+- The `system-database` namespace runs at PSA `baseline`. The operator pod uses a restricted security context: `runAsNonRoot: true`, `allowPrivilegeEscalation: false`, all capabilities dropped, `seccompProfile: RuntimeDefault`.
+- Tenant Postgres pods inherit security context from the operator's defaults. Operators creating `Cluster` resources should set explicit `imagePullSecrets`, `serviceAccount`, and resource limits.
+- The webhook configuration is `failurePolicy: Fail` for both mutating and validating webhooks. This is correct for the operator's role (admission must validate `Cluster` specs) but means an operator outage blocks new tenant Clusters until the webhook is back.
+- WAL and data PVCs are encrypted only if the underlying CSI driver provides encryption (AWS EBS defaults to `encrypted: true`; OpenEBS hostpath does not).
+
+## See also
+
+- [contexts/_template/facets/addon-database.yaml](../../contexts/_template/facets/addon-database.yaml) — canonical wiring (operator + dashboard).
+- [contexts/_template/facets/option-single-node.yaml](../../contexts/_template/facets/option-single-node.yaml) — adds the `cloudnativepg/single-node` patch when topology is single-node.
+- Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
+- CloudNativePG operator docs — https://cloudnative-pg.io/docs/
+- Related stacks: [csi](../csi/), [telemetry](../telemetry/), [observability](../observability/).

--- a/kustomize/database/README.md
+++ b/kustomize/database/README.md
@@ -1,5 +1,5 @@
 ---
-title: Database stack
+title: Database add-on
 description: PostgreSQL operator (CloudNativePG) — installs the operator only; tenant Postgres clusters are created by workloads.
 ---
 
@@ -7,12 +7,12 @@ description: PostgreSQL operator (CloudNativePG) — installs the operator only;
 
 Installs the CloudNativePG operator in `system-database`. The operator
 watches `Cluster` (cnpg.io/v1) resources cluster-wide; tenants create their
-own `Cluster` objects to provision Postgres instances. This stack does NOT
+own `Cluster` objects to provision Postgres instances. This add-on does NOT
 ship a tenant Postgres cluster — it only deploys the operator and (on HA
 clusters) makes the operator itself highly available.
 
 `cloudnative-pg` is currently the only supported driver
-(`addons.database.postgres.driver: cloudnativepg`). The stack is gated on
+(`addons.database.postgres.driver: cloudnativepg`). The add-on is gated on
 `addons.database.postgres.enabled: true` — disabled by default.
 
 ## Flow
@@ -78,8 +78,8 @@ disables the operator's leader election.
 ### With Grafana dashboard
 
 When `addons.observability.enabled: true` is also on, `addon-database`
-patches the observability stack to add the CloudNativePG dashboard. Wired
-separately from the database stack itself:
+patches the observability add-on to add the CloudNativePG dashboard. Wired
+separately from the database add-on itself:
 
 ```yaml
 - name: observability
@@ -91,7 +91,7 @@ separately from the database stack itself:
 
 ## Substitutions
 
-This stack does not consume any blueprint substitutions. Behavior is
+This add-on does not consume any blueprint substitutions. Behavior is
 fully driven by component selection.
 
 ## Components
@@ -101,23 +101,23 @@ fully driven by component selection.
 | `cloudnativepg` | `addons.database.postgres.driver: cloudnativepg` | Helm release of `cloudnative-pg` v0.28.0 in `system-database`. Operator image v1.29.0. `clusterWide: true` so the operator watches `Cluster` resources in every namespace. Webhook `failurePolicy: Fail` (admission rejects requests if the webhook is down). Resource requests 250m/256Mi, memory limit 256Mi. |
 | `cloudnativepg/single-node` | `topology: single-node` | Appends `--leader-elect=false` to the operator's `additionalArgs`. The chart unconditionally passes `--leader-elect`; Go's flag parser applies last-wins so the override sticks. |
 | `cloudnativepg/ha` | `topology: ha` | `operator.replicaCount: 2`, hard pod anti-affinity (hostname topology key), PodDisruptionBudget with `minAvailable: 1`, `rollingUpdate.maxUnavailable: 1`. |
-| `cloudnativepg/prometheus` | always (per addon-database) | Adds `monitoring.podMonitorEnabled: true` and labels the PodMonitor with `release: kube-prometheus-stack` so the telemetry stack's Prometheus picks it up. Adds a Flux `dependsOn` so the operator waits for `kube-prometheus-stack` to be ready. |
+| `cloudnativepg/prometheus` | always (per addon-database) | Adds `monitoring.podMonitorEnabled: true` and labels the PodMonitor with `release: kube-prometheus-stack` so the telemetry add-on's Prometheus picks it up. Adds a Flux `dependsOn` so the operator waits for `kube-prometheus-stack` to be ready. |
 
 ## Dependencies
 
-| Stack | Reason |
+| Add-on | Reason |
 |---|---|
 | `csi` | Tenant `Cluster` resources allocate PVCs for WAL archives and data volumes as soon as the first one is applied. The operator itself doesn't create PVCs, but reconciliation fails immediately if no StorageClass is available. |
 
 The `cloudnativepg/prometheus` component adds an implicit dependency on
-`kube-prometheus-stack` (in the `telemetry` stack) via Flux's HelmRelease
+`kube-prometheus-stack` (in the `telemetry` add-on) via Flux's HelmRelease
 `dependsOn`. The `addon-database` facet also patches the observability
-stack to add the Grafana dashboard, but that's a separate Kustomization
+add-on to add the Grafana dashboard, but that's a separate Kustomization
 entry rather than a hard dependency of `database`.
 
 ## Operations
 
-Stack-specific failure modes; generic Flux/Renovate behaviour is documented
+Add-on-specific failure modes; generic Flux/Renovate behaviour is documented
 at the repo level.
 
 - **Tenant `Cluster` stuck creating** — usually a CSI / StorageClass issue. Check the tenant's `Cluster` events and confirm a default StorageClass exists. The operator does not create PVCs eagerly; PVCs come up as the operator reconciles tenant Clusters.
@@ -143,4 +143,4 @@ emit metrics; they're scraped by the same Prometheus when the
 - [contexts/_template/facets/option-single-node.yaml](../../contexts/_template/facets/option-single-node.yaml) — adds the `cloudnativepg/single-node` patch when topology is single-node.
 - Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
 - CloudNativePG operator docs — https://cloudnative-pg.io/docs/
-- Related stacks: [csi](../csi/), [telemetry](../telemetry/), [observability](../observability/).
+- Related add-ons: [csi](../csi/), [telemetry](../telemetry/), [observability](../observability/).

--- a/kustomize/demo/README.md
+++ b/kustomize/demo/README.md
@@ -1,19 +1,19 @@
 ---
-title: Demo stack
+title: Demo add-on
 description: Example workloads (CNPG cluster, live-reload static site, Istio bookinfo) for trying out cluster features.
 ---
 
 # Demo
 
-Example workloads — not infrastructure. Use this stack to confirm the
+Example workloads — not infrastructure. Use this add-on to confirm the
 cluster's networking, storage, ingress, and database integration paths
 work end-to-end. Each subcomponent is a self-contained sample that runs in
 its own `demo-*` namespace.
 
-`option-demo` gates the whole stack on `demo.enabled: true`. Inside, three
+`option-demo` gates the whole add-on on `demo.enabled: true`. Inside, three
 independent toggles select which samples to deploy:
 
-- `demo.resources.database: true` — a CNPG `Cluster` (depends on the database stack).
+- `demo.resources.database: true` — a CNPG `Cluster` (depends on the database add-on).
 - `demo.resources.static: true` — a live-reload Node.js website with PVC, Service, and Ingress.
 - `demo.resources.bookinfo: true` — Istio's bookinfo sample fetched directly from upstream Istio releases.
 
@@ -64,7 +64,7 @@ The `option-demo` facet emits only the workload components, not the
 
 `dependsOn: [database]` is conditional in the facet — it only fires when
 `demo.resources.database: true` is set. Without the database sample, the
-demo stack has no required `dependsOn`.
+demo add-on has no required `dependsOn`.
 
 ### Just the static site (with Ingress)
 
@@ -114,7 +114,7 @@ resources.
 
 | Component | Effect |
 |---|---|
-| `database` | `Namespace/demo-database` (PSA `baseline`) plus `Cluster/demo-cluster` (cnpg.io/v1): 2 instances, 1Gi storage per replica, 100 max_connections, requests 100m/256Mi, memory limit 512Mi, `monitoring.enablePodMonitor: true` with relabelings. Requires the database stack's CloudNativePG operator to be running first. |
+| `database` | `Namespace/demo-database` (PSA `baseline`) plus `Cluster/demo-cluster` (cnpg.io/v1): 2 instances, 1Gi storage per replica, 100 max_connections, requests 100m/256Mi, memory limit 512Mi, `monitoring.enablePodMonitor: true` with relabelings. Requires the database add-on's CloudNativePG operator to be running first. |
 
 ### `static/`
 
@@ -132,22 +132,22 @@ resources.
 
 ## Dependencies
 
-| Stack | Reason |
+| Add-on | Reason |
 |---|---|
 | `database` *(when `demo.resources.database: true`)* | The CNPG operator (in the `database` Kustomization) must be running before the `Cluster/demo-cluster` resource is admitted. Without it, the apply fails on `no matches for kind Cluster.postgresql.cnpg.io/v1`. |
 
 The `static` and `bookinfo` samples have no hard dependencies in the
 facet; they assume:
 - A default StorageClass (for `static`'s PVC) — comes from `csi`.
-- An IngressClass-default Ingress controller — currently this would be the legacy `ingress` stack, which is not wired by default. The samples use Kubernetes `Ingress` (not Gateway API HTTPRoute), so they do **not** integrate with the modern `gateway` stack out of the box.
+- An IngressClass-default Ingress controller — currently this would be the legacy `ingress` add-on, which is not wired by default. The samples use Kubernetes `Ingress` (not Gateway API HTTPRoute), so they do **not** integrate with the modern `gateway` add-on out of the box.
 
 ## Operations
 
-Stack-specific failure modes; generic Flux/Renovate behaviour is documented
+Add-on-specific failure modes; generic Flux/Renovate behaviour is documented
 at the repo level.
 
 - **`demo-static` Deployment ImagePullBackoff** — `${REGISTRY_URL}` is empty or the registry is unreachable. The image reference becomes `/demo:1.0.6` if the substitution doesn't resolve. Set `REGISTRY_URL` via a substitution in your `option-demo` override.
-- **Ingress hostnames return 404** — no Ingress controller is running. The samples ship `kind: Ingress` (legacy), not `kind: HTTPRoute`. To use the gateway stack instead, replace the Ingress objects with HTTPRoutes manually.
+- **Ingress hostnames return 404** — no Ingress controller is running. The samples ship `kind: Ingress` (legacy), not `kind: HTTPRoute`. To use the gateway add-on instead, replace the Ingress objects with HTTPRoutes manually.
 - **CNPG `Cluster/demo-cluster` stuck `Pending`** — usually a StorageClass or PVC issue. The Cluster requests 1Gi per instance; check `kubectl get pvc -n demo-database` and the default StorageClass.
 - **bookinfo upstream YAML version drift** — the URL is pinned to Istio 1.22.8; Renovate updates the version via the `# renovate:` marker comment. If the URL stops resolving, Renovate has likely landed a newer version that doesn't match the comment's regex.
 
@@ -162,4 +162,4 @@ at the repo level.
 - [contexts/_template/facets/option-demo.yaml](../../contexts/_template/facets/option-demo.yaml) — canonical wiring with the per-sample toggles.
 - [contexts/_template/facets/addon-database.yaml](../../contexts/_template/facets/addon-database.yaml) — required when `demo.resources.database: true` (provides the CNPG operator).
 - Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
-- Related stacks: [database](../database/), [csi](../csi/), [ingress](../ingress/), [gateway](../gateway/).
+- Related add-ons: [database](../database/), [csi](../csi/), [ingress](../ingress/), [gateway](../gateway/).

--- a/kustomize/demo/README.md
+++ b/kustomize/demo/README.md
@@ -1,0 +1,165 @@
+---
+title: Demo stack
+description: Example workloads (CNPG cluster, live-reload static site, Istio bookinfo) for trying out cluster features.
+---
+
+# Demo
+
+Example workloads — not infrastructure. Use this stack to confirm the
+cluster's networking, storage, ingress, and database integration paths
+work end-to-end. Each subcomponent is a self-contained sample that runs in
+its own `demo-*` namespace.
+
+`option-demo` gates the whole stack on `demo.enabled: true`. Inside, three
+independent toggles select which samples to deploy:
+
+- `demo.resources.database: true` — a CNPG `Cluster` (depends on the database stack).
+- `demo.resources.static: true` — a live-reload Node.js website with PVC, Service, and Ingress.
+- `demo.resources.bookinfo: true` — Istio's bookinfo sample fetched directly from upstream Istio releases.
+
+## Flow
+
+```mermaid
+flowchart LR
+    operator[Operator]
+
+    subgraph demodatabase[demo-database]
+        cnpg[Cluster demo-cluster<br/>2 instances · 1Gi PVC]
+    end
+
+    subgraph demostatic[demo-static]
+        site[website Deployment<br/>+ PVC + Service + Ingress]
+    end
+
+    subgraph demobookinfo[demo-bookinfo]
+        bi[Istio bookinfo<br/>productpage / details / ratings / reviews]
+    end
+
+    operator -.toggles.-> cnpg
+    operator -.toggles.-> site
+    operator -.toggles.-> bi
+```
+
+The samples are independent — each one toggles separately. There is no
+flow between them.
+
+## Recipes
+
+### All samples on (including Ingresses)
+
+The `option-demo` facet emits only the workload components, not the
+`*/ingress` sub-components. Hand-author the recipe to include them.
+
+```yaml
+- name: demo
+  path: demo
+  dependsOn: [database]
+  components:
+    - database
+    - static
+    - static/ingress
+    - bookinfo
+    - bookinfo/ingress
+```
+
+`dependsOn: [database]` is conditional in the facet — it only fires when
+`demo.resources.database: true` is set. Without the database sample, the
+demo stack has no required `dependsOn`.
+
+### Just the static site (with Ingress)
+
+The `option-demo` facet only emits `static`, not `static/ingress`.
+Hand-author both for the full demo. Without the ingress component, the
+`website` Service is only reachable in-cluster.
+
+```yaml
+- name: demo
+  path: demo
+  components:
+    - static
+    - static/ingress
+  substitutions:
+    REGISTRY_URL: registry.test:5000
+```
+
+### Just the CNPG demo cluster
+
+```yaml
+- name: demo
+  path: demo
+  dependsOn: [database]
+  components:
+    - database
+```
+
+## Substitutions
+
+| Name | Required when | Effect |
+|---|---|---|
+| `REGISTRY_URL` | `static` is enabled | Container registry hostname for the demo image (`${REGISTRY_URL}/demo:1.0.6`). No kustomize fallback — empty produces an invalid image reference. The `option-demo` facet does NOT emit this; operators must supply it via blueprint substitutions or accept that the static demo won't pull. |
+| `DOMAIN` | `static` or `bookinfo` is enabled | Hostname suffix for the Ingress rules (`static.${DOMAIN:-test}`, `bookinfo.${DOMAIN:-test}`). Falls back to `test` via the kustomize default. The facet does not emit this either; on local clusters the fallback is usually correct. |
+
+Both substitutions are uppercase, suggesting they were originally meant
+to come from environment-style substitution rather than the Windsor schema.
+Treat them as operator-supplied; if you need real values flowing through
+the facet, add a `substitutions:` block to your `option-demo` override.
+
+## Components
+
+The base kustomization is empty (`resources: []`). Each sample is a
+component that brings its own namespace, manifests, and any associated
+resources.
+
+### `database/`
+
+| Component | Effect |
+|---|---|
+| `database` | `Namespace/demo-database` (PSA `baseline`) plus `Cluster/demo-cluster` (cnpg.io/v1): 2 instances, 1Gi storage per replica, 100 max_connections, requests 100m/256Mi, memory limit 512Mi, `monitoring.enablePodMonitor: true` with relabelings. Requires the database stack's CloudNativePG operator to be running first. |
+
+### `static/`
+
+| Component | Effect |
+|---|---|
+| `static` | `Namespace/demo-static` (PSA `restricted`); `Deployment/website` running `${REGISTRY_URL}/demo:1.0.6` on port 8080 with restricted security context (runAsNonRoot, runAsUser 1000, all capabilities dropped, RuntimeDefault seccomp); `Service/website` exposing port 80 → 8080; `PVC/content` requesting 100Mi RWO. **Does not include the Ingress** — that's a separate component (`static/ingress`). |
+| `static/ingress` | Separate Component creating `Ingress/static-ingress` routing `static.${DOMAIN:-test}` to the Service. **Not emitted by `option-demo`** — operators wanting the Ingress must add it to the components list manually. |
+
+### `bookinfo/`
+
+| Component | Effect |
+|---|---|
+| `bookinfo` | `Namespace/demo-bookinfo` (PSA `restricted`) plus the upstream Istio `bookinfo.yaml` (pinned to Istio 1.22.8 via the `https://raw.githubusercontent.com/istio/istio/refs/tags/1.22.8/...` URL — Renovate keeps this version updated via the comment marker). Patches every Deployment to add a restricted security context. The `kustomize` `namespace: demo-bookinfo` directive overrides the namespace of every resource in the upstream YAML. **Does not include the Ingress.** |
+| `bookinfo/ingress` | Separate Component creating `Ingress/productpage-ingress` routing `bookinfo.${DOMAIN:-test}` to the `productpage` Service on port 9080. **Not emitted by `option-demo`** — same pattern as `static/ingress`. |
+
+## Dependencies
+
+| Stack | Reason |
+|---|---|
+| `database` *(when `demo.resources.database: true`)* | The CNPG operator (in the `database` Kustomization) must be running before the `Cluster/demo-cluster` resource is admitted. Without it, the apply fails on `no matches for kind Cluster.postgresql.cnpg.io/v1`. |
+
+The `static` and `bookinfo` samples have no hard dependencies in the
+facet; they assume:
+- A default StorageClass (for `static`'s PVC) — comes from `csi`.
+- An IngressClass-default Ingress controller — currently this would be the legacy `ingress` stack, which is not wired by default. The samples use Kubernetes `Ingress` (not Gateway API HTTPRoute), so they do **not** integrate with the modern `gateway` stack out of the box.
+
+## Operations
+
+Stack-specific failure modes; generic Flux/Renovate behaviour is documented
+at the repo level.
+
+- **`demo-static` Deployment ImagePullBackoff** — `${REGISTRY_URL}` is empty or the registry is unreachable. The image reference becomes `/demo:1.0.6` if the substitution doesn't resolve. Set `REGISTRY_URL` via a substitution in your `option-demo` override.
+- **Ingress hostnames return 404** — no Ingress controller is running. The samples ship `kind: Ingress` (legacy), not `kind: HTTPRoute`. To use the gateway stack instead, replace the Ingress objects with HTTPRoutes manually.
+- **CNPG `Cluster/demo-cluster` stuck `Pending`** — usually a StorageClass or PVC issue. The Cluster requests 1Gi per instance; check `kubectl get pvc -n demo-database` and the default StorageClass.
+- **bookinfo upstream YAML version drift** — the URL is pinned to Istio 1.22.8; Renovate updates the version via the `# renovate:` marker comment. If the URL stops resolving, Renovate has likely landed a newer version that doesn't match the comment's regex.
+
+## Security
+
+- `demo-database` runs at PSA `baseline` (CNPG needs minor flexibility for postgres processes).
+- `demo-static` and `demo-bookinfo` run at PSA `restricted`. The static demo's Deployment ships a fully-restricted security context. The bookinfo patch adds the same security context to every upstream Istio Deployment so they pass `restricted` admission.
+- Demo workloads are not gated on Kyverno policies (the `demo-*` namespaces don't have `policy.windsorcli.dev/managed: "true"` labels), so the `require-image-digest` policy doesn't apply. The demo image (`${REGISTRY_URL}/demo:1.0.6`) is not pinned by digest.
+
+## See also
+
+- [contexts/_template/facets/option-demo.yaml](../../contexts/_template/facets/option-demo.yaml) — canonical wiring with the per-sample toggles.
+- [contexts/_template/facets/addon-database.yaml](../../contexts/_template/facets/addon-database.yaml) — required when `demo.resources.database: true` (provides the CNPG operator).
+- Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
+- Related stacks: [database](../database/), [csi](../csi/), [ingress](../ingress/), [gateway](../gateway/).

--- a/kustomize/dns/README.md
+++ b/kustomize/dns/README.md
@@ -1,0 +1,223 @@
+---
+title: DNS stack
+description: CoreDNS for private zones and external-dns for record automation.
+---
+
+# DNS
+
+Self-hosted DNS for the cluster's private zone, with automatic record
+reconciliation against an in-cluster or cloud provider.
+
+## Flow
+
+```mermaid
+flowchart LR
+    client([Client])
+    sources[Service / Ingress / HTTPRoute]
+
+    subgraph systemdns[system-dns namespace]
+        exposure[LoadBalancer Service<br/>or Gateway TCP/UDPRoute]
+        coredns[CoreDNS]
+        etcd[(etcd)]
+        extdns[external-dns]
+    end
+
+    route53[Route 53]
+    azure[Azure DNS]
+
+    client --> exposure --> coredns
+    coredns -->|reads| etcd
+    sources -.->|watched by| extdns
+    extdns -->|writes| etcd
+    extdns -->|writes| route53
+    extdns -->|writes| azure
+```
+
+The provider that external-dns writes to is selected by the
+`external-dns/providers/*` component (one of `coredns`, `route53`, `azure`).
+
+## Recipes
+
+The shipped facet at [contexts/_template/facets/addon-private-dns.yaml](../../contexts/_template/facets/addon-private-dns.yaml)
+materializes one of the configurations below from blueprint inputs. If you are
+authoring a blueprint by hand, copy the recipe that matches your environment.
+
+### docker-desktop (local dev)
+
+Kyverno rewrites DNS targets to `127.0.0.1` so ingress hostnames resolve to
+the host loopback.
+
+```yaml
+- name: dns
+  path: dns
+  dependsOn: [pki-base, policy-resources]
+  timeout: 20m
+  interval: 5m
+  components:
+    - coredns
+    - coredns/etcd
+    - external-dns
+    - external-dns/providers/coredns
+    - external-dns/localhost
+  substitutions:
+    external_domain: test
+    loadbalancer_start_ip: 127.0.0.1
+```
+
+### Local Cilium VM cluster
+
+Default `windsor up` topology. CoreDNS exposed via a LoadBalancer Service
+sharing the gateway IP through Cilium LBIPAM.
+
+```yaml
+- name: dns
+  path: dns
+  dependsOn: [pki-base, cni]
+  timeout: 20m
+  interval: 5m
+  components:
+    - coredns
+    - coredns/etcd
+    - coredns/loadbalancer
+    - coredns/cilium
+    - external-dns
+    - external-dns/providers/coredns
+    - external-dns/sources/gateway-httproute
+  substitutions:
+    external_domain: example.internal
+    loadbalancer_start_ip: 10.5.0.10
+```
+
+### Envoy gateway
+
+CoreDNS port-53 listeners attached to the edge Gateway via TCPRoute/UDPRoute.
+
+```yaml
+- name: dns
+  path: dns
+  dependsOn: [pki-base, gateway-base]
+  timeout: 20m
+  interval: 5m
+  components:
+    - coredns
+    - coredns/etcd
+    - coredns/gateway
+    - external-dns
+    - external-dns/providers/coredns
+    - external-dns/sources/gateway-httproute
+  substitutions:
+    external_domain: example.internal
+    loadbalancer_start_ip: 10.5.0.10
+```
+
+### AWS production (Route 53)
+
+```yaml
+- name: dns
+  path: dns
+  dependsOn: [pki-base, cni]
+  timeout: 20m
+  interval: 5m
+  components:
+    - coredns
+    - coredns/etcd
+    - coredns/ha
+    - coredns/loadbalancer
+    - coredns/cilium
+    - external-dns
+    - external-dns/providers/route53
+    - external-dns/ha
+    - external-dns/sources/gateway-httproute
+  substitutions:
+    external_domain: prod.example.com
+    loadbalancer_start_ip: 10.0.10.10
+```
+
+### Azure production (Azure DNS)
+
+Same shape as the AWS recipe, swapping the provider component to
+`external-dns/providers/azure`.
+
+## Substitutions
+
+| Name | Default | Effect and constraints |
+|---|---|---|
+| `external_domain` | `test` (fallback in helm-release values) | Private zone served by CoreDNS and the `domainFilters` value passed to external-dns. Records outside this domain will not be reconciled. |
+| `loadbalancer_start_ip` | required | Anchor IP for the CoreDNS LoadBalancer Service. Must sit inside the LBIPAM pool configured by the `cni` stack on Cilium clusters. Ignored when `coredns/loadbalancer` is not enabled. |
+
+## Components
+
+### `coredns/`
+
+| Component | Enable when | Effect |
+|---|---|---|
+| `coredns` | always | Helm release of CoreDNS in `system-dns`. |
+| `coredns/etcd` | always (record store) | StatefulSet, Service, and mTLS certs for the etcd backing CoreDNS records. |
+| `coredns/ha` | `topology == ha` | Multi-replica deployment with anti-affinity. |
+| `coredns/loadbalancer` | gateway driver is Cilium | Switches the CoreDNS Service to type `LoadBalancer`. |
+| `coredns/cilium` | gateway driver is Cilium | LBIPAM annotation so CoreDNS shares the gateway IP. |
+| `coredns/gateway` | gateway driver is Envoy and enabled | TCPRoute and UDPRoute on port 53 attached to the edge Gateway. |
+
+### `external-dns/`
+
+| Component | Enable when | Effect |
+|---|---|---|
+| `external-dns` | always | Helm release of external-dns in `system-dns`. |
+| `external-dns/providers/coredns` | provider is in-cluster CoreDNS-via-etcd | Wires external-dns to write records into the CoreDNS etcd. |
+| `external-dns/providers/route53` | provider is AWS Route 53 | IRSA-based AWS provider config. |
+| `external-dns/providers/azure` | provider is Azure DNS | Workload-identity-based Azure provider config. |
+| `external-dns/ha` | `topology == ha` | Two replicas with leader election. |
+| `external-dns/localhost` | runtime is `docker-desktop` | Kyverno ClusterPolicy that mutates Ingress, Gateway, and HTTPRoute objects to set `external-dns.alpha.kubernetes.io/target: 127.0.0.1`. Requires `policy-resources`. |
+| `external-dns/sources/gateway-httproute` | a Gateway controller is installed | Adds Gateway API HTTPRoute to external-dns sources. Crashloops if enabled without HTTPRoute CRDs present. |
+
+## Dependencies
+
+| Depends on | Reason |
+|---|---|
+| `pki-base` | etcd peer, server, and client certificates are issued by the `private` ClusterIssuer. |
+| `cni` *(Cilium only)* | LoadBalancer Service for CoreDNS uses Cilium LBIPAM. |
+| `gateway-base` *(Envoy only, when gateway enabled)* | TCPRoute/UDPRoute CRDs for the port-53 listeners. |
+| `policy-resources` *(docker-desktop only)* | Kyverno CRDs needed by the `external-dns/localhost` ClusterPolicy. |
+
+## Operations
+
+Stack-specific failure modes; generic Flux/Renovate behaviour is documented at
+the repo level.
+
+- **`external-dns` crashlooping with `failed to sync HTTPRoute`** — the
+  `external-dns/sources/gateway-httproute` component is enabled but the
+  Gateway API CRDs are not installed. Either install a Gateway controller or
+  drop the component.
+- **`HelmRelease/external-dns` reports `no matches for kind ClusterPolicy`** —
+  the `external-dns/localhost` component is enabled outside docker-desktop or
+  before `policy-resources` (Kyverno) is ready. Confirm the facet still gates
+  this on `workstation.runtime == 'docker-desktop'`.
+- **CoreDNS pods stuck in `Pending`** — the LoadBalancer Service has no IP.
+  On Cilium check the LBIPAM pool covers `loadbalancer_start_ip`; on Envoy
+  confirm `coredns/gateway` is selected instead of `coredns/loadbalancer`.
+- **Records appear in CoreDNS but not in DNS responses** — etcd peer mTLS is
+  failing. Check certificates under [coredns/etcd/certificates.yaml](coredns/etcd/certificates.yaml)
+  and that the cert-manager issuer from `pki-base` is `Ready`.
+
+Metrics are scraped by the `telemetry` stack. CoreDNS exposes Prometheus
+metrics on port 9153 via the `prometheus` plugin configured in
+[coredns/helm-release.yaml](coredns/helm-release.yaml). external-dns metrics
+follow the chart default.
+
+## Security
+
+- etcd peer, server, and client traffic is mTLS. Certificates are issued by
+  the `private` ClusterIssuer (provided by `pki-base`) and managed under
+  [coredns/etcd/certificates.yaml](coredns/etcd/certificates.yaml).
+- external-dns identity:
+  - Route 53: pod identity (`provider.aws.usePodIdentity: true`) scoped to the hosted zone.
+  - Azure DNS: workload identity scoped to the resource group.
+- The `external-dns/localhost` Kyverno policy mutates Ingress, Gateway, and
+  HTTPRoute objects cluster-wide. It is gated to `docker-desktop` runtime to
+  keep it out of shared clusters.
+
+## See also
+
+- [contexts/_template/facets/addon-private-dns.yaml](../../contexts/_template/facets/addon-private-dns.yaml) — canonical wiring with conditional logic.
+- Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
+- Related stacks: [pki](../pki/), [gateway](../gateway/), [cni](../cni/), [policy](../policy/), [telemetry](../telemetry/).

--- a/kustomize/dns/README.md
+++ b/kustomize/dns/README.md
@@ -153,10 +153,10 @@ Same shape as the AWS recipe, swapping the provider component to
 |---|---|---|
 | `coredns` | always | Helm release of CoreDNS in `system-dns`. |
 | `coredns/etcd` | always (record store) | StatefulSet, Service, and mTLS certs for the etcd backing CoreDNS records. |
-| `coredns/ha` | `topology == ha` | Multi-replica deployment with anti-affinity. |
-| `coredns/loadbalancer` | gateway driver is Cilium | Switches the CoreDNS Service to type `LoadBalancer`. |
-| `coredns/cilium` | gateway driver is Cilium | LBIPAM annotation so CoreDNS shares the gateway IP. |
-| `coredns/gateway` | gateway driver is Envoy and enabled | TCPRoute and UDPRoute on port 53 attached to the edge Gateway. |
+| `coredns/ha` | `cluster.topology: ha` | Multi-replica deployment with anti-affinity. |
+| `coredns/loadbalancer` | `gateway.driver: cilium` | Switches the CoreDNS Service to type `LoadBalancer`. |
+| `coredns/cilium` | `gateway.driver: cilium` | LBIPAM annotation so CoreDNS shares the gateway IP. |
+| `coredns/gateway` | `gateway.driver: envoy` AND `gateway.enabled: true` | TCPRoute and UDPRoute on port 53 attached to the edge Gateway. |
 
 ### `external-dns/`
 
@@ -166,9 +166,9 @@ Same shape as the AWS recipe, swapping the provider component to
 | `external-dns/providers/coredns` | provider is in-cluster CoreDNS-via-etcd | Wires external-dns to write records into the CoreDNS etcd. |
 | `external-dns/providers/route53` | provider is AWS Route 53 | IRSA-based AWS provider config. |
 | `external-dns/providers/azure` | provider is Azure DNS | Workload-identity-based Azure provider config. |
-| `external-dns/ha` | `topology == ha` | Two replicas with leader election. |
-| `external-dns/localhost` | runtime is `docker-desktop` | Kyverno ClusterPolicy that mutates Ingress, Gateway, and HTTPRoute objects to set `external-dns.alpha.kubernetes.io/target: 127.0.0.1`. Requires `policy-resources`. |
-| `external-dns/sources/gateway-httproute` | a Gateway controller is installed | Adds Gateway API HTTPRoute to external-dns sources. Crashloops if enabled without HTTPRoute CRDs present. |
+| `external-dns/ha` | `cluster.topology: ha` | Two replicas with leader election. |
+| `external-dns/localhost` | `workstation.runtime: docker-desktop` | Kyverno ClusterPolicy that mutates Ingress, Gateway, and HTTPRoute objects to set `external-dns.alpha.kubernetes.io/target: 127.0.0.1`. Requires `policy-resources`. |
+| `external-dns/sources/gateway-httproute` | `gateway.enabled: true` | Adds Gateway API HTTPRoute to external-dns sources. Crashloops if enabled without HTTPRoute CRDs present. |
 
 ## Dependencies
 

--- a/kustomize/dns/README.md
+++ b/kustomize/dns/README.md
@@ -1,5 +1,5 @@
 ---
-title: DNS stack
+title: DNS add-on
 description: CoreDNS for private zones and external-dns for record automation.
 ---
 
@@ -143,7 +143,7 @@ Same shape as the AWS recipe, swapping the provider component to
 | Name | Default | Effect and constraints |
 |---|---|---|
 | `external_domain` | `test` (fallback in helm-release values) | Private zone served by CoreDNS and the `domainFilters` value passed to external-dns. Records outside this domain will not be reconciled. |
-| `loadbalancer_start_ip` | required | Anchor IP for the CoreDNS LoadBalancer Service. Must sit inside the LBIPAM pool configured by the `cni` stack on Cilium clusters. Ignored when `coredns/loadbalancer` is not enabled. |
+| `loadbalancer_start_ip` | required | Anchor IP for the CoreDNS LoadBalancer Service. Must sit inside the LBIPAM pool configured by the `cni` add-on on Cilium clusters. Ignored when `coredns/loadbalancer` is not enabled. |
 
 ## Components
 
@@ -181,7 +181,7 @@ Same shape as the AWS recipe, swapping the provider component to
 
 ## Operations
 
-Stack-specific failure modes; generic Flux/Renovate behaviour is documented at
+Add-on-specific failure modes; generic Flux/Renovate behaviour is documented at
 the repo level.
 
 - **`external-dns` crashlooping with `failed to sync HTTPRoute`** — the
@@ -199,7 +199,7 @@ the repo level.
   failing. Check certificates under [coredns/etcd/certificates.yaml](coredns/etcd/certificates.yaml)
   and that the cert-manager issuer from `pki-base` is `Ready`.
 
-Metrics are scraped by the `telemetry` stack. CoreDNS exposes Prometheus
+Metrics are scraped by the `telemetry` add-on. CoreDNS exposes Prometheus
 metrics on port 9153 via the `prometheus` plugin configured in
 [coredns/helm-release.yaml](coredns/helm-release.yaml). external-dns metrics
 follow the chart default.
@@ -220,4 +220,4 @@ follow the chart default.
 
 - [contexts/_template/facets/addon-private-dns.yaml](../../contexts/_template/facets/addon-private-dns.yaml) — canonical wiring with conditional logic.
 - Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
-- Related stacks: [pki](../pki/), [gateway](../gateway/), [cni](../cni/), [policy](../policy/), [telemetry](../telemetry/).
+- Related add-ons: [pki](../pki/), [gateway](../gateway/), [cni](../cni/), [policy](../policy/), [telemetry](../telemetry/).

--- a/kustomize/dns/README.md
+++ b/kustomize/dns/README.md
@@ -153,7 +153,7 @@ Same shape as the AWS recipe, swapping the provider component to
 |---|---|---|
 | `coredns` | always | Helm release of CoreDNS in `system-dns`. |
 | `coredns/etcd` | always (record store) | StatefulSet, Service, and mTLS certs for the etcd backing CoreDNS records. |
-| `coredns/ha` | `cluster.topology: ha` | Multi-replica deployment with anti-affinity. |
+| `coredns/ha` | `topology: ha` | Multi-replica deployment with anti-affinity. |
 | `coredns/loadbalancer` | `gateway.driver: cilium` | Switches the CoreDNS Service to type `LoadBalancer`. |
 | `coredns/cilium` | `gateway.driver: cilium` | LBIPAM annotation so CoreDNS shares the gateway IP. |
 | `coredns/gateway` | `gateway.driver: envoy` AND `gateway.enabled: true` | TCPRoute and UDPRoute on port 53 attached to the edge Gateway. |
@@ -166,7 +166,7 @@ Same shape as the AWS recipe, swapping the provider component to
 | `external-dns/providers/coredns` | provider is in-cluster CoreDNS-via-etcd | Wires external-dns to write records into the CoreDNS etcd. |
 | `external-dns/providers/route53` | provider is AWS Route 53 | IRSA-based AWS provider config. |
 | `external-dns/providers/azure` | provider is Azure DNS | Workload-identity-based Azure provider config. |
-| `external-dns/ha` | `cluster.topology: ha` | Two replicas with leader election. |
+| `external-dns/ha` | `topology: ha` | Two replicas with leader election. |
 | `external-dns/localhost` | `workstation.runtime: docker-desktop` | Kyverno ClusterPolicy that mutates Ingress, Gateway, and HTTPRoute objects to set `external-dns.alpha.kubernetes.io/target: 127.0.0.1`. Requires `policy-resources`. |
 | `external-dns/sources/gateway-httproute` | `gateway.enabled: true` | Adds Gateway API HTTPRoute to external-dns sources. Crashloops if enabled without HTTPRoute CRDs present. |
 

--- a/kustomize/gateway/README.md
+++ b/kustomize/gateway/README.md
@@ -1,0 +1,239 @@
+---
+title: Gateway stack
+description: Gateway API entrypoint with Envoy or Cilium controllers and a shared TLS-terminated Gateway resource.
+---
+
+# Gateway
+
+The cluster's traffic entrypoint. A single Gateway resource named `external`
+is rendered into `system-gateway` with HTTP, HTTPS, and (optionally) DNS
+and Flux listeners. Two implementation paths share the same Gateway: Envoy
+Gateway as a separately-deployed controller, or Cilium's built-in Gateway
+API support via the CNI. cert-manager (from the `pki` stack) issues the TLS
+certificate; HTTPRoutes from any namespace attach to the Gateway.
+
+## Flow
+
+```mermaid
+flowchart LR
+    client([Client])
+    workload[Backend Service]
+
+    subgraph systemgateway[system-gateway]
+        controller{Envoy Gateway<br/>or<br/>Cilium CNI}
+        gw[Gateway: external<br/>HTTPS · HTTP · DNS · Flux]
+        cert[Certificate<br/>external-web-tls]
+        cm[cert-manager]
+    end
+
+    issuer[ClusterIssuer<br/>from pki stack]
+    routes[HTTPRoute · UDPRoute · TCPRoute]
+
+    client --> controller
+    controller -.implements.-> gw
+    controller --> workload
+    routes -.attach to.-> gw
+
+    cert --> cm --> issuer
+    cm -.writes Secret.-> gw
+```
+
+The Gateway resource is identical across drivers; what changes is which
+controller reconciles it (`gateway.envoyproxy.io/gatewayclass-controller`
+for Envoy, `io.cilium/gateway-controller` for Cilium) and how the data plane
+is exposed (Envoy via a Service of type LoadBalancer or NodePort; Cilium via
+the CNI's own LBIPAM path).
+
+## Recipes
+
+`gateway-base` is rendered when `gateway_effective.enabled == true`.
+`gateway-resources` is rendered alongside it. Platform facets layer
+cloud-specific patches onto `gateway-base` (AWS NLB annotations, Azure SLB
+internal flip).
+
+### Local Cilium cluster (default `windsor up`)
+
+Cilium provides the Gateway implementation through the CNI; this stack only
+supplies the GatewayClass and the Gateway/Certificate resources.
+
+```yaml
+- name: gateway-base
+  path: gateway/base
+  dependsOn: [pki-base]
+  components:
+    - cilium
+  timeout: 10m
+
+- name: gateway-resources
+  path: gateway/resources
+  dependsOn: [gateway-base]
+  components:
+    - cilium
+    - lb-address
+    - flux-webhook
+  substitutions:
+    gateway_class_name: cilium
+    gateway_dns_target: 10.5.0.10
+    external_domain: example.internal
+    gateway_cert_issuer: public-selfsigned
+    loadbalancer_start_ip: 10.5.0.10
+```
+
+### Envoy with NodePort (docker-desktop or metal)
+
+```yaml
+- name: gateway-base
+  path: gateway/base
+  dependsOn: [pki-base]
+  components:
+    - envoy
+    - envoy/nodeport
+    - envoy/prometheus
+
+- name: gateway-resources
+  path: gateway/resources
+  dependsOn: [gateway-base]
+  components:
+    - envoy/default-404
+    - flux-webhook
+  substitutions:
+    gateway_class_name: envoy
+    external_domain: example.internal
+    gateway_cert_issuer: public-selfsigned
+```
+
+### Envoy on AWS (NLB)
+
+The AWS Load Balancer Controller (separately installed by `lb-base`)
+provisions an NLB pointed at the Envoy data-plane Service.
+
+```yaml
+- name: gateway-base
+  path: gateway/base
+  dependsOn: [pki-base, lb-base]
+  components:
+    - envoy
+    - envoy/loadbalancer
+    - envoy/loadbalancer/aws-nlb
+    - envoy/prometheus
+
+- name: gateway-resources
+  path: gateway/resources
+  dependsOn: [gateway-base, lb-base]
+  components:
+    - envoy/default-404
+    - envoy/default-404/external-dns
+    - flux-webhook
+  substitutions:
+    gateway_class_name: envoy
+    external_domain: example.com
+    gateway_cert_issuer: public-acme
+```
+
+### Envoy on Azure (private)
+
+```yaml
+- name: gateway-base
+  path: gateway/base
+  dependsOn: [pki-base]
+  components:
+    - envoy
+    - envoy/loadbalancer
+    - envoy/loadbalancer/azure-lb-internal
+    - envoy/prometheus
+
+- name: gateway-resources
+  path: gateway/resources
+  dependsOn: [gateway-base]
+  components:
+    - envoy/default-404
+    - envoy/default-404/external-dns
+    - flux-webhook
+  substitutions:
+    gateway_class_name: envoy
+    external_domain: vpc.example.com
+    gateway_cert_issuer: private
+```
+
+## Substitutions
+
+| Name | Required when | Effect |
+|---|---|---|
+| `gateway_class_name` | always | Drives `Gateway.spec.gatewayClassName`. Must match the GatewayClass installed by the chosen driver (`envoy` or `cilium`). |
+| `external_domain` | always | DNS name (and wildcard) on the Gateway TLS certificate. Switches between `dns.private_domain` and `dns.public_domain` in the upstream facet based on `gateway.access`. |
+| `gateway_cert_issuer` | always | ClusterIssuer name the `external-web-tls` Certificate references. One of `private`, `public-selfsigned`, `public-acme` — must exist (rendered by the `pki` stack). Renaming the issuer triggers cert-manager reissuance. |
+| `gateway_dns_target` | when external-dns is reconciling Gateway hostnames | IP advertised by external-dns for Gateway-attached hostnames. Stamped onto the Gateway via the `dns` component's annotation. |
+| `loadbalancer_start_ip` | `cilium`, `lb-address`, or any in-cluster LB path | Anchor IP for the Gateway's load balancer. Used by Cilium LBIPAM, the `lb-address` patch, and intended for `envoy/loadbalancer`. Must sit inside the LBIPAM pool (Cilium) or the cluster's MetalLB pool (Envoy). |
+| `lb_scheme` | AWS only, when `gateway.access == 'private'` | AWS LB scheme annotation. Defaults to `internet-facing` when empty (kustomize fallback `${lb_scheme:-internet-facing}`); set to `internal` for VPC-only gateways. |
+
+## Components
+
+### `gateway/base/`
+
+The base kustomization always installs the upstream Gateway API experimental
+CRDs (vendored at `gateway-api-experimental-v1.5.1.yaml`) and the
+`system-gateway` namespace.
+
+| Component | Enable when | Effect |
+|---|---|---|
+| `cilium` | driver is Cilium | GatewayClass `cilium` pointing at `io.cilium/gateway-controller`. The Cilium HelmRelease itself is owned by the `cni` stack. |
+| `envoy` | driver is Envoy | Helm release of Envoy Gateway in `system-gateway`, vendored Envoy Gateway CRDs v1.7.1, GatewayClass `envoy`. |
+| `envoy/loadbalancer` | Envoy + LB mode | Patches the Envoy data-plane Service to type `LoadBalancer`. |
+| `envoy/loadbalancer/aws-nlb` | AWS + Envoy + LB mode | AWS LB Controller annotations: `aws-load-balancer-type: external`, `nlb-target-type: ip`, scheme from `${lb_scheme}`, cross-zone enabled. |
+| `envoy/loadbalancer/azure-lb-internal` | Azure + Envoy + private gateway | Adds `service.beta.kubernetes.io/azure-load-balancer-internal: "true"` to flip the AKS Standard LB to internal. |
+| `envoy/nodeport` | Envoy + NodePort mode | Patches the Envoy data-plane Service to NodePort with hardcoded ports: 80→30080, 443→30443, 53 UDP/TCP→30053, 9292→30292. |
+| `envoy/prometheus` | Envoy + telemetry metrics enabled | ServiceMonitor + PodMonitor for the Envoy controller and proxies. |
+
+### `gateway/resources/`
+
+The base kustomization always renders `Gateway/external` (HTTP/80 +
+HTTPS/443 listeners) and `Certificate/external-web-tls`.
+
+| Component | Enable when | Effect |
+|---|---|---|
+| `cilium` | driver is Cilium | LBIPAM annotations on the Gateway (`lbipam.cilium.io/ips`, `sharing-key: external`, `sharing-cross-namespace: "*"`) so the Gateway can share its IP with CoreDNS and other LB consumers. |
+| `dns` | private-DNS addon enabled (Envoy only) | Adds UDP/53 (UDPRoute) and TCP/53 (TCPRoute) listeners so CoreDNS port-53 traffic terminates on the Gateway. |
+| `envoy/default-404` | Envoy only | Catch-all 404 HTTPRoute using the Envoy-specific `gateway.envoyproxy.io/HTTPRouteFilter` `directResponse`. Cilium clusters don't ship that CRD. |
+| `envoy/default-404/external-dns` | a public or private DNS zone exists | Adds `external-dns.alpha.kubernetes.io/hostname: "${external_domain},*.${external_domain}"` to the 404 route so external-dns publishes apex + wildcard records pointing at the Gateway IP. |
+| `flux-webhook` | gitops mode is `push` | Adds an HTTP/9292 listener for the Flux notification receiver. |
+| `lb-address` | in-cluster LB is active | Pins `spec.addresses` on the Gateway to `${loadbalancer_start_ip}`. |
+
+## Dependencies
+
+| Stack | Reason |
+|---|---|
+| `pki-base` | cert-manager must be running before `Certificate/external-web-tls` is created. |
+| `lb-base` *(when an LB controller is required)* | Provides the AWS Load Balancer Controller (or MetalLB) that the Envoy data-plane Service needs to acquire an external IP. |
+| `dns` *(when `dns.enabled`)* | external-dns (in the `dns` stack) watches Gateway HTTPRoutes for hostname annotations. When the private-DNS addon is also active, the `gateway-resources/dns` component attaches port-53 listeners that route to upstream CoreDNS. |
+| `cni` *(reverse, Cilium driver only)* | When Cilium is the driver, the `cni` stack `dependsOn` `gateway-base` so the Gateway API CRDs are present before the Cilium HelmRelease is applied — Cilium's operator initializes its Gateway controller at startup and won't pick up CRDs added later. |
+
+## Operations
+
+Stack-specific failure modes; generic Flux/Renovate behaviour is documented
+at the repo level.
+
+- **`Certificate/external-web-tls` stuck `Issuing`** — the `gateway_cert_issuer` substitution names a ClusterIssuer that the `pki-resources` Kustomization hasn't rendered yet. Confirm the ClusterIssuer exists (`kubectl get clusterissuer`) and matches the substitution. On a switch from `public-selfsigned` to `public-acme`, the Certificate spec changes and cert-manager reissues.
+- **Envoy data-plane Service stuck without an external IP** — the LB controller isn't installed or reachable. On AWS check `lb-base` is healthy and the AWS LB Controller pods are running. On metal/incus check MetalLB.
+- **`gateway-base` reports `no matches for kind GatewayClass`** — the base CRDs (vendored `gateway-api-experimental-v1.5.1.yaml`) didn't apply. Usually a kustomize build failure; reconcile manually with `flux reconcile kustomization gateway-base`.
+- **Cilium clusters: HTTPRoutes attach but never serve traffic** — Cilium's Gateway controller didn't initialize because the CRDs weren't present when cilium-operator started. The reverse `cni dependsOn gateway-base` ordering is meant to prevent this; if it fires, restart `cilium-operator`.
+- **Envoy LB IP appears unset on `envoy/loadbalancer`** — known issue: the `loadBalancerIP` patch references `${loadbalancer_ip_start}` but the actual substitution is `loadbalancer_start_ip`. The patch silently renders an empty value; the cloud LB allocates an arbitrary IP. Either pin via `lb-address` (which uses the correct name) or fix the substitution name in the patch.
+
+The Envoy controller exposes Prometheus metrics through the
+`envoy/prometheus` component (ServiceMonitor + PodMonitor). Cilium's metrics
+are scraped by the `cni` stack's own ServiceMonitor.
+
+## Security
+
+- The `system-gateway` namespace is PSA `baseline`.
+- The Gateway's `external-web-tls` Certificate is issued by a ClusterIssuer from the `pki` stack. The Secret is consumed only by the Gateway's TLS listener; it is not mounted by application workloads.
+- HTTPRoute, UDPRoute, TCPRoute resources are accepted from all namespaces (`spec.listeners[*].allowedRoutes.namespaces.from: All`). Tenant isolation, if needed, must come from upstream policy (NetworkPolicy, Kyverno) — the Gateway itself does not gate cross-namespace attachment.
+- AWS NLB target-type is `ip` so traffic flows directly to Envoy pods (kube-proxy is bypassed); the source IP reaches Envoy unmodified for X-Forwarded-For handling.
+- The Azure internal-LB annotation pins the data-plane Service to the VNet — it is not reachable from outside the VNet. Public exposure on Azure requires omitting `envoy/loadbalancer/azure-lb-internal`.
+
+## See also
+
+- [contexts/_template/facets/option-gateway.yaml](../../contexts/_template/facets/option-gateway.yaml) — canonical wiring for both drivers, including the reverse `cni` dep and the cert-issuer fallback logic.
+- [contexts/_template/facets/platform-aws.yaml](../../contexts/_template/facets/platform-aws.yaml) — AWS NLB annotations layered onto `gateway-base`.
+- [contexts/_template/facets/platform-azure.yaml](../../contexts/_template/facets/platform-azure.yaml) — Azure internal-LB conditional layering.
+- Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
+- Related stacks: [pki](../pki/), [dns](../dns/), [cni](../cni/), [lb](../lb/), [gitops](../gitops/), [telemetry](../telemetry/).

--- a/kustomize/gateway/README.md
+++ b/kustomize/gateway/README.md
@@ -46,10 +46,9 @@ the CNI's own LBIPAM path).
 
 ## Recipes
 
-`gateway-base` is rendered when `gateway_effective.enabled == true`.
-`gateway-resources` is rendered alongside it. Platform facets layer
-cloud-specific patches onto `gateway-base` (AWS NLB annotations, Azure SLB
-internal flip).
+`gateway-base` is rendered when `gateway.enabled: true`. `gateway-resources`
+is rendered alongside it. Platform facets layer cloud-specific patches onto
+`gateway-base` (AWS NLB annotations, Azure SLB internal flip).
 
 ### Local Cilium cluster (default `windsor up`)
 
@@ -176,13 +175,13 @@ CRDs (vendored at `gateway-api-experimental-v1.5.1.yaml`) and the
 
 | Component | Enable when | Effect |
 |---|---|---|
-| `cilium` | driver is Cilium | GatewayClass `cilium` pointing at `io.cilium/gateway-controller`. The Cilium HelmRelease itself is owned by the `cni` stack. |
-| `envoy` | driver is Envoy | Helm release of Envoy Gateway in `system-gateway`, vendored Envoy Gateway CRDs v1.7.1, GatewayClass `envoy`. |
-| `envoy/loadbalancer` | Envoy + LB mode | Patches the Envoy data-plane Service to type `LoadBalancer`. |
-| `envoy/loadbalancer/aws-nlb` | AWS + Envoy + LB mode | AWS LB Controller annotations: `aws-load-balancer-type: external`, `nlb-target-type: ip`, scheme from `${lb_scheme}`, cross-zone enabled. |
-| `envoy/loadbalancer/azure-lb-internal` | Azure + Envoy + private gateway | Adds `service.beta.kubernetes.io/azure-load-balancer-internal: "true"` to flip the AKS Standard LB to internal. |
-| `envoy/nodeport` | Envoy + NodePort mode | Patches the Envoy data-plane Service to NodePort with hardcoded ports: 80→30080, 443→30443, 53 UDP/TCP→30053, 9292→30292. |
-| `envoy/prometheus` | Envoy + telemetry metrics enabled | ServiceMonitor + PodMonitor for the Envoy controller and proxies. |
+| `cilium` | `gateway.driver: cilium` | GatewayClass `cilium` pointing at `io.cilium/gateway-controller`. The Cilium HelmRelease itself is owned by the `cni` stack. |
+| `envoy` | `gateway.driver: envoy` | Helm release of Envoy Gateway in `system-gateway`, vendored Envoy Gateway CRDs v1.7.1, GatewayClass `envoy`. |
+| `envoy/loadbalancer` | `gateway.driver: envoy` AND `gateway.service_type: LoadBalancer` (or platform default) | Patches the Envoy data-plane Service to type `LoadBalancer`. |
+| `envoy/loadbalancer/aws-nlb` | `platform: aws` AND `gateway.driver: envoy` AND LB mode | AWS LB Controller annotations: `aws-load-balancer-type: external`, `nlb-target-type: ip`, scheme from `${lb_scheme}`, cross-zone enabled. |
+| `envoy/loadbalancer/azure-lb-internal` | `platform: azure` AND `gateway.driver: envoy` AND `gateway.access: private` | Adds `service.beta.kubernetes.io/azure-load-balancer-internal: "true"` to flip the AKS Standard LB to internal. |
+| `envoy/nodeport` | `gateway.driver: envoy` AND `gateway.service_type: NodePort` (or docker-desktop default) | Patches the Envoy data-plane Service to NodePort with hardcoded ports: 80→30080, 443→30443, 53 UDP/TCP→30053, 9292→30292. |
+| `envoy/prometheus` | `gateway.driver: envoy` AND `telemetry.metrics.enabled: true` | ServiceMonitor + PodMonitor for the Envoy controller and proxies. |
 
 ### `gateway/resources/`
 
@@ -191,21 +190,21 @@ HTTPS/443 listeners) and `Certificate/external-web-tls`.
 
 | Component | Enable when | Effect |
 |---|---|---|
-| `cilium` | driver is Cilium | LBIPAM annotations on the Gateway (`lbipam.cilium.io/ips`, `sharing-key: external`, `sharing-cross-namespace: "*"`) so the Gateway can share its IP with CoreDNS and other LB consumers. |
-| `dns` | private-DNS addon enabled (Envoy only) | Adds UDP/53 (UDPRoute) and TCP/53 (TCPRoute) listeners so CoreDNS port-53 traffic terminates on the Gateway. |
-| `envoy/default-404` | Envoy only | Catch-all 404 HTTPRoute using the Envoy-specific `gateway.envoyproxy.io/HTTPRouteFilter` `directResponse`. Cilium clusters don't ship that CRD. |
-| `envoy/default-404/external-dns` | a public or private DNS zone exists | Adds `external-dns.alpha.kubernetes.io/hostname: "${external_domain},*.${external_domain}"` to the 404 route so external-dns publishes apex + wildcard records pointing at the Gateway IP. |
-| `flux-webhook` | gitops mode is `push` | Adds an HTTP/9292 listener for the Flux notification receiver. |
-| `lb-address` | in-cluster LB is active | Pins `spec.addresses` on the Gateway to `${loadbalancer_start_ip}`. |
+| `cilium` | `gateway.driver: cilium` | LBIPAM annotations on the Gateway (`lbipam.cilium.io/ips`, `sharing-key: external`, `sharing-cross-namespace: "*"`) so the Gateway can share its IP with CoreDNS and other LB consumers. |
+| `dns` | `addons.private_dns.enabled: true` AND `gateway.driver: envoy` | Adds UDP/53 (UDPRoute) and TCP/53 (TCPRoute) listeners so CoreDNS port-53 traffic terminates on the Gateway. |
+| `envoy/default-404` | `gateway.driver: envoy` | Catch-all 404 HTTPRoute using the Envoy-specific `gateway.envoyproxy.io/HTTPRouteFilter` `directResponse`. Cilium clusters don't ship that CRD. |
+| `envoy/default-404/external-dns` | `dns.public_domain` is set OR (`gateway.access: private` AND `dns.private_domain` is set) | Adds `external-dns.alpha.kubernetes.io/hostname: "${external_domain},*.${external_domain}"` to the 404 route so external-dns publishes apex + wildcard records pointing at the Gateway IP. |
+| `flux-webhook` | `gitops.mode: push` (the default) | Adds an HTTP/9292 listener for the Flux notification receiver. |
+| `lb-address` | in-cluster LB is active (`network.loadbalancer_driver` is set on metal/incus, or `gateway.driver: cilium`) | Pins `spec.addresses` on the Gateway to `${loadbalancer_start_ip}`. |
 
 ## Dependencies
 
 | Stack | Reason |
 |---|---|
 | `pki-base` | cert-manager must be running before `Certificate/external-web-tls` is created. |
-| `lb-base` *(when an LB controller is required)* | Provides the AWS Load Balancer Controller (or MetalLB) that the Envoy data-plane Service needs to acquire an external IP. |
-| `dns` *(when `dns.enabled`)* | external-dns (in the `dns` stack) watches Gateway HTTPRoutes for hostname annotations. When the private-DNS addon is also active, the `gateway-resources/dns` component attaches port-53 listeners that route to upstream CoreDNS. |
-| `cni` *(reverse, Cilium driver only)* | When Cilium is the driver, the `cni` stack `dependsOn` `gateway-base` so the Gateway API CRDs are present before the Cilium HelmRelease is applied — Cilium's operator initializes its Gateway controller at startup and won't pick up CRDs added later. |
+| `lb-base` *(`platform: aws`, or `network.loadbalancer_driver` set on metal/incus)* | Provides the AWS Load Balancer Controller (or MetalLB) that the Envoy data-plane Service needs to acquire an external IP. |
+| `dns` *(when `dns.enabled: true`)* | external-dns (in the `dns` stack) watches Gateway HTTPRoutes for hostname annotations. When the private-DNS addon is also active, the `gateway-resources/dns` component attaches port-53 listeners that route to upstream CoreDNS. |
+| `cni` *(reverse, `gateway.driver: cilium` only)* | When Cilium is the driver, the `cni` stack `dependsOn` `gateway-base` so the Gateway API CRDs are present before the Cilium HelmRelease is applied — Cilium's operator initializes its Gateway controller at startup and won't pick up CRDs added later. |
 
 ## Operations
 

--- a/kustomize/gateway/README.md
+++ b/kustomize/gateway/README.md
@@ -1,5 +1,5 @@
 ---
-title: Gateway stack
+title: Gateway add-on
 description: Gateway API entrypoint with Envoy or Cilium controllers and a shared TLS-terminated Gateway resource.
 ---
 
@@ -9,7 +9,7 @@ The cluster's traffic entrypoint. A single Gateway resource named `external`
 is rendered into `system-gateway` with HTTP, HTTPS, and (optionally) DNS
 and Flux listeners. Two implementation paths share the same Gateway: Envoy
 Gateway as a separately-deployed controller, or Cilium's built-in Gateway
-API support via the CNI. cert-manager (from the `pki` stack) issues the TLS
+API support via the CNI. cert-manager (from the `pki` add-on) issues the TLS
 certificate; HTTPRoutes from any namespace attach to the Gateway.
 
 ## Flow
@@ -26,7 +26,7 @@ flowchart LR
         cm[cert-manager]
     end
 
-    issuer[ClusterIssuer<br/>from pki stack]
+    issuer[ClusterIssuer<br/>from pki add-on]
     routes[HTTPRoute · UDPRoute · TCPRoute]
 
     client --> controller
@@ -52,7 +52,7 @@ is rendered alongside it. Platform facets layer cloud-specific patches onto
 
 ### Local Cilium cluster (default `windsor up`)
 
-Cilium provides the Gateway implementation through the CNI; this stack only
+Cilium provides the Gateway implementation through the CNI; this add-on only
 supplies the GatewayClass and the Gateway/Certificate resources.
 
 ```yaml
@@ -160,7 +160,7 @@ provisions an NLB pointed at the Envoy data-plane Service.
 |---|---|---|
 | `gateway_class_name` | always | Drives `Gateway.spec.gatewayClassName`. Must match the GatewayClass installed by the chosen driver (`envoy` or `cilium`). |
 | `external_domain` | always | DNS name (and wildcard) on the Gateway TLS certificate. Switches between `dns.private_domain` and `dns.public_domain` in the upstream facet based on `gateway.access`. |
-| `gateway_cert_issuer` | always | ClusterIssuer name the `external-web-tls` Certificate references. One of `private`, `public-selfsigned`, `public-acme` — must exist (rendered by the `pki` stack). Renaming the issuer triggers cert-manager reissuance. |
+| `gateway_cert_issuer` | always | ClusterIssuer name the `external-web-tls` Certificate references. One of `private`, `public-selfsigned`, `public-acme` — must exist (rendered by the `pki` add-on). Renaming the issuer triggers cert-manager reissuance. |
 | `gateway_dns_target` | when external-dns is reconciling Gateway hostnames | IP advertised by external-dns for Gateway-attached hostnames. Stamped onto the Gateway via the `dns` component's annotation. |
 | `loadbalancer_start_ip` | `cilium`, `lb-address`, or any in-cluster LB path | Anchor IP for the Gateway's load balancer. Used by Cilium LBIPAM, the `lb-address` patch, and intended for `envoy/loadbalancer`. Must sit inside the LBIPAM pool (Cilium) or the cluster's MetalLB pool (Envoy). |
 | `lb_scheme` | AWS only, when `gateway.access == 'private'` | AWS LB scheme annotation. Defaults to `internet-facing` when empty (kustomize fallback `${lb_scheme:-internet-facing}`); set to `internal` for VPC-only gateways. |
@@ -175,7 +175,7 @@ CRDs (vendored at `gateway-api-experimental-v1.5.1.yaml`) and the
 
 | Component | Enable when | Effect |
 |---|---|---|
-| `cilium` | `gateway.driver: cilium` | GatewayClass `cilium` pointing at `io.cilium/gateway-controller`. The Cilium HelmRelease itself is owned by the `cni` stack. |
+| `cilium` | `gateway.driver: cilium` | GatewayClass `cilium` pointing at `io.cilium/gateway-controller`. The Cilium HelmRelease itself is owned by the `cni` add-on. |
 | `envoy` | `gateway.driver: envoy` | Helm release of Envoy Gateway in `system-gateway`, vendored Envoy Gateway CRDs v1.7.1, GatewayClass `envoy`. |
 | `envoy/loadbalancer` | `gateway.driver: envoy` AND `gateway.service_type: LoadBalancer` (or platform default) | Patches the Envoy data-plane Service to type `LoadBalancer`. |
 | `envoy/loadbalancer/aws-nlb` | `platform: aws` AND `gateway.driver: envoy` AND LB mode | AWS LB Controller annotations: `aws-load-balancer-type: external`, `nlb-target-type: ip`, scheme from `${lb_scheme}`, cross-zone enabled. |
@@ -199,16 +199,16 @@ HTTPS/443 listeners) and `Certificate/external-web-tls`.
 
 ## Dependencies
 
-| Stack | Reason |
+| Add-on | Reason |
 |---|---|
 | `pki-base` | cert-manager must be running before `Certificate/external-web-tls` is created. |
 | `lb-base` *(`platform: aws`, or `network.loadbalancer_driver` set on metal/incus)* | Provides the AWS Load Balancer Controller (or MetalLB) that the Envoy data-plane Service needs to acquire an external IP. |
-| `dns` *(when `dns.enabled: true`)* | external-dns (in the `dns` stack) watches Gateway HTTPRoutes for hostname annotations. When the private-DNS addon is also active, the `gateway-resources/dns` component attaches port-53 listeners that route to upstream CoreDNS. |
-| `cni` *(reverse, `gateway.driver: cilium` only)* | When Cilium is the driver, the `cni` stack `dependsOn` `gateway-base` so the Gateway API CRDs are present before the Cilium HelmRelease is applied — Cilium's operator initializes its Gateway controller at startup and won't pick up CRDs added later. |
+| `dns` *(when `dns.enabled: true`)* | external-dns (in the `dns` add-on) watches Gateway HTTPRoutes for hostname annotations. When the private-DNS addon is also active, the `gateway-resources/dns` component attaches port-53 listeners that route to upstream CoreDNS. |
+| `cni` *(reverse, `gateway.driver: cilium` only)* | When Cilium is the driver, the `cni` add-on `dependsOn` `gateway-base` so the Gateway API CRDs are present before the Cilium HelmRelease is applied — Cilium's operator initializes its Gateway controller at startup and won't pick up CRDs added later. |
 
 ## Operations
 
-Stack-specific failure modes; generic Flux/Renovate behaviour is documented
+Add-on-specific failure modes; generic Flux/Renovate behaviour is documented
 at the repo level.
 
 - **`Certificate/external-web-tls` stuck `Issuing`** — the `gateway_cert_issuer` substitution names a ClusterIssuer that the `pki-resources` Kustomization hasn't rendered yet. Confirm the ClusterIssuer exists (`kubectl get clusterissuer`) and matches the substitution. On a switch from `public-selfsigned` to `public-acme`, the Certificate spec changes and cert-manager reissues.
@@ -219,12 +219,12 @@ at the repo level.
 
 The Envoy controller exposes Prometheus metrics through the
 `envoy/prometheus` component (ServiceMonitor + PodMonitor). Cilium's metrics
-are scraped by the `cni` stack's own ServiceMonitor.
+are scraped by the `cni` add-on's own ServiceMonitor.
 
 ## Security
 
 - The `system-gateway` namespace is PSA `baseline`.
-- The Gateway's `external-web-tls` Certificate is issued by a ClusterIssuer from the `pki` stack. The Secret is consumed only by the Gateway's TLS listener; it is not mounted by application workloads.
+- The Gateway's `external-web-tls` Certificate is issued by a ClusterIssuer from the `pki` add-on. The Secret is consumed only by the Gateway's TLS listener; it is not mounted by application workloads.
 - HTTPRoute, UDPRoute, TCPRoute resources are accepted from all namespaces (`spec.listeners[*].allowedRoutes.namespaces.from: All`). Tenant isolation, if needed, must come from upstream policy (NetworkPolicy, Kyverno) — the Gateway itself does not gate cross-namespace attachment.
 - AWS NLB target-type is `ip` so traffic flows directly to Envoy pods (kube-proxy is bypassed); the source IP reaches Envoy unmodified for X-Forwarded-For handling.
 - The Azure internal-LB annotation pins the data-plane Service to the VNet — it is not reachable from outside the VNet. Public exposure on Azure requires omitting `envoy/loadbalancer/azure-lb-internal`.
@@ -235,4 +235,4 @@ are scraped by the `cni` stack's own ServiceMonitor.
 - [contexts/_template/facets/platform-aws.yaml](../../contexts/_template/facets/platform-aws.yaml) — AWS NLB annotations layered onto `gateway-base`.
 - [contexts/_template/facets/platform-azure.yaml](../../contexts/_template/facets/platform-azure.yaml) — Azure internal-LB conditional layering.
 - Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
-- Related stacks: [pki](../pki/), [dns](../dns/), [cni](../cni/), [lb](../lb/), [gitops](../gitops/), [telemetry](../telemetry/).
+- Related add-ons: [pki](../pki/), [dns](../dns/), [cni](../cni/), [lb](../lb/), [gitops](../gitops/), [telemetry](../telemetry/).

--- a/kustomize/gitops/README.md
+++ b/kustomize/gitops/README.md
@@ -1,0 +1,170 @@
+---
+title: GitOps stack
+description: Flux notification webhook receiver and HTTPRoute. Flux itself is installed by Terraform, not this stack.
+---
+
+# GitOps
+
+Almost all of the GitOps weight in this blueprint is in the Terraform module
+at [terraform/gitops/flux/](../../terraform/gitops/flux/) — that's what
+installs Flux's controllers, the root `GitRepository`, and the bootstrap
+`Kustomization`. This Kustomize stack adds the **flux notification
+webhook receiver** on top: a `Receiver` resource the
+notification-controller exposes for HMAC-authenticated push triggers, plus
+an HTTPRoute that lets external git hosts (GitHub, GitLab) reach it.
+
+If `gitops.mode` is `pull`, this stack renders nothing — Flux polls and no
+inbound webhook is needed.
+
+## Flow
+
+```mermaid
+flowchart LR
+    git[Git host webhook<br/>_GitHub / GitLab_]
+    gateway[Cluster Gateway]
+    gitrepo[(GitRepository<br/>flux-system)]
+
+    subgraph systemgitops[system-gitops]
+        receiver[Receiver flux-webhook<br/>HMAC token]
+        nc[notification-controller]
+    end
+
+    git -->|POST /hook/...| gateway
+    gateway -->|HTTPRoute| nc
+    nc --> receiver
+    receiver -.triggers reconcile.-> gitrepo
+```
+
+The receiver is a `notification.toolkit.fluxcd.io/v1` `Receiver` of `type:
+generic` — the `webhook-token` Secret holds the HMAC the git host signs
+each delivery with. On a valid signature, notification-controller forces a
+reconcile of the named `GitRepository` (`${git_repository_name}`).
+
+## Recipes
+
+`platform-base` emits exactly one of two variants based on whether a
+Gateway is available; both are gated on `(gitops.mode ?? 'push') == 'push'`.
+
+### Push mode without a Gateway
+
+Plain `Receiver` only — no HTTPRoute, so reachability depends on something
+else exposing the notification-controller Service. Useful for clusters
+with no Gateway API controller (rare in this blueprint, since the bootstrap
+flow assumes one).
+
+```yaml
+- name: gitops
+  path: gitops/flux
+  components:
+    - webhook
+  substitutions:
+    git_repository_name: my-repo
+```
+
+### Push mode with Envoy gateway
+
+Webhook plus an HTTPRoute attached to the cluster's `external` Gateway.
+The Gateway has a dedicated `flux-webhook` listener (port 9292) added by
+[gateway-resources/flux-webhook](../gateway/resources/flux-webhook).
+
+```yaml
+- name: gitops
+  path: gitops/flux
+  dependsOn: [gateway-base]
+  components:
+    - webhook
+    - webhook/gateway
+  substitutions:
+    git_repository_name: my-repo
+```
+
+### Push mode with Cilium gateway
+
+Same as Envoy plus a `CiliumNetworkPolicy` permitting ingress from the
+`ingress` entity to the notification-controller pods. The policy is
+required on Cilium clusters where default-deny network policies block
+gateway-originated traffic.
+
+```yaml
+- name: gitops
+  path: gitops/flux
+  dependsOn: [gateway-base]
+  components:
+    - webhook
+    - webhook/gateway
+    - webhook/gateway/cilium
+  substitutions:
+    git_repository_name: my-repo
+```
+
+### Pull mode
+
+Set `gitops.mode: pull`. Both webhook entries' `when:` evaluates false and
+this stack contributes nothing beyond the namespace already created by
+Terraform.
+
+## Substitutions
+
+| Name | Required when | Effect |
+|---|---|---|
+| `git_repository_name` | always (when push mode) | Name of the `GitRepository` the receiver triggers. Defaults to `"local"` (workstation default); platform facets pass through `gitops.repository.name`. The receiver will accept any payload but will only ever reconcile the named repository. |
+
+The `webhook-token` Secret holding the HMAC is provisioned by the
+Terraform module — not by this stack. This Kustomization only references
+it (`secretRef.name: webhook-token`).
+
+## Components
+
+The Kustomize stack has only a webhook subtree. Flux's controllers are
+not in this stack — they ship from the Terraform module.
+
+| Component | Enable when | Effect |
+|---|---|---|
+| `webhook` | push mode | `Receiver/flux-webhook` of `type: generic`, referencing the `webhook-token` Secret and triggering the `${git_repository_name}` GitRepository. |
+| `webhook/gateway` | push mode AND a Gateway is enabled | HTTPRoute attaching the receiver Service to the cluster Gateway's `web-http` and `flux-webhook` listeners. The `web-http` listener is the standard port-80; `flux-webhook` is a dedicated port-9292 listener (added by [gateway-resources/flux-webhook](../gateway/resources/flux-webhook)). PathPrefix `/hook/` routes to the `webhook-receiver` Service on port 80. |
+| `webhook/gateway/cilium` | push mode + Cilium gateway driver | `CiliumNetworkPolicy` named `allow-gateway-webhooks` that permits ingress traffic from the `ingress` entity to the notification-controller pods (matched by label `app: notification-controller`). |
+
+## Dependencies
+
+The Kustomize stack has minimal dependencies:
+
+| Stack | Reason |
+|---|---|
+| `gateway-base` *(when Gateway variant)* | The Gateway API CRDs (HTTPRoute) and the `external` Gateway must exist before `webhook/gateway` is applied. |
+
+Dependencies on the Terraform side are richer:
+
+- `terraform: gitops` `dependsOn: cluster` (every platform).
+- `terraform: gitops` `dependsOn: cni` on platforms where Cilium is the CNI (waits for pod networking).
+- `terraform: gitops` `dependsOn: cluster, cluster-extensions` on AWS (EKS-specific, when applicable).
+
+These are not part of the Kustomize stack but matter for ordering: Flux
+itself must be running before any Windsor Kustomization (including this
+one) can reconcile.
+
+## Operations
+
+Stack-specific failure modes; generic Flux/Renovate behaviour is documented
+at the repo level.
+
+- **Webhook returns 401** — the HMAC secret in `webhook-token` doesn't match what the git host is signing with. Inspect `kubectl get secret webhook-token -n system-gitops` and confirm the git host webhook config uses the same value. The Terraform module provisions this; on workstations the default is `${gitops.webhook.token ?? "abcdef123456"}`.
+- **Webhook returns 404** — the HTTPRoute path or listener doesn't match. The route uses `PathPrefix: /hook/` — git hosts must POST to `https://<external_domain>/hook/<receiver-path>` (the suffix is the `webhook-path` from the Receiver status).
+- **Cilium clusters: webhook reachable but reconciles don't trigger** — the `webhook/gateway/cilium` policy isn't applied. Without it, ingress traffic is dropped before reaching notification-controller. Ensure the component is enabled when `gateway_effective.driver == 'cilium'`.
+- **Push mode set but receiver not rendered** — confirm `gitops.mode` is exactly `push` (or unset, which defaults to push). The `when:` clauses use `(gitops.mode ?? 'push') == 'push'` so both work.
+- **GitRepository never reconciles on push** — the receiver references `${git_repository_name}`. If the substitution doesn't match the actual GitRepository name in `system-gitops`, the receiver will accept the webhook but reconcile a non-existent target. Check `kubectl get gitrepository -n system-gitops` and the Receiver's `spec.resources[0].name`.
+
+## Security
+
+- The `system-gitops` namespace has no PSA enforce labels in [namespace.yaml](namespace.yaml). The chart's pod security defaults apply; Flux runs at PSA `restricted` upstream.
+- Authentication on the webhook is HMAC via the `webhook-token` Secret. The Receiver type is `generic` — for git-host-specific verification (e.g. GitHub's `X-Hub-Signature-256`) configure the receiver type accordingly. The shipped `generic` type accepts any signature on any payload as long as the HMAC matches.
+- The Cilium policy permits ingress to notification-controller from `fromEntities: [ingress]` only — pod-to-pod traffic from other namespaces is still blocked by default.
+- Webhook tokens default to `abcdef123456` on workstation contexts via `option-workstation`'s `webhook_token: ${gitops.webhook.token ?? "abcdef123456"}`. Production clusters MUST override this; the default is documented as a placeholder.
+
+## See also
+
+- [terraform/gitops/flux/](../../terraform/gitops/flux/) — the Flux installer, including controllers, GitRepository, root Kustomization, and the `webhook-token` Secret. Most operator concerns about gitops live there, not in this stack.
+- [contexts/_template/facets/platform-base.yaml](../../contexts/_template/facets/platform-base.yaml) (lines ~491-509) — canonical wiring for both webhook variants.
+- [contexts/_template/facets/option-workstation.yaml](../../contexts/_template/facets/option-workstation.yaml) — workstation-specific Terraform inputs (`concurrency`, `git_username`, `git_password`, `webhook_token`).
+- [contexts/_template/facets/option-cni.yaml](../../contexts/_template/facets/option-cni.yaml) — adds the `cni` Terraform dep so Flux waits for pod networking on Cilium clusters.
+- Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
+- Related stacks: [gateway](../gateway/), [cni](../cni/).

--- a/kustomize/gitops/README.md
+++ b/kustomize/gitops/README.md
@@ -149,7 +149,7 @@ at the repo level.
 
 - **Webhook returns 401** — the HMAC secret in `webhook-token` doesn't match what the git host is signing with. Inspect `kubectl get secret webhook-token -n system-gitops` and confirm the git host webhook config uses the same value. The Terraform module provisions this; on workstations the default is `${gitops.webhook.token ?? "abcdef123456"}`.
 - **Webhook returns 404** — the HTTPRoute path or listener doesn't match. The route uses `PathPrefix: /hook/` — git hosts must POST to `https://<external_domain>/hook/<receiver-path>` (the suffix is the `webhook-path` from the Receiver status).
-- **Cilium clusters: webhook reachable but reconciles don't trigger** — the `webhook/gateway/cilium` policy isn't applied. Without it, ingress traffic is dropped before reaching notification-controller. Ensure the component is enabled when `gateway_effective.driver == 'cilium'`.
+- **Cilium clusters: webhook reachable but reconciles don't trigger** — the `webhook/gateway/cilium` policy isn't applied. Without it, ingress traffic is dropped before reaching notification-controller. Ensure the component is enabled when `gateway.driver: cilium`.
 - **Push mode set but receiver not rendered** — confirm `gitops.mode` is exactly `push` (or unset, which defaults to push). The `when:` clauses use `(gitops.mode ?? 'push') == 'push'` so both work.
 - **GitRepository never reconciles on push** — the receiver references `${git_repository_name}`. If the substitution doesn't match the actual GitRepository name in `system-gitops`, the receiver will accept the webhook but reconcile a non-existent target. Check `kubectl get gitrepository -n system-gitops` and the Receiver's `spec.resources[0].name`.
 

--- a/kustomize/gitops/README.md
+++ b/kustomize/gitops/README.md
@@ -1,6 +1,6 @@
 ---
-title: GitOps stack
-description: Flux notification webhook receiver and HTTPRoute. Flux itself is installed by Terraform, not this stack.
+title: GitOps add-on
+description: Flux notification webhook receiver and HTTPRoute. Flux itself is installed by Terraform, not this add-on.
 ---
 
 # GitOps
@@ -8,12 +8,12 @@ description: Flux notification webhook receiver and HTTPRoute. Flux itself is in
 Almost all of the GitOps weight in this blueprint is in the Terraform module
 at [terraform/gitops/flux/](../../terraform/gitops/flux/) — that's what
 installs Flux's controllers, the root `GitRepository`, and the bootstrap
-`Kustomization`. This Kustomize stack adds the **flux notification
+`Kustomization`. This Kustomize add-on adds the **flux notification
 webhook receiver** on top: a `Receiver` resource the
 notification-controller exposes for HMAC-authenticated push triggers, plus
 an HTTPRoute that lets external git hosts (GitHub, GitLab) reach it.
 
-If `gitops.mode` is `pull`, this stack renders nothing — Flux polls and no
+If `gitops.mode` is `pull`, this add-on renders nothing — Flux polls and no
 inbound webhook is needed.
 
 ## Flow
@@ -100,7 +100,7 @@ gateway-originated traffic.
 ### Pull mode
 
 Set `gitops.mode: pull`. Both webhook entries' `when:` evaluates false and
-this stack contributes nothing beyond the namespace already created by
+this add-on contributes nothing beyond the namespace already created by
 Terraform.
 
 ## Substitutions
@@ -110,13 +110,13 @@ Terraform.
 | `git_repository_name` | always (when push mode) | Name of the `GitRepository` the receiver triggers. Defaults to `"local"` (workstation default); platform facets pass through `gitops.repository.name`. The receiver will accept any payload but will only ever reconcile the named repository. |
 
 The `webhook-token` Secret holding the HMAC is provisioned by the
-Terraform module — not by this stack. This Kustomization only references
+Terraform module — not by this add-on. This Kustomization only references
 it (`secretRef.name: webhook-token`).
 
 ## Components
 
-The Kustomize stack has only a webhook subtree. Flux's controllers are
-not in this stack — they ship from the Terraform module.
+The Kustomize add-on has only a webhook subtree. Flux's controllers are
+not in this add-on — they ship from the Terraform module.
 
 | Component | Enable when | Effect |
 |---|---|---|
@@ -126,9 +126,9 @@ not in this stack — they ship from the Terraform module.
 
 ## Dependencies
 
-The Kustomize stack has minimal dependencies:
+The Kustomize add-on has minimal dependencies:
 
-| Stack | Reason |
+| Add-on | Reason |
 |---|---|
 | `gateway-base` *(when Gateway variant)* | The Gateway API CRDs (HTTPRoute) and the `external` Gateway must exist before `webhook/gateway` is applied. |
 
@@ -138,13 +138,13 @@ Dependencies on the Terraform side are richer:
 - `terraform: gitops` `dependsOn: cni` on platforms where Cilium is the CNI (waits for pod networking).
 - `terraform: gitops` `dependsOn: cluster, cluster-extensions` on AWS (EKS-specific, when applicable).
 
-These are not part of the Kustomize stack but matter for ordering: Flux
+These are not part of the Kustomize add-on but matter for ordering: Flux
 itself must be running before any Windsor Kustomization (including this
 one) can reconcile.
 
 ## Operations
 
-Stack-specific failure modes; generic Flux/Renovate behaviour is documented
+Add-on-specific failure modes; generic Flux/Renovate behaviour is documented
 at the repo level.
 
 - **Webhook returns 401** — the HMAC secret in `webhook-token` doesn't match what the git host is signing with. Inspect `kubectl get secret webhook-token -n system-gitops` and confirm the git host webhook config uses the same value. The Terraform module provisions this; on workstations the default is `${gitops.webhook.token ?? "abcdef123456"}`.
@@ -162,9 +162,9 @@ at the repo level.
 
 ## See also
 
-- [terraform/gitops/flux/](../../terraform/gitops/flux/) — the Flux installer, including controllers, GitRepository, root Kustomization, and the `webhook-token` Secret. Most operator concerns about gitops live there, not in this stack.
+- [terraform/gitops/flux/](../../terraform/gitops/flux/) — the Flux installer, including controllers, GitRepository, root Kustomization, and the `webhook-token` Secret. Most operator concerns about gitops live there, not in this add-on.
 - [contexts/_template/facets/platform-base.yaml](../../contexts/_template/facets/platform-base.yaml) (lines ~491-509) — canonical wiring for both webhook variants.
 - [contexts/_template/facets/option-workstation.yaml](../../contexts/_template/facets/option-workstation.yaml) — workstation-specific Terraform inputs (`concurrency`, `git_username`, `git_password`, `webhook_token`).
 - [contexts/_template/facets/option-cni.yaml](../../contexts/_template/facets/option-cni.yaml) — adds the `cni` Terraform dep so Flux waits for pod networking on Cilium clusters.
 - Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
-- Related stacks: [gateway](../gateway/), [cni](../cni/).
+- Related add-ons: [gateway](../gateway/), [cni](../cni/).

--- a/kustomize/ingress/README.md
+++ b/kustomize/ingress/README.md
@@ -1,0 +1,141 @@
+---
+title: Ingress stack
+description: Legacy nginx-ingress controller. Not wired by current facets — the gateway stack is the recommended traffic entrypoint.
+---
+
+# Ingress
+
+> **Status:** No shipped facet wires this stack. The
+> [gateway](../gateway/) stack is the supported traffic entrypoint
+> (Envoy Gateway or Cilium via Gateway API). The components here remain for
+> blueprint authors who explicitly want a Kubernetes Ingress / nginx-based
+> path. The legacy `ingress.driver` field on the schema is treated as an
+> alias by `platform-base` (`'envoy-gateway'` and `'nginx'` both fold into
+> `gateway.driver: envoy`); see
+> [contexts/_template/facets/platform-base.yaml](../../contexts/_template/facets/platform-base.yaml)
+> around the `gateway_effective.driver` resolution.
+
+## Flow
+
+```mermaid
+flowchart LR
+    client([External traffic])
+    pods[Backend Service]
+
+    subgraph systemingress[system-ingress]
+        nginx[ingress-nginx<br/>controller]
+    end
+
+    upstream[(Cluster Services<br/>Ingress / via TCP-UDP map)]
+
+    client -->|LoadBalancer / NodePort| nginx
+    nginx --> upstream --> pods
+```
+
+ingress-nginx terminates HTTP/HTTPS and (when extra components are layered)
+also TCP/UDP for port 53 (CoreDNS) and 9292 (Flux webhook). The data-plane
+Service is exposed via either LoadBalancer or NodePort depending on which
+service-mode component is enabled.
+
+## Recipes
+
+Hand-authored — no shipped facet emits these entries.
+
+### NodePort (docker-desktop, single-node)
+
+```yaml
+- name: ingress
+  path: ingress
+  components:
+    - nginx
+    - nginx/nodeport
+    - nginx/web
+  timeout: 10m
+  interval: 5m
+```
+
+### LoadBalancer (cloud or in-cluster LB)
+
+```yaml
+- name: ingress
+  path: ingress
+  components:
+    - nginx
+    - nginx/loadbalancer
+    - nginx/web
+  timeout: 10m
+  substitutions:
+    loadbalancer_start_ip: 10.5.0.10
+```
+
+> The `nginx/loadbalancer` patch references `${loadbalancer_ip_start}` (note
+> the swapped wording) instead of the canonical `${loadbalancer_start_ip}`
+> — same typo as `gateway/base/envoy/loadbalancer`. The substitution
+> renders empty and the cloud LB allocates an arbitrary IP. To pin a
+> specific IP, fix the patch's variable name first.
+
+### With CoreDNS pass-through and Flux webhook
+
+```yaml
+- name: ingress
+  path: ingress
+  components:
+    - nginx
+    - nginx/nodeport
+    - nginx/web
+    - nginx/coredns
+    - nginx/flux-webhook
+    - nginx/prometheus
+```
+
+## Substitutions
+
+| Name | Required when | Effect |
+|---|---|---|
+| `loadbalancer_start_ip` | `nginx/loadbalancer` is enabled | Anchor IP for the LoadBalancer Service. Must sit inside the cluster's LB IP pool. **Note:** the patch in [nginx/loadbalancer/patches/helm-release.yaml](nginx/loadbalancer/patches/helm-release.yaml) uses `${loadbalancer_ip_start}` (typo) — the value never threads through unless the patch is fixed. |
+
+## Components
+
+| Component | Effect |
+|---|---|
+| `nginx` | Helm release of ingress-nginx v4.15.1 in `system-ingress`. The Service has `enableHttp: false`, `enableTls: false` until layered with `nginx/web`. The IngressClass is set as default. |
+| `nginx/loadbalancer` | Patches the Service to type `LoadBalancer` with `loadBalancerIP` from `${loadbalancer_ip_start}` (see typo note above). |
+| `nginx/nodeport` | Patches the Service to type `NodePort`. |
+| `nginx/web` | Enables HTTP and TLS on the Service with NodePorts 30080 (HTTP) and 30443 (HTTPS). |
+| `nginx/coredns` | Maps Service UDP/TCP port 53 (NodePort 30053 each) to `system-dns/coredns:53`. Use when ingress-nginx is the path for in-cluster DNS exposure (mirrors the gateway stack's `coredns/gateway` and `dns` components). |
+| `nginx/flux-webhook` | Maps Service TCP port 9292 (NodePort 30292) to `system-gitops/webhook-receiver:80`. Mirrors the gateway stack's `gitops/flux/webhook/gateway` route. |
+| `nginx/prometheus` | Enables controller metrics and adds a ServiceMonitor labeled `release: kube-prometheus-stack`. Adds a Flux `dependsOn` so ingress-nginx waits for the Prometheus stack. |
+
+## Dependencies
+
+This stack has no platform-emitted dependencies (no facet wires it).
+Hand-authored recipes should add:
+
+| Stack | When |
+|---|---|
+| `policy-resources` | When `policies.enabled: true`. Without it, ingress-nginx pods may fail Kyverno's image-digest validation on first reconcile. |
+| `pki-base` | When the Ingress consumes a `Certificate` from cert-manager (the `nginx` chart does not ship one — operators add it themselves via `Ingress.spec.tls`). |
+| `lb-base` | When `nginx/loadbalancer` is enabled on AWS or any cluster needing a managed LB controller. |
+| `dns` | When `nginx/coredns` is enabled, since the upstream `system-dns/coredns:53` Service must exist before ingress-nginx forwards to it. |
+
+## Operations
+
+Stack-specific failure modes; generic Flux/Renovate behaviour is documented
+at the repo level.
+
+- **`nginx/loadbalancer` Service has no IP** — see the typo note above; the patch references the wrong variable name, so `loadBalancerIP` renders empty. Either fix the patch (`loadbalancer_ip_start` → `loadbalancer_start_ip`) or pin via cloud-provider annotations on the Service instead.
+- **`nginx/coredns` doesn't resolve queries** — the `system-dns` Kustomization isn't applied, or the `coredns` Service in that namespace is named differently. The TCP/UDP map points at `system-dns/coredns:53`; verify both the namespace and the Service name with `kubectl get svc -n system-dns`.
+- **Flux pushes don't trigger reconciles via the webhook port** — `nginx/flux-webhook` maps to `system-gitops/webhook-receiver:80`. Without that Service (provisioned by the gitops stack's `webhook` component), the TCP map dead-ends.
+- **Prometheus metrics missing** — `nginx/prometheus` adds a ServiceMonitor with the `kube-prometheus-stack` release label. If telemetry uses a different Prometheus setup, the label must match.
+
+## Security
+
+- The `system-ingress` namespace runs at PSA `baseline`. ingress-nginx does not need privileged mode.
+- TLS termination is handled by ingress-nginx; certificates come from `Secret` references in each `Ingress` resource. Operators are responsible for creating those Secrets — typically via cert-manager `Certificate` resources from the `pki` stack.
+
+## See also
+
+- [contexts/_template/facets/platform-base.yaml](../../contexts/_template/facets/platform-base.yaml) — `gateway_effective.driver` resolution that folds the legacy `ingress.driver` field into `gateway.driver`.
+- [../gateway/](../gateway/) — the supported traffic entrypoint stack. New blueprints should wire that instead.
+- Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
+- Related stacks: [gateway](../gateway/), [pki](../pki/), [lb](../lb/), [dns](../dns/), [gitops](../gitops/), [telemetry](../telemetry/).

--- a/kustomize/ingress/README.md
+++ b/kustomize/ingress/README.md
@@ -1,12 +1,12 @@
 ---
-title: Ingress stack
-description: Legacy nginx-ingress controller. Not wired by current facets — the gateway stack is the recommended traffic entrypoint.
+title: Ingress add-on
+description: Legacy nginx-ingress controller. Not wired by current facets — the gateway add-on is the recommended traffic entrypoint.
 ---
 
 # Ingress
 
-> **Status:** No shipped facet wires this stack. The
-> [gateway](../gateway/) stack is the supported traffic entrypoint
+> **Status:** No shipped facet wires this add-on. The
+> [gateway](../gateway/) add-on is the supported traffic entrypoint
 > (Envoy Gateway or Cilium via Gateway API). The components here remain for
 > blueprint authors who explicitly want a Kubernetes Ingress / nginx-based
 > path. The legacy `ingress.driver` field on the schema is treated as an
@@ -102,16 +102,16 @@ Hand-authored — no shipped facet emits these entries.
 | `nginx/loadbalancer` | Patches the Service to type `LoadBalancer` with `loadBalancerIP` from `${loadbalancer_ip_start}` (see typo note above). |
 | `nginx/nodeport` | Patches the Service to type `NodePort`. |
 | `nginx/web` | Enables HTTP and TLS on the Service with NodePorts 30080 (HTTP) and 30443 (HTTPS). |
-| `nginx/coredns` | Maps Service UDP/TCP port 53 (NodePort 30053 each) to `system-dns/coredns:53`. Use when ingress-nginx is the path for in-cluster DNS exposure (mirrors the gateway stack's `coredns/gateway` and `dns` components). |
-| `nginx/flux-webhook` | Maps Service TCP port 9292 (NodePort 30292) to `system-gitops/webhook-receiver:80`. Mirrors the gateway stack's `gitops/flux/webhook/gateway` route. |
-| `nginx/prometheus` | Enables controller metrics and adds a ServiceMonitor labeled `release: kube-prometheus-stack`. Adds a Flux `dependsOn` so ingress-nginx waits for the Prometheus stack. |
+| `nginx/coredns` | Maps Service UDP/TCP port 53 (NodePort 30053 each) to `system-dns/coredns:53`. Use when ingress-nginx is the path for in-cluster DNS exposure (mirrors the gateway add-on's `coredns/gateway` and `dns` components). |
+| `nginx/flux-webhook` | Maps Service TCP port 9292 (NodePort 30292) to `system-gitops/webhook-receiver:80`. Mirrors the gateway add-on's `gitops/flux/webhook/gateway` route. |
+| `nginx/prometheus` | Enables controller metrics and adds a ServiceMonitor labeled `release: kube-prometheus-stack`. Adds a Flux `dependsOn` so ingress-nginx waits for the Prometheus add-on. |
 
 ## Dependencies
 
-This stack has no platform-emitted dependencies (no facet wires it).
+This add-on has no platform-emitted dependencies (no facet wires it).
 Hand-authored recipes should add:
 
-| Stack | When |
+| Add-on | When |
 |---|---|
 | `policy-resources` | When `policies.enabled: true`. Without it, ingress-nginx pods may fail Kyverno's image-digest validation on first reconcile. |
 | `pki-base` | When the Ingress consumes a `Certificate` from cert-manager (the `nginx` chart does not ship one — operators add it themselves via `Ingress.spec.tls`). |
@@ -120,22 +120,22 @@ Hand-authored recipes should add:
 
 ## Operations
 
-Stack-specific failure modes; generic Flux/Renovate behaviour is documented
+Add-on-specific failure modes; generic Flux/Renovate behaviour is documented
 at the repo level.
 
 - **`nginx/loadbalancer` Service has no IP** — see the typo note above; the patch references the wrong variable name, so `loadBalancerIP` renders empty. Either fix the patch (`loadbalancer_ip_start` → `loadbalancer_start_ip`) or pin via cloud-provider annotations on the Service instead.
 - **`nginx/coredns` doesn't resolve queries** — the `system-dns` Kustomization isn't applied, or the `coredns` Service in that namespace is named differently. The TCP/UDP map points at `system-dns/coredns:53`; verify both the namespace and the Service name with `kubectl get svc -n system-dns`.
-- **Flux pushes don't trigger reconciles via the webhook port** — `nginx/flux-webhook` maps to `system-gitops/webhook-receiver:80`. Without that Service (provisioned by the gitops stack's `webhook` component), the TCP map dead-ends.
+- **Flux pushes don't trigger reconciles via the webhook port** — `nginx/flux-webhook` maps to `system-gitops/webhook-receiver:80`. Without that Service (provisioned by the gitops add-on's `webhook` component), the TCP map dead-ends.
 - **Prometheus metrics missing** — `nginx/prometheus` adds a ServiceMonitor with the `kube-prometheus-stack` release label. If telemetry uses a different Prometheus setup, the label must match.
 
 ## Security
 
 - The `system-ingress` namespace runs at PSA `baseline`. ingress-nginx does not need privileged mode.
-- TLS termination is handled by ingress-nginx; certificates come from `Secret` references in each `Ingress` resource. Operators are responsible for creating those Secrets — typically via cert-manager `Certificate` resources from the `pki` stack.
+- TLS termination is handled by ingress-nginx; certificates come from `Secret` references in each `Ingress` resource. Operators are responsible for creating those Secrets — typically via cert-manager `Certificate` resources from the `pki` add-on.
 
 ## See also
 
 - [contexts/_template/facets/platform-base.yaml](../../contexts/_template/facets/platform-base.yaml) — `gateway_effective.driver` resolution that folds the legacy `ingress.driver` field into `gateway.driver`.
-- [../gateway/](../gateway/) — the supported traffic entrypoint stack. New blueprints should wire that instead.
+- [../gateway/](../gateway/) — the supported traffic entrypoint add-on. New blueprints should wire that instead.
 - Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
-- Related stacks: [gateway](../gateway/), [pki](../pki/), [lb](../lb/), [dns](../dns/), [gitops](../gitops/), [telemetry](../telemetry/).
+- Related add-ons: [gateway](../gateway/), [pki](../pki/), [lb](../lb/), [dns](../dns/), [gitops](../gitops/), [telemetry](../telemetry/).

--- a/kustomize/lb/README.md
+++ b/kustomize/lb/README.md
@@ -1,0 +1,198 @@
+---
+title: Load balancer stack
+description: AWS Load Balancer Controller for cloud, MetalLB or kube-vip for bare metal and incus.
+---
+
+# Load balancer
+
+Exposes Kubernetes `Service` of type `LoadBalancer` to clients outside the
+cluster. Two paths share the same `system-lb` namespace and the same
+canonical Kustomization names — which controller is wired depends on the
+platform.
+
+- **Cloud** (AWS): the `aws-load-balancer-controller` reconciles Services
+  and Ingress into AWS NLBs and ALBs.
+- **In-cluster** (metal, incus, docker): MetalLB or kube-vip allocates an IP
+  from a pool defined by the network module and advertises it via ARP/L2.
+
+Azure clusters use the native AKS LB and do not render this stack.
+
+## Flow
+
+```mermaid
+flowchart LR
+    svc[Service type=LoadBalancer]
+    client([External traffic])
+
+    subgraph systemlb[system-lb]
+        aws[aws-load-balancer-controller]
+        metallb[MetalLB controller<br/>+ speaker DaemonSet]
+        kubevip[kube-vip DaemonSet]
+    end
+
+    nlb[AWS NLB / ALB]
+    pool[(IP from<br/>loadbalancer_ip_range)]
+
+    svc -.watched by.-> aws
+    svc -.watched by.-> metallb
+    svc -.watched by.-> kubevip
+
+    aws -->|reconciles| nlb
+    metallb -->|advertises via ARP| pool
+    kubevip -->|advertises via ARP| pool
+
+    nlb --> client
+    pool --> client
+```
+
+The `system-lb` namespace runs at PSA `privileged` because the in-cluster
+speakers need NET_ADMIN and host networking to send gratuitous ARP. The AWS
+LB Controller does not need privilege but shares the namespace.
+
+## Recipes
+
+`lb-base` and `lb-resources` are conditional. AWS always renders `lb-base`
+(the AWS LB Controller). metal/incus/docker render both when
+`lb_effective.enabled` is true. docker-desktop and Azure never render this
+stack.
+
+### AWS (cloud-managed NLB/ALB)
+
+The controller does not allocate IPs itself — it provisions cloud LBs in
+response to `Service` and `Ingress` resources. No `lb-resources` is needed.
+
+```yaml
+- name: lb-base
+  path: lb/base
+  dependsOn: [policy-resources]
+  components:
+    - aws-lb-controller
+  substitutions:
+    cluster_name: <terraform output cluster.cluster_name>
+    vpc_id: <terraform output network.vpc_id>
+    aws_region: us-east-1
+```
+
+### Metal or incus with MetalLB
+
+Set `network.loadbalancer_driver: metallb` to choose this path
+(`lb_effective.driver` otherwise defaults to `kube-vip`).
+
+```yaml
+- name: lb-base
+  path: lb/base
+  dependsOn: [policy-resources]
+  components:
+    - metallb
+
+- name: lb-resources
+  path: lb/resources
+  dependsOn: [lb-base]
+  components:
+    - metallb/arp
+  substitutions:
+    loadbalancer_ip_range: 10.5.1.10-10.5.1.30
+```
+
+### Metal or incus with kube-vip (default driver)
+
+kube-vip is deployed entirely from `lb-resources` — there is no `lb-base`
+component for kube-vip, so `lb-base` only renders the `system-lb` namespace.
+
+```yaml
+- name: lb-base
+  path: lb/base
+  dependsOn: [policy-resources]
+  components: []
+
+- name: lb-resources
+  path: lb/resources
+  dependsOn: [lb-base]
+  components:
+    - kube-vip
+    - kube-vip/arp
+  substitutions:
+    loadbalancer_ip_range: 10.5.1.10-10.5.1.30
+```
+
+## Substitutions
+
+| Name | Required when | Effect |
+|---|---|---|
+| `cluster_name` | `aws-lb-controller` is enabled | AWS LB Controller `clusterName` value. Stamped onto every AWS resource the controller owns; the controller filters reconciliation by this tag, so two clusters in the same account must use distinct names. No fallback — empty fails the helm install loudly. |
+| `vpc_id` | `aws-lb-controller` is enabled | VPC ID passed explicitly so the controller does not fall back to IMDS (worker launch templates set `http_put_response_hop_limit=1`, blocking pod-network IMDS calls). |
+| `aws_region` | `aws-lb-controller` is enabled | AWS region the controller's API calls target. No default — a wrong region silently misses the cluster's VPC and emits confusing "not found" errors. |
+| `loadbalancer_ip_range` | `metallb/arp` or `kube-vip/arp` is enabled | IP range MetalLB or kube-vip allocates LoadBalancer IPs from. Format `start-end` (e.g. `10.5.1.10-10.5.1.30`); platform facets render this from `network_effective.loadbalancer_ips.start + '-' + .end`. |
+
+## Components
+
+### `lb/base/`
+
+The base kustomization always renders the `system-lb` namespace.
+
+| Component | Enable when | Effect |
+|---|---|---|
+| `aws-lb-controller` | platform is AWS | Helm release of `aws-load-balancer-controller` v3.2.2 in `system-lb`. Two replicas with anti-affinity (degrades gracefully on single-node). IRSA / Pod Identity provides the IAM role; `clusterName`, `vpcId`, and `region` are passed through substitutions to avoid IMDS. |
+| `metallb` | `lb_effective.driver == 'metallb'` | Helm release of MetalLB v0.15.3 (controller + speaker) in `system-lb`. CRDs (IPAddressPool, L2Advertisement) ship with the chart. |
+
+### `lb/resources/`
+
+The base kustomization is empty by default. AWS does not render
+`lb-resources` (the controller manages cloud LBs, not in-cluster IPs).
+
+| Component | Enable when | Effect |
+|---|---|---|
+| `metallb/arp` | metallb + ARP / L2 mode | Creates `IPAddressPool/metallb-layer2` with `addresses: ${loadbalancer_ip_range}` and `L2Advertisement/metallb-layer2` selecting that pool. |
+| `metallb/layer2` | (deprecated) | Compatibility shim that imports `../arp`. Will be dropped in v0.8.0 — switch to `metallb/arp` directly. |
+| `kube-vip` | `lb_effective.driver == 'kube-vip'` | Helm release of kube-vip v0.9.8 with service election enabled, plus a sidecar release for the kube-vip cloud-provider that handles IP allocation. |
+| `kube-vip/arp` | kube-vip + ARP mode | Patches the kube-vip HelmRelease to set `vip_arp: true` and `vip_routing_table: false` (gratuitous ARP advertisement, no BGP table). |
+
+There is intentionally no top-level `metallb` Component in `lb/resources/`
+— the `metallb/arp` component does all the work and `lb-base` already owns
+the controller. Platform facets that emit `${lb_effective.driver}` as a
+component path (uniform with the kube-vip path) effectively no-op for
+metallb; hand-authored blueprints should list only `metallb/arp`.
+
+## Dependencies
+
+| Stack | Reason |
+|---|---|
+| `policy-resources` | `lb-base` `dependsOn` policy-resources on every platform that wires it. The lb namespace runs at PSA `privileged` and Kyverno policies inspect/exempt it; reconciling the helm release before policy CRDs exist would race. |
+
+`lb-resources` always depends on `lb-base` (the controller must be running
+before any `IPAddressPool` or `L2Advertisement` is created — without the
+MetalLB CRDs the apply fails on `no matches for kind IPAddressPool`).
+
+Reverse dependency: any stack that owns a `Service` of type `LoadBalancer`
+or an `Ingress` reconciled by the AWS LBC declares `dependsOn: lb-base` so
+destroy ordering puts the controller last. The controller has to be alive
+to clear AWS finalizers (`service.k8s.aws/resources`,
+`elbv2.k8s.aws/resources`) when the consumer Service is deleted; if the
+controller is torn down first, those resources hang.
+
+## Operations
+
+Stack-specific failure modes; generic Flux/Renovate behaviour is documented
+at the repo level.
+
+- **AWS LB Controller crashlooping with `failed to discover VPC`** — `vpc_id` or `aws_region` substitution didn't resolve. Check `terraform_output('network', 'vpc_id')` returned a value and that the deferred substitution propagated.
+- **AWS LB Controller starts but no AWS resources are created** — `clusterName` doesn't match the EKS / Pod Identity association. The IAM role's trust policy is scoped by cluster name; a mismatch fails silently with permission errors at API call time.
+- **MetalLB Service stuck in `Pending` with no external IP** — `loadbalancer_ip_range` is empty or doesn't cover any unused IPs. Confirm `network.loadbalancer_ips` in the context values resolves to a real range; check `kubectl get ipaddresspool -n system-lb -o yaml`.
+- **MetalLB IP allocated but unreachable** — speakers can't send gratuitous ARP. Usually a CNI / underlay network policy issue; the speaker DaemonSet runs at PSA `privileged` and needs host networking on every node.
+- **`lb-resources` reports `no matches for kind IPAddressPool`** — the MetalLB CRDs aren't ready. Either `lb-base` hasn't reconciled yet, or the chart version is mismatched with the CRD apiVersion (`metallb.io/v1beta1`).
+- **AWS LB stuck on destroy** — a consumer Service was torn down after `lb-base`. Re-reconcile `lb-base`, wait for the controller to come back, then delete the Service / Ingress.
+
+## Security
+
+- The `system-lb` namespace runs at PSA `privileged`. MetalLB speakers and kube-vip require NET_ADMIN and host networking; the AWS LB Controller does not but shares the namespace.
+- AWS LB Controller IAM is provided by IRSA or Pod Identity (the `serviceMutatorWebhook` is disabled — pods are not annotated). The associated IAM role is provisioned by the cluster Terraform module.
+- MetalLB advertises only IPs in `loadbalancer_ip_range`. The pool is namespace-scoped to `system-lb`; a Service requesting a `loadBalancerClass` MetalLB does not own will be ignored.
+
+## See also
+
+- [contexts/_template/facets/platform-aws.yaml](../../contexts/_template/facets/platform-aws.yaml) — AWS LBC wiring with `cluster_name` / `vpc_id` substitutions.
+- [contexts/_template/facets/platform-metal.yaml](../../contexts/_template/facets/platform-metal.yaml) — metal MetalLB wiring.
+- [contexts/_template/facets/platform-incus.yaml](../../contexts/_template/facets/platform-incus.yaml) — incus wiring (supports both metallb and kube-vip drivers).
+- [contexts/_template/facets/platform-base.yaml](../../contexts/_template/facets/platform-base.yaml) — `lb_effective` resolution, including the `controller_required` flag consumers depend on.
+- Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
+- Related stacks: [policy](../policy/), [gateway](../gateway/).

--- a/kustomize/lb/README.md
+++ b/kustomize/lb/README.md
@@ -1,5 +1,5 @@
 ---
-title: Load balancer stack
+title: Load balancer add-on
 description: AWS Load Balancer Controller for cloud, MetalLB or kube-vip for bare metal and incus.
 ---
 
@@ -15,7 +15,7 @@ platform.
 - **In-cluster** (metal, incus, docker): MetalLB or kube-vip allocates an IP
   from a pool defined by the network module and advertises it via ARP/L2.
 
-Azure clusters use the native AKS LB and do not render this stack.
+Azure clusters use the native AKS LB and do not render this add-on.
 
 ## Flow
 
@@ -54,7 +54,7 @@ LB Controller does not need privilege but shares the namespace.
 `lb-base` and `lb-resources` are conditional. AWS always renders `lb-base`
 (the AWS LB Controller). metal/incus/docker render both when
 `network.loadbalancer_driver` is set. docker-desktop forces no in-cluster
-LB regardless (no routable node network); Azure never renders this stack
+LB regardless (no routable node network); Azure never renders this add-on
 (uses native AKS LBs).
 
 ### AWS (cloud-managed NLB/ALB)
@@ -151,7 +151,7 @@ The base kustomization is empty by default. AWS does not render
 
 ## Dependencies
 
-| Stack | Reason |
+| Add-on | Reason |
 |---|---|
 | `policy-resources` | `lb-base` `dependsOn` policy-resources on every platform that wires it. The lb namespace runs at PSA `privileged` and Kyverno policies inspect/exempt it; reconciling the helm release before policy CRDs exist would race. |
 
@@ -159,7 +159,7 @@ The base kustomization is empty by default. AWS does not render
 before any `IPAddressPool` or `L2Advertisement` is created — without the
 MetalLB CRDs the apply fails on `no matches for kind IPAddressPool`).
 
-Reverse dependency: any stack that owns a `Service` of type `LoadBalancer`
+Reverse dependency: any add-on that owns a `Service` of type `LoadBalancer`
 or an `Ingress` reconciled by the AWS LBC declares `dependsOn: lb-base` so
 destroy ordering puts the controller last. The controller has to be alive
 to clear AWS finalizers (`service.k8s.aws/resources`,
@@ -168,7 +168,7 @@ controller is torn down first, those resources hang.
 
 ## Operations
 
-Stack-specific failure modes; generic Flux/Renovate behaviour is documented
+Add-on-specific failure modes; generic Flux/Renovate behaviour is documented
 at the repo level.
 
 - **AWS LB Controller crashlooping with `failed to discover VPC`** — `vpc_id` or `aws_region` substitution didn't resolve. Check `terraform_output('network', 'vpc_id')` returned a value and that the deferred substitution propagated.
@@ -191,4 +191,4 @@ at the repo level.
 - [contexts/_template/facets/platform-incus.yaml](../../contexts/_template/facets/platform-incus.yaml) — incus wiring (supports both metallb and kube-vip drivers).
 - [contexts/_template/facets/platform-base.yaml](../../contexts/_template/facets/platform-base.yaml) — `lb_effective` resolution (the internal config that folds `network.loadbalancer_driver` together with platform-specific overrides like docker-desktop's force-disable).
 - Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
-- Related stacks: [policy](../policy/), [gateway](../gateway/).
+- Related add-ons: [policy](../policy/), [gateway](../gateway/).

--- a/kustomize/lb/README.md
+++ b/kustomize/lb/README.md
@@ -89,6 +89,7 @@ Set `network.loadbalancer_driver: metallb` to choose this path
   path: lb/resources
   dependsOn: [lb-base]
   components:
+    - metallb
     - metallb/arp
   substitutions:
     loadbalancer_ip_range: 10.5.1.10-10.5.1.30
@@ -142,16 +143,11 @@ The base kustomization is empty by default. AWS does not render
 
 | Component | Enable when | Effect |
 |---|---|---|
+| `metallb` | `lb_effective.driver == 'metallb'` | Empty placeholder Component. The MetalLB controller is installed by `lb-base/metallb`; this exists so the uniform `${lb_effective.driver}` pattern in platform facets resolves to a real path on both driver branches. |
 | `metallb/arp` | metallb + ARP / L2 mode | Creates `IPAddressPool/metallb-layer2` with `addresses: ${loadbalancer_ip_range}` and `L2Advertisement/metallb-layer2` selecting that pool. |
 | `metallb/layer2` | (deprecated) | Compatibility shim that imports `../arp`. Will be dropped in v0.8.0 — switch to `metallb/arp` directly. |
 | `kube-vip` | `lb_effective.driver == 'kube-vip'` | Helm release of kube-vip v0.9.8 with service election enabled, plus a sidecar release for the kube-vip cloud-provider that handles IP allocation. |
 | `kube-vip/arp` | kube-vip + ARP mode | Patches the kube-vip HelmRelease to set `vip_arp: true` and `vip_routing_table: false` (gratuitous ARP advertisement, no BGP table). |
-
-There is intentionally no top-level `metallb` Component in `lb/resources/`
-— the `metallb/arp` component does all the work and `lb-base` already owns
-the controller. Platform facets that emit `${lb_effective.driver}` as a
-component path (uniform with the kube-vip path) effectively no-op for
-metallb; hand-authored blueprints should list only `metallb/arp`.
 
 ## Dependencies
 

--- a/kustomize/lb/README.md
+++ b/kustomize/lb/README.md
@@ -53,8 +53,9 @@ LB Controller does not need privilege but shares the namespace.
 
 `lb-base` and `lb-resources` are conditional. AWS always renders `lb-base`
 (the AWS LB Controller). metal/incus/docker render both when
-`lb_effective.enabled` is true. docker-desktop and Azure never render this
-stack.
+`network.loadbalancer_driver` is set. docker-desktop forces no in-cluster
+LB regardless (no routable node network); Azure never renders this stack
+(uses native AKS LBs).
 
 ### AWS (cloud-managed NLB/ALB)
 
@@ -75,8 +76,7 @@ response to `Service` and `Ingress` resources. No `lb-resources` is needed.
 
 ### Metal or incus with MetalLB
 
-Set `network.loadbalancer_driver: metallb` to choose this path
-(`lb_effective.driver` otherwise defaults to `kube-vip`).
+Set `network.loadbalancer_driver: metallb`. The default is `kube-vip`.
 
 ```yaml
 - name: lb-base
@@ -123,7 +123,7 @@ component for kube-vip, so `lb-base` only renders the `system-lb` namespace.
 | `cluster_name` | `aws-lb-controller` is enabled | AWS LB Controller `clusterName` value. Stamped onto every AWS resource the controller owns; the controller filters reconciliation by this tag, so two clusters in the same account must use distinct names. No fallback — empty fails the helm install loudly. |
 | `vpc_id` | `aws-lb-controller` is enabled | VPC ID passed explicitly so the controller does not fall back to IMDS (worker launch templates set `http_put_response_hop_limit=1`, blocking pod-network IMDS calls). |
 | `aws_region` | `aws-lb-controller` is enabled | AWS region the controller's API calls target. No default — a wrong region silently misses the cluster's VPC and emits confusing "not found" errors. |
-| `loadbalancer_ip_range` | `metallb/arp` or `kube-vip/arp` is enabled | IP range MetalLB or kube-vip allocates LoadBalancer IPs from. Format `start-end` (e.g. `10.5.1.10-10.5.1.30`); platform facets render this from `network_effective.loadbalancer_ips.start + '-' + .end`. |
+| `loadbalancer_ip_range` | `metallb/arp` or `kube-vip/arp` is enabled | IP range MetalLB or kube-vip allocates LoadBalancer IPs from. Format `start-end` (e.g. `10.5.1.10-10.5.1.30`); sourced from `network.loadbalancer_ips.start` and `network.loadbalancer_ips.end` joined by `-`. |
 
 ## Components
 
@@ -134,7 +134,7 @@ The base kustomization always renders the `system-lb` namespace.
 | Component | Enable when | Effect |
 |---|---|---|
 | `aws-lb-controller` | platform is AWS | Helm release of `aws-load-balancer-controller` v3.2.2 in `system-lb`. Two replicas with anti-affinity (degrades gracefully on single-node). IRSA / Pod Identity provides the IAM role; `clusterName`, `vpcId`, and `region` are passed through substitutions to avoid IMDS. |
-| `metallb` | `lb_effective.driver == 'metallb'` | Helm release of MetalLB v0.15.3 (controller + speaker) in `system-lb`. CRDs (IPAddressPool, L2Advertisement) ship with the chart. |
+| `metallb` | `network.loadbalancer_driver: metallb` | Helm release of MetalLB v0.15.3 (controller + speaker) in `system-lb`. CRDs (IPAddressPool, L2Advertisement) ship with the chart. |
 
 ### `lb/resources/`
 
@@ -143,11 +143,11 @@ The base kustomization is empty by default. AWS does not render
 
 | Component | Enable when | Effect |
 |---|---|---|
-| `metallb` | `lb_effective.driver == 'metallb'` | Empty placeholder Component. The MetalLB controller is installed by `lb-base/metallb`; this exists so the uniform `${lb_effective.driver}` pattern in platform facets resolves to a real path on both driver branches. |
-| `metallb/arp` | metallb + ARP / L2 mode | Creates `IPAddressPool/metallb-layer2` with `addresses: ${loadbalancer_ip_range}` and `L2Advertisement/metallb-layer2` selecting that pool. |
+| `metallb` | `network.loadbalancer_driver: metallb` | Empty placeholder Component. The MetalLB controller is installed by `lb-base/metallb`; this exists so the uniform `${driver}` pattern in platform facets resolves to a real path on both driver branches. |
+| `metallb/arp` | metallb + `network.loadbalancer_mode: arp` (default) | Creates `IPAddressPool/metallb-layer2` with `addresses: ${loadbalancer_ip_range}` and `L2Advertisement/metallb-layer2` selecting that pool. |
 | `metallb/layer2` | (deprecated) | Compatibility shim that imports `../arp`. Will be dropped in v0.8.0 — switch to `metallb/arp` directly. |
-| `kube-vip` | `lb_effective.driver == 'kube-vip'` | Helm release of kube-vip v0.9.8 with service election enabled, plus a sidecar release for the kube-vip cloud-provider that handles IP allocation. |
-| `kube-vip/arp` | kube-vip + ARP mode | Patches the kube-vip HelmRelease to set `vip_arp: true` and `vip_routing_table: false` (gratuitous ARP advertisement, no BGP table). |
+| `kube-vip` | `network.loadbalancer_driver: kube-vip` (the default) | Helm release of kube-vip v0.9.8 with service election enabled, plus a sidecar release for the kube-vip cloud-provider that handles IP allocation. |
+| `kube-vip/arp` | kube-vip + `network.loadbalancer_mode: arp` (default) | Patches the kube-vip HelmRelease to set `vip_arp: true` and `vip_routing_table: false` (gratuitous ARP advertisement, no BGP table). |
 
 ## Dependencies
 
@@ -189,6 +189,6 @@ at the repo level.
 - [contexts/_template/facets/platform-aws.yaml](../../contexts/_template/facets/platform-aws.yaml) — AWS LBC wiring with `cluster_name` / `vpc_id` substitutions.
 - [contexts/_template/facets/platform-metal.yaml](../../contexts/_template/facets/platform-metal.yaml) — metal MetalLB wiring.
 - [contexts/_template/facets/platform-incus.yaml](../../contexts/_template/facets/platform-incus.yaml) — incus wiring (supports both metallb and kube-vip drivers).
-- [contexts/_template/facets/platform-base.yaml](../../contexts/_template/facets/platform-base.yaml) — `lb_effective` resolution, including the `controller_required` flag consumers depend on.
+- [contexts/_template/facets/platform-base.yaml](../../contexts/_template/facets/platform-base.yaml) — `lb_effective` resolution (the internal config that folds `network.loadbalancer_driver` together with platform-specific overrides like docker-desktop's force-disable).
 - Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
 - Related stacks: [policy](../policy/), [gateway](../gateway/).

--- a/kustomize/lb/resources/metallb/kustomization.yaml
+++ b/kustomize/lb/resources/metallb/kustomization.yaml
@@ -1,0 +1,2 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component

--- a/kustomize/object-store/README.md
+++ b/kustomize/object-store/README.md
@@ -1,5 +1,5 @@
 ---
-title: Object store stack
+title: Object store add-on
 description: MinIO operator and tenant resources for S3-compatible object storage.
 ---
 
@@ -33,7 +33,7 @@ flowchart LR
     end
 
     csi[(CSI PVC)]
-    issuer[ClusterIssuer 'private'<br/>from pki stack]
+    issuer[ClusterIssuer 'private'<br/>from pki add-on]
 
     job -->|creates| secret
     cert -.issued by.-> issuer
@@ -97,7 +97,7 @@ Certificate stays `Pending` and the Tenant never gets a TLS Secret.
 
 ## Substitutions
 
-This stack does not consume any blueprint substitutions. All tenant
+This add-on does not consume any blueprint substitutions. All tenant
 configuration is in the shipped manifests.
 
 ## Components
@@ -126,14 +126,14 @@ provides a reference tenant.
 
 ## Dependencies
 
-| Stack | Reason |
+| Add-on | Reason |
 |---|---|
 | `csi` | The MinIO operator does not allocate PVCs eagerly, but tenant pools do. The shipped reference tenant requests a 1Gi PVC on StorageClass `single`; without a CSI driver, tenant pods stay `Pending`. |
 | `pki-resources` *(only when wiring `resources/common`)* | The reference tenant's `Certificate` references `ClusterIssuer/private`, which is created by `addon-private-ca`'s `pki-resources` entry. Wiring `object-store/resources` without `addon-private-ca` enabled produces a Certificate stuck `Pending`. |
 
 ## Operations
 
-Stack-specific failure modes; generic Flux/Renovate behaviour is documented
+Add-on-specific failure modes; generic Flux/Renovate behaviour is documented
 at the repo level.
 
 - **`Tenant` reconciles but pods stay `Pending`** — PVC scheduling. The reference tenant uses StorageClass `single` and 1 volume per server; check `kubectl get pvc -n system-object-store` and the StorageClass's `volumeBindingMode` (it's `WaitForFirstConsumer` on the cloud paths, so the volume only provisions when the Pod schedules).
@@ -146,7 +146,7 @@ at the repo level.
 
 - The `system-object-store` namespace runs at PSA `baseline`. The namespace is also labeled `use-custom-ca: "true"`, so trust-manager's Bundle (from `addon-private-ca`) distributes the cluster's private CA to it.
 - The operator pod runs `runAsUser: 1000`, `fsGroup: 1000`. The credential-generation Job runs `runAsNonRoot: true`, drops all capabilities, and uses `seccompProfile: RuntimeDefault`.
-- mTLS for the tenant is enforced via `requestAutoCert: false` + `externalCertSecret` referencing the cert-manager-issued `minio-private-tls`. There is no in-tree certificate generation; everything flows through the `pki` stack.
+- mTLS for the tenant is enforced via `requestAutoCert: false` + `externalCertSecret` referencing the cert-manager-issued `minio-private-tls`. There is no in-tree certificate generation; everything flows through the `pki` add-on.
 - Root credentials are generated in-cluster (12-byte hex access key, 16-byte hex secret key) by the bootstrap Job. They're stored in the `minio-root-creds` Secret in `system-object-store`. Tenant workloads needing the root credentials must reference this Secret directly; consider rotating before exposing the tenant.
 - Tenant ingress (API and console) is disabled by default. Exposing the tenant externally is the consumer's responsibility — add an HTTPRoute and update the Certificate SANs.
 
@@ -156,4 +156,4 @@ at the repo level.
 - [base/minio/git-repository.yaml](base/minio/git-repository.yaml) — stray file not included in the kustomization. Unused.
 - Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
 - MinIO operator docs — https://min.io/docs/minio/kubernetes/upstream/
-- Related stacks: [csi](../csi/), [pki](../pki/).
+- Related add-ons: [csi](../csi/), [pki](../pki/).

--- a/kustomize/object-store/README.md
+++ b/kustomize/object-store/README.md
@@ -1,0 +1,159 @@
+---
+title: Object store stack
+description: MinIO operator and tenant resources for S3-compatible object storage.
+---
+
+# Object store
+
+S3-compatible object storage backed by the MinIO operator. The operator
+runs in `system-object-store` and watches `Tenant` (minio.min.io/v2)
+resources cluster-wide; tenants instantiate actual MinIO server pools.
+
+The shipped `addon-object-store` facet wires only the operator (the
+`object-store-base` Kustomization). The tenant resources at
+`object-store/resources/common/` — a `Tenant` HelmRelease, mTLS
+certificate, root-credential generation Job, and supporting RBAC — are not
+emitted by any shipped facet. Blueprint authors who want a default tenant
+must wire `object-store/resources` themselves.
+
+`addons.object_store.driver: minio` is currently the only driver wired.
+
+## Flow
+
+```mermaid
+flowchart LR
+    consumer[Consumer pods<br/>S3 API client]
+
+    subgraph systemobjectstore[system-object-store]
+        operator[MinIO operator]
+        tenant[Tenant 'common'<br/>_unwired by addon_]
+        secret[(minio-root-creds Secret)]
+        cert[Certificate minio-private]
+        job[generate-minio-root-creds Job]
+    end
+
+    csi[(CSI PVC)]
+    issuer[ClusterIssuer 'private'<br/>from pki stack]
+
+    job -->|creates| secret
+    cert -.issued by.-> issuer
+    operator -.reconciles.-> tenant
+    tenant -->|reads| secret
+    tenant -->|TLS from| cert
+    tenant -->|backs to| csi
+
+    consumer -->|S3 over mTLS| tenant
+```
+
+The operator alone is enough to deploy MinIO tenants — workloads can apply
+their own `Tenant` resources in any namespace. The shipped (but unwired)
+`resources/common/` set is a complete reference tenant: it issues a
+`Certificate` from the `private` ClusterIssuer (so the addon-private-ca
+trust path covers it), generates root credentials via a Job, and creates
+a single-pool tenant named `common`.
+
+## Recipes
+
+### Operator only (what `addon-object-store` ships)
+
+Sufficient for blueprints whose workloads define their own `Tenant`
+resources.
+
+```yaml
+- name: object-store-base
+  path: object-store/base
+  dependsOn: [csi]
+  components:
+    - minio
+  timeout: 10m
+  interval: 5m
+```
+
+### With the reference `common` tenant (manual wiring)
+
+Adds a `Tenant` HelmRelease, mTLS certificate, and root-credential Job.
+Single pool, 1 server, 1 volume, 1Gi PVC on the `single` StorageClass.
+
+```yaml
+- name: object-store-base
+  path: object-store/base
+  dependsOn: [csi]
+  components:
+    - minio
+
+- name: object-store-resources
+  path: object-store/resources
+  dependsOn: [object-store-base, pki-resources]
+  components:
+    - common
+  timeout: 10m
+  interval: 5m
+```
+
+The dependency on `pki-resources` is critical: the tenant Certificate
+references `ClusterIssuer/private`, which is created by the
+`addon-private-ca` facet's `pki-resources` entry. Without it, the
+Certificate stays `Pending` and the Tenant never gets a TLS Secret.
+
+## Substitutions
+
+This stack does not consume any blueprint substitutions. All tenant
+configuration is in the shipped manifests.
+
+## Components
+
+### `object-store/base/`
+
+| Component | Enable when | Effect |
+|---|---|---|
+| `minio` | `addons.object_store.driver: minio` | Helm release of the MinIO operator chart v7.1.1 in `system-object-store`. Operator image v7.1.1, runAsUser 1000, fsGroup 1000. Adds `use-custom-ca: "true"` label to operator pods so trust-manager distributes the private CA bundle when the addon-private-ca path is enabled. |
+
+The base directory also contains a [`git-repository.yaml`](base/minio/git-repository.yaml)
+referencing the upstream MinIO operator git repo. It is **not included** in
+`base/minio/kustomization.yaml` (which lists only `helm-repository.yaml`
+and `helm-release.yaml`) — the file is a stray and currently has no
+effect. The HelmRepository at `https://operator.min.io` is what actually
+sources the operator chart.
+
+### `object-store/resources/`
+
+The base kustomization is empty (`resources: []`). The single subcomponent
+provides a reference tenant.
+
+| Component | Effect |
+|---|---|
+| `common` | Bundle of: `Tenant/common` HelmRelease (1 pool, 1 server, 1 volume, 1Gi PVC on the `single` StorageClass, mountPath `/export`, subPath `/data`); `Certificate/minio-private` issued by the `private` ClusterIssuer with SANs covering `common-hl.system-object-store.svc.cluster.local` and `minio.system-object-store.svc.cluster.local` (plus wildcards); `Job/generate-minio-root-creds` that randomizes a 12-byte access key and 16-byte secret key on first reconcile and stores them in the `minio-root-creds` Secret; supporting `ServiceAccount`, `Role`, `RoleBinding` for the Job. Ingress is disabled — exposure is the consumer's responsibility. |
+
+## Dependencies
+
+| Stack | Reason |
+|---|---|
+| `csi` | The MinIO operator does not allocate PVCs eagerly, but tenant pools do. The shipped reference tenant requests a 1Gi PVC on StorageClass `single`; without a CSI driver, tenant pods stay `Pending`. |
+| `pki-resources` *(only when wiring `resources/common`)* | The reference tenant's `Certificate` references `ClusterIssuer/private`, which is created by `addon-private-ca`'s `pki-resources` entry. Wiring `object-store/resources` without `addon-private-ca` enabled produces a Certificate stuck `Pending`. |
+
+## Operations
+
+Stack-specific failure modes; generic Flux/Renovate behaviour is documented
+at the repo level.
+
+- **`Tenant` reconciles but pods stay `Pending`** — PVC scheduling. The reference tenant uses StorageClass `single` and 1 volume per server; check `kubectl get pvc -n system-object-store` and the StorageClass's `volumeBindingMode` (it's `WaitForFirstConsumer` on the cloud paths, so the volume only provisions when the Pod schedules).
+- **Tenant pods crashloop with `tls: bad certificate`** — the Certificate isn't ready or the `minio-private-tls` Secret hasn't been created yet. Confirm `kubectl get certificate -n system-object-store minio-private` shows `READY=True`. The Tenant references `minio-private-tls` via `externalCertSecret` — until cert-manager populates it, the operator can't bring up MinIO over HTTPS.
+- **Root credentials missing** — the `generate-minio-root-creds` Job didn't run or hasn't finished. The Job has `ttlSecondsAfterFinished: 86400` (24h) and the manifest is annotated `kustomize.toolkit.fluxcd.io/force: enabled` so Flux re-applies on every reconcile. Check `kubectl get job -n system-object-store` and the Job's logs.
+- **External clients can't reach the tenant** — by design. The reference tenant has `ingress.api.enabled: false` and `ingress.console.enabled: false`. To expose externally, add an HTTPRoute or Ingress and update the Certificate SANs to cover the external hostname.
+- **`HelmRelease/cluster-tenant` reports `no matches for kind Tenant`** — the operator hasn't installed the Tenant CRD. The CRDs ship with the operator chart; reconcile `object-store-base` before `object-store-resources`.
+
+## Security
+
+- The `system-object-store` namespace runs at PSA `baseline`. The namespace is also labeled `use-custom-ca: "true"`, so trust-manager's Bundle (from `addon-private-ca`) distributes the cluster's private CA to it.
+- The operator pod runs `runAsUser: 1000`, `fsGroup: 1000`. The credential-generation Job runs `runAsNonRoot: true`, drops all capabilities, and uses `seccompProfile: RuntimeDefault`.
+- mTLS for the tenant is enforced via `requestAutoCert: false` + `externalCertSecret` referencing the cert-manager-issued `minio-private-tls`. There is no in-tree certificate generation; everything flows through the `pki` stack.
+- Root credentials are generated in-cluster (12-byte hex access key, 16-byte hex secret key) by the bootstrap Job. They're stored in the `minio-root-creds` Secret in `system-object-store`. Tenant workloads needing the root credentials must reference this Secret directly; consider rotating before exposing the tenant.
+- Tenant ingress (API and console) is disabled by default. Exposing the tenant externally is the consumer's responsibility — add an HTTPRoute and update the Certificate SANs.
+
+## See also
+
+- [contexts/_template/facets/addon-object-store.yaml](../../contexts/_template/facets/addon-object-store.yaml) — canonical wiring of the operator. Note that `object-store/resources` is NOT wired by this facet.
+- [base/minio/git-repository.yaml](base/minio/git-repository.yaml) — stray file not included in the kustomization. Unused.
+- Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
+- MinIO operator docs — https://min.io/docs/minio/kubernetes/upstream/
+- Related stacks: [csi](../csi/), [pki](../pki/).

--- a/kustomize/observability/README.md
+++ b/kustomize/observability/README.md
@@ -1,5 +1,5 @@
 ---
-title: Observability stack
+title: Observability add-on
 description: Grafana, fluentd aggregator, and pluggable log storage (stdout, Quickwit, Elasticsearch+Kibana).
 ---
 
@@ -108,7 +108,7 @@ When the cluster has a Gateway, layer in the `grafana/gateway` HTTPRoute and
 
 ### Quickwit logs
 
-Set `addons.observability.logs_driver: quickwit`. Full sink stack with a
+Set `addons.observability.logs_driver: quickwit`. Full sink add-on with a
 PVC-backed staging directory; depends on a CSI driver.
 
 ```yaml
@@ -257,7 +257,7 @@ are added by their respective owner facets.
 `observability` is contributed to by multiple facets, so dependencies vary
 per facet entry. Common patterns:
 
-| Stack | Reason |
+| Add-on | Reason |
 |---|---|
 | `telemetry-base` | Grafana points at the Prometheus instance from telemetry; fluentd inherits CRDs from fluent-operator (also installed by telemetry-base). |
 | `dns` | Conditional. Grafana's HTTPRoute hostname is reconciled via external-dns; without `dns` the record never publishes. |
@@ -267,7 +267,7 @@ per facet entry. Common patterns:
 
 ## Operations
 
-Stack-specific failure modes; generic Flux/Renovate behaviour is documented
+Add-on-specific failure modes; generic Flux/Renovate behaviour is documented
 at the repo level.
 
 - **Grafana panels show "no data" but Prometheus has metrics** — the `grafana/prometheus` datasource isn't configured or points at the wrong service. Check the Grafana ConfigMap with the datasource definition.
@@ -296,4 +296,4 @@ default dashboards.
 - [contexts/_template/facets/option-cni.yaml](../../contexts/_template/facets/option-cni.yaml) — example of a sibling facet patching dashboards into observability.
 - [elasticsearch/README.md](elasticsearch/README.md) — Talos sysctl prerequisite for Elasticsearch.
 - Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
-- Related stacks: [telemetry](../telemetry/), [pki](../pki/), [gateway](../gateway/), [dns](../dns/), [csi](../csi/), [database](../database/).
+- Related add-ons: [telemetry](../telemetry/), [pki](../pki/), [gateway](../gateway/), [dns](../dns/), [csi](../csi/), [database](../database/).

--- a/kustomize/observability/README.md
+++ b/kustomize/observability/README.md
@@ -1,0 +1,299 @@
+---
+title: Observability stack
+description: Grafana, fluentd aggregator, and pluggable log storage (stdout, Quickwit, Elasticsearch+Kibana).
+---
+
+# Observability
+
+Visualization (Grafana) plus the log sink for the telemetry pipeline. The
+`observability` Kustomization is unusual in that it has **no `base/` or
+`resources/` split** — every component lives directly under
+`kustomize/observability/`, and four different facets contribute components
+to the same Kustomization name:
+
+- `platform-base` always emits the fluentd aggregator when `logs_driver == 'fluentd'` (even without `addons.observability.enabled`). Without addon-observability, fluentd runs as a terminal receiver with no output; the pipeline shape stays intact so enabling the addon later doesn't reconfigure telemetry.
+- `addon-observability` (gated on `addons.observability.enabled == true`) adds Grafana, dashboards, the gateway route, and the chosen log-storage backend.
+- `option-cni` adds `grafana/dashboards/cilium` when `dashboards == 'grafana'`.
+- Other facets (`option-storage`, `addon-database`) add their own dashboards the same way.
+
+## Flow
+
+```mermaid
+flowchart LR
+    fb[fluent-bit DaemonSet<br/>_from telemetry stack_]
+
+    subgraph systemobservability[system-observability]
+        fluentd[fluentd aggregator]
+        grafana[Grafana]
+        quickwit[Quickwit]
+        es[Elasticsearch + Kibana]
+    end
+
+    user([Operator])
+    prom[Prometheus<br/>_from telemetry_]
+
+    fb -->|forward 24224| fluentd
+    fluentd -->|stdout| stdout[(container stdout)]
+    fluentd -->|push| quickwit
+    fb -.elasticsearch driver.-> es
+
+    user -->|HTTPRoute via gateway| grafana
+    user -->|HTTPRoute via gateway| es
+    grafana -.queries.-> prom
+    grafana -.queries.-> quickwit
+```
+
+`platform-base` is responsible for fluentd; `addon-observability` is
+responsible for Grafana and the storage backend. Choosing
+`logs_driver: elasticsearch` is special — it replaces `telemetry-base` and
+`telemetry-resources` entirely, swapping fluent-bit for filebeat (which
+ships directly to Elasticsearch and bypasses fluentd).
+
+## Recipes
+
+`addons.observability.enabled` toggles the Grafana / storage path. Even with
+the addon off, fluentd still runs from `platform-base` if
+`telemetry.logs.driver` is `fluentd` (the default).
+
+### Default (addon enabled, no external log store)
+
+Grafana plus fluentd as a terminal receiver. Logs are buffered and dropped;
+useful for trying observability without committing storage.
+
+```yaml
+- name: observability
+  path: observability
+  dependsOn: [telemetry-base, dns]
+  components:
+    - grafana
+    - grafana/prometheus
+    - grafana/dashboards/node
+    - grafana/dashboards/kubernetes
+    - grafana/dashboards/flux
+    - grafana/dashboards/cert-manager
+    - grafana/dashboards/fluent-bit
+    - grafana/dashboards/fluentd
+    - fluentd
+    - fluentd/filters/otel
+    - fluentd/prometheus
+    - fluentd/filters/log-level/info
+  substitutions:
+    external_domain: example.internal
+    timezone: UTC
+    date_full: "YYYY-MM-DD HH:mm:ss"
+```
+
+### With Gateway HTTPRoute
+
+When the cluster has a Gateway, layer in the `grafana/gateway` HTTPRoute and
+(on Envoy) the envoy dashboards.
+
+```yaml
+- name: observability
+  path: observability
+  dependsOn: [telemetry-base, dns, gateway-resources]
+  components:
+    - grafana
+    - grafana/prometheus
+    - grafana/gateway
+    - grafana/dashboards/envoy
+    # ... plus the dashboards from the previous recipe
+    - fluentd
+    - fluentd/filters/otel
+    - fluentd/prometheus
+    - fluentd/filters/log-level/info
+  substitutions:
+    external_domain: example.internal
+```
+
+### Quickwit logs
+
+Set `addons.observability.logs_driver: quickwit`. Full sink stack with a
+PVC-backed staging directory; depends on a CSI driver.
+
+```yaml
+- name: observability
+  path: observability
+  dependsOn: [telemetry-base, dns, csi, telemetry-resources]
+  components:
+    - grafana
+    - grafana/prometheus
+    - grafana/quickwit
+    - grafana/dashboards/logs/quickwit
+    - fluentd
+    - fluentd/outputs/quickwit
+    - fluentd/filters/otel
+    - fluentd/prometheus
+    - quickwit
+    - quickwit/pvc
+    - quickwit/prometheus
+```
+
+### Elasticsearch + Kibana
+
+`addons.observability.logs_driver: elasticsearch`. This recipe **replaces**
+`telemetry-base` and `telemetry-resources` (filebeat → Elasticsearch directly,
+no fluent-bit, no fluentd). Requires a Gateway for Kibana's HTTPRoute.
+
+```yaml
+- name: telemetry-base
+  path: telemetry/base
+  strategy: replace
+  components:
+    - prometheus
+    - prometheus/flux
+    - filebeat
+
+- name: telemetry-resources
+  path: telemetry/resources
+  strategy: replace
+  dependsOn: [telemetry-base]
+  components:
+    - metrics-server
+    - prometheus
+    - prometheus/flux
+
+- name: observability
+  path: observability
+  dependsOn: [telemetry-base, dns, csi, gateway-resources]
+  components:
+    - grafana
+    - grafana/prometheus
+    - elasticsearch
+    - kibana
+    - kibana/gateway
+  substitutions:
+    external_domain: example.com
+```
+
+Talos clusters running Elasticsearch must apply
+`vm.max_map_count: 262144` in machine config; see
+[elasticsearch/README.md](elasticsearch/README.md).
+
+## Substitutions
+
+| Name | Required when | Effect |
+|---|---|---|
+| `external_domain` | always | Hostname (and wildcard) on the Grafana / Kibana HTTPRoutes. Resolved from `dns.public_domain` if set, otherwise `dns.private_domain`. |
+| `timezone` | always | Grafana default timezone (`grafana.ini` → `default.timezone`). Stamped from the context-level `timezone` value; falls back to `utc`. |
+| `date_full`, `date_interval_*` | always (with fallbacks) | Grafana date format strings, switched between 12h and 24h based on the context-level `time_format`. Each has a kustomize fallback so dropping the substitution doesn't break panels. |
+| `admin_password` | optional | Grafana admin password. Falls back to `grafana` (the `option-dev` default). Production should set this via secret-mgr. |
+
+## Components
+
+The component tree is large. Components group by subsystem:
+
+### `grafana/`
+
+| Component | Effect |
+|---|---|
+| `grafana` | Helm release of Grafana v10.5.15 in `system-observability`. Image v13.0.1. Sidecars import dashboards from labeled ConfigMaps. |
+| `grafana/dev` | Patches the helm release to set `adminPassword: ${admin_password:-grafana}` for dev clusters. |
+| `grafana/prometheus` | Configures the Prometheus datasource pointing at the kube-prometheus-stack instance in `system-telemetry`. |
+| `grafana/quickwit` | Configures the Quickwit datasource (only when logs_driver=quickwit). |
+| `grafana/gateway` | HTTPRoute on the cluster's Gateway exposing Grafana at `grafana.${external_domain}`. |
+| `grafana/ingress` | Plain Kubernetes Ingress (alternative to gateway when no Gateway API controller is installed). |
+| `grafana/cert-manager` | Datasource / config for the cert-manager dashboard. |
+| `grafana/cloudnativepg` | Datasource for the CloudNativePG dashboard. |
+| `grafana/flux` | Datasource for the Flux dashboard. |
+| `grafana/kubernetes` | Datasource for the Kubernetes overview dashboards. |
+| `grafana/nginx` | Datasource for the nginx-ingress dashboard. |
+| `grafana/node` | Datasource for the node-exporter dashboard. |
+
+### `grafana/dashboards/`
+
+Each subdirectory is a ConfigMap dashboard (Grafana's sidecar imports them by
+label). Always-on dashboards are wired from `addon-observability`; the rest
+are added by their respective owner facets.
+
+| Component | Wired by | Effect |
+|---|---|---|
+| `grafana/dashboards/node` | addon-observability | Standard node-exporter dashboard. |
+| `grafana/dashboards/kubernetes` | addon-observability | Multi-cluster Kubernetes overview. |
+| `grafana/dashboards/flux` | addon-observability | Flux controllers and reconciliation status. |
+| `grafana/dashboards/cert-manager` | addon-observability | cert-manager controller / certificate health. |
+| `grafana/dashboards/fluent-bit` | addon-observability | fluent-bit metrics. |
+| `grafana/dashboards/fluentd` | addon-observability | fluentd aggregator metrics. |
+| `grafana/dashboards/envoy` | addon-observability (Envoy gateway only) | Envoy data-plane metrics. |
+| `grafana/dashboards/cilium` | option-cni (when dashboards=grafana) | Cilium agent and operator metrics. |
+| `grafana/dashboards/cloudnativepg` | addon-database | CloudNativePG cluster health. |
+| `grafana/dashboards/longhorn` | option-storage | Longhorn volumes / replicas. |
+| `grafana/dashboards/logs/quickwit` | addon-observability (logs_driver=quickwit) | Logs panel populated from the Quickwit datasource. |
+| `grafana/dashboards/nginx` | *(unwired)* | nginx ingress metrics. Available for manual blueprint wiring; not in any shipped facet. |
+| `grafana/dashboards/prometheus` | *(unwired)* | Prometheus self-monitoring. Available for manual blueprint wiring; not in any shipped facet. |
+| `grafana/dashboards/quickwit` | *(unwired)* | Quickwit operator metrics. Exists on disk but not in any shipped facet — `addon-observability` pulls in `grafana/dashboards/logs/quickwit` (the logs panel) but not this one. |
+| `grafana/dashboards/logs` | *(unwired)* | Logs panel framework. Exists on disk but not referenced by any facet. |
+
+### `fluentd/`
+
+| Component | Wired by | Effect |
+|---|---|---|
+| `fluentd` | platform-base (when logs_driver=fluentd) | `Fluentd` CR (replicas: 1) in `system-observability` listening on TCP 24224 for forward protocol. ClusterFluentdConfig selects all configs labeled `config.fluentd.fluent.io/enabled: "true"`. |
+| `fluentd/prometheus` | platform-base (when metrics enabled) | ServiceMonitor for fluentd's own metrics. |
+| `fluentd/filters/otel` | platform-base | OpenTelemetry filter normalizing fields. |
+| `fluentd/filters/log-level/{debug,info,warn,error}` | platform-base (one chosen by `log_level`) | Drops records below the configured severity. `log_level: 'trace'` skips this component entirely (passes everything). |
+| `fluentd/outputs/stdout` | addon-observability (logs_driver=stdout) | ClusterOutput writing to fluentd's container stdout. |
+| `fluentd/outputs/quickwit` | addon-observability (logs_driver=quickwit) | ClusterOutput pushing to Quickwit's ingest API. |
+
+### `quickwit/`
+
+| Component | Wired by | Effect |
+|---|---|---|
+| `quickwit` | addon-observability (logs_driver=quickwit) | Helm release of Quickwit. |
+| `quickwit/pvc` | addon-observability (logs_driver=quickwit) | PVC for Quickwit's staging / index data. Requires a `csi` driver. |
+| `quickwit/prometheus` | addon-observability (logs_driver=quickwit) | ServiceMonitor for Quickwit. |
+
+### `elasticsearch/` and `kibana/`
+
+| Component | Wired by | Effect |
+|---|---|---|
+| `elasticsearch` | addon-observability (logs_driver=elasticsearch) | Helm release of Elasticsearch. Talos requires `vm.max_map_count: 262144` in machine sysctls — see [elasticsearch/README.md](elasticsearch/README.md). |
+| `kibana` | addon-observability (logs_driver=elasticsearch) | Helm release of Kibana. |
+| `kibana/gateway` | addon-observability (logs_driver=elasticsearch) | HTTPRoute exposing Kibana via the cluster Gateway. Required because Kibana has no other path out. |
+| `kibana/ingress` | (consumer-wired) | Plain Ingress alternative to the Gateway route. |
+
+## Dependencies
+
+`observability` is contributed to by multiple facets, so dependencies vary
+per facet entry. Common patterns:
+
+| Stack | Reason |
+|---|---|
+| `telemetry-base` | Grafana points at the Prometheus instance from telemetry; fluentd inherits CRDs from fluent-operator (also installed by telemetry-base). |
+| `dns` | Conditional. Grafana's HTTPRoute hostname is reconciled via external-dns; without `dns` the record never publishes. |
+| `gateway-resources` | When wiring `grafana/gateway` or `kibana/gateway`. The Gateway must exist before the HTTPRoute is applied. |
+| `csi` | When wiring `quickwit/pvc` or `elasticsearch` — both need persistent volumes. |
+| `telemetry-resources` | When `logs_driver` is stdout or quickwit — fluentd outputs reference fluent-bit's ClusterFluentdConfig from telemetry-resources. |
+
+## Operations
+
+Stack-specific failure modes; generic Flux/Renovate behaviour is documented
+at the repo level.
+
+- **Grafana panels show "no data" but Prometheus has metrics** — the `grafana/prometheus` datasource isn't configured or points at the wrong service. Check the Grafana ConfigMap with the datasource definition.
+- **Logs reach fluentd but disappear** — no ClusterOutput is configured. When `addons.observability.enabled` is false but `logs_driver: fluentd`, fluentd runs as a terminal receiver and buffers. Set `addons.observability.logs_driver` to `stdout` (cheapest) to emit somewhere.
+- **`quickwit/pvc` stuck `Pending`** — CSI driver isn't ready. Check `csi` Kustomization status and the StorageClass referenced by the PVC.
+- **Elasticsearch pods crash on Talos with `max virtual memory areas vm.max_map_count too low`** — required Talos sysctl missing. Apply `vm.max_map_count: 262144` in the machine config; see [elasticsearch/README.md](elasticsearch/README.md). This is a Talos-only requirement.
+- **Switching between log drivers leaves stale ClusterOutputs** — fluentd's selectors are label-based, so an unmatched ClusterOutput is harmless. To clean up, delete the resource by hand (Flux removes it on the next reconcile after the component is dropped).
+- **Kibana HTTPRoute returns 404** — `kibana/gateway` was applied before `gateway-resources` finished. Reconcile order should prevent this; if it fires, re-reconcile `observability`.
+
+Grafana exposes its own metrics at `/metrics` on the same port as the UI;
+node-exporter, kube-state-metrics, and Prometheus itself feed into the
+default dashboards.
+
+## Security
+
+- `system-observability` runs at PSA `baseline` and is labeled `use-custom-ca: "true"`. The label opts the namespace into the trust-manager Bundle from `addon-private-ca` so Grafana / Kibana / Elasticsearch trust the private CA when issued certs from it.
+- Grafana admin credentials default to `admin/grafana` via `grafana/dev`. Production blueprints should override `admin_password` from a secret store (the helm release values use `${admin_password:-grafana}` so the substitution wins when set).
+- Kibana exposes Elasticsearch query / config UI; the HTTPRoute relies on the Gateway TLS cert from `pki` for transport security but does not enforce auth. If exposing publicly, layer authentication in front.
+- fluentd's forward port (24224) is namespace-scoped; only fluent-bit pods (in `system-telemetry`) reach it via the cluster network. No external listener.
+- Quickwit's ingest API is internal only by default — if exposing to other clusters, add an HTTPRoute and authentication.
+
+## See also
+
+- [contexts/_template/facets/addon-observability.yaml](../../contexts/_template/facets/addon-observability.yaml) — Grafana, dashboards, log-driver branching, and the Elasticsearch telemetry replacement.
+- [contexts/_template/facets/platform-base.yaml](../../contexts/_template/facets/platform-base.yaml) (lines ~462-473) — fluentd aggregator wiring, runs even without the addon when logs_driver=fluentd.
+- [contexts/_template/facets/option-cni.yaml](../../contexts/_template/facets/option-cni.yaml) — example of a sibling facet patching dashboards into observability.
+- [elasticsearch/README.md](elasticsearch/README.md) — Talos sysctl prerequisite for Elasticsearch.
+- Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
+- Related stacks: [telemetry](../telemetry/), [pki](../pki/), [gateway](../gateway/), [dns](../dns/), [csi](../csi/), [database](../database/).

--- a/kustomize/observability/README.md
+++ b/kustomize/observability/README.md
@@ -229,7 +229,7 @@ are added by their respective owner facets.
 | Component | Wired by | Effect |
 |---|---|---|
 | `fluentd` | platform-base (when logs_driver=fluentd) | `Fluentd` CR (replicas: 1) in `system-observability` listening on TCP 24224 for forward protocol. ClusterFluentdConfig selects all configs labeled `config.fluentd.fluent.io/enabled: "true"`. |
-| `fluentd/prometheus` | platform-base (when metrics enabled) | ServiceMonitor for fluentd's own metrics. |
+| `fluentd/prometheus` | platform-base (when `telemetry.metrics.enabled: true`) | ServiceMonitor for fluentd's own metrics. |
 | `fluentd/filters/otel` | platform-base | OpenTelemetry filter normalizing fields. |
 | `fluentd/filters/log-level/{debug,info,warn,error}` | platform-base (one chosen by `log_level`) | Drops records below the configured severity. `log_level: 'trace'` skips this component entirely (passes everything). |
 | `fluentd/outputs/stdout` | addon-observability (logs_driver=stdout) | ClusterOutput writing to fluentd's container stdout. |

--- a/kustomize/pki/README.md
+++ b/kustomize/pki/README.md
@@ -181,8 +181,8 @@ rather than replacing them.
 | Component | Enable when | Effect |
 |---|---|---|
 | `cert-manager` | always (default platform path) | Helm release of cert-manager in `system-pki`. CRDs enabled. |
-| `cert-manager/single-node` | single-node clusters | Disables leader election on the controller and cainjector. |
-| `cert-manager/prometheus` | telemetry metrics enabled | Enables the chart's ServiceMonitor with the `kube-prometheus-stack` release label, and adds a Flux `dependsOn` so cert-manager waits for kube-prometheus-stack to be ready. |
+| `cert-manager/single-node` | `cluster.topology: single-node` | Disables leader election on the controller and cainjector. |
+| `cert-manager/prometheus` | `telemetry.metrics.enabled: true` | Enables the chart's ServiceMonitor with the `kube-prometheus-stack` release label, and adds a Flux `dependsOn` so cert-manager waits for kube-prometheus-stack to be ready. |
 | `cert-manager/azure-workload-identity` | platform is Azure with a public domain | Adds Azure workload-identity labels and annotations to the cert-manager ServiceAccount and pods. |
 | `trust-manager` | `addons.private_ca.enabled == true` | Helm release of trust-manager in `system-pki-trust`. Flux waits for cert-manager. |
 | `trust-manager/single-node` | single-node + private-ca | Disables leader election on trust-manager. |
@@ -214,7 +214,7 @@ mutating one shared `public` issuer in place would not.
 | Stack | Reason |
 |---|---|
 | `policy-resources` *(when policies enabled)* | `private-issuer/ca` ships a Kyverno ClusterPolicy that mounts the CA bundle into opted-in pods. Flux fails the apply on `no matches for kind ClusterPolicy` if Kyverno's CRDs aren't installed. |
-| `telemetry-base` *(when telemetry metrics or logs enabled)* | `cert-manager/prometheus` enables a ServiceMonitor with `release: kube-prometheus-stack`; without telemetry-base the ServiceMonitor has no Prometheus to register against. |
+| `telemetry-base` *(when `telemetry.metrics.enabled: true` or `telemetry.logs.enabled: true`)* | `cert-manager/prometheus` enables a ServiceMonitor with `release: kube-prometheus-stack`; without telemetry-base the ServiceMonitor has no Prometheus to register against. |
 
 `pki-resources` always depends on `pki-base` (the operators must be running before any ClusterIssuer is created).
 

--- a/kustomize/pki/README.md
+++ b/kustomize/pki/README.md
@@ -1,0 +1,252 @@
+---
+title: PKI stack
+description: cert-manager and trust-manager operators with private and public ClusterIssuers.
+---
+
+# PKI
+
+cert-manager issues TLS certificates from one or more ClusterIssuers. trust-manager
+distributes the private CA bundle to opted-in namespaces. The stack is split into
+two kustomizations so the operators (`pki/base`) bootstrap before any issuer
+(`pki/resources`) tries to create CRD instances.
+
+## Flow
+
+```mermaid
+flowchart LR
+    cert[Certificate resource]
+    workload[Gateway / Workload]
+
+    subgraph systempki[system-pki / system-pki-trust]
+        cm[cert-manager]
+        issuers{ClusterIssuer<br/>private<br/>public-selfsigned<br/>public-acme}
+        secret[(TLS Secret)]
+        ca[(private-ca-cert)]
+        tm[trust-manager Bundle]
+    end
+
+    dns01[Route 53 / Azure DNS]
+    cmap[ConfigMap private-ca<br/>in labeled namespaces]
+
+    cert --> cm --> issuers --> secret
+    secret -.->|mounted by| workload
+    issuers -.DNS-01.-> dns01
+    issuers -.signs with.-> ca
+    ca --> tm --> cmap
+```
+
+cert-manager runs in `system-pki` (PSA baseline). trust-manager runs in
+`system-pki-trust` (PSA restricted). The DNS-01 path is only exercised by the
+`public-acme` issuer; the CA distribution path is only exercised when the
+private-ca addon is enabled.
+
+## Recipes
+
+`pki-base` is always rendered (cert-manager is required by every other stack
+that issues certs). `pki-resources` is rendered conditionally — platform and
+context-level facets contribute one issuer per cluster, and `addon-private-ca`
+adds another. Multiple facets can contribute components to the same `pki-base`
+and `pki-resources` entries; the materialized component list is the union.
+
+The recipes below show that materialized union for common combinations.
+
+### Single-node local dev (no private-CA addon)
+
+Set `addons.private_ca.enabled: false` if you don't want the trust-manager
+distribution path. Otherwise see the addon-private-ca recipe at the bottom.
+
+```yaml
+- name: pki-base
+  path: pki/base
+  components:
+    - cert-manager
+    - cert-manager/single-node
+
+- name: pki-resources
+  path: pki/resources
+  dependsOn: [pki-base]
+  components:
+    - public-issuer/selfsigned
+```
+
+### AWS without a public domain
+
+Bootstrap mode. The gateway gets a self-signed cert from `public-selfsigned`;
+browsers warn but the cluster is reachable. Setting `dns.public_domain` later
+flips the issuer to `public-acme` and cert-manager re-issues automatically.
+
+```yaml
+- name: pki-base
+  path: pki/base
+  dependsOn: [policy-resources, telemetry-base]
+  components:
+    - cert-manager
+    - cert-manager/prometheus
+  timeout: 20m
+
+- name: pki-resources
+  path: pki/resources
+  dependsOn: [pki-base, policy-resources]
+  components:
+    - public-issuer/selfsigned
+```
+
+### AWS with a public domain
+
+Let's Encrypt via Route 53 DNS-01. The cluster module provisions IAM (Pod
+Identity, Route 53 zone permissions) so cert-manager can write TXT records.
+
+```yaml
+- name: pki-resources
+  path: pki/resources
+  dependsOn: [pki-base, policy-resources]
+  components:
+    - public-issuer/acme/route53
+  substitutions:
+    acme_server: https://acme-v02.api.letsencrypt.org/directory
+    acme_email: ops@example.com
+    acme_dns_zone: example.com
+    acme_region: us-east-1
+    acme_hosted_zone_id: Z1234567890ABC
+```
+
+### Azure with a public domain
+
+Same as AWS but the cert-manager pod uses Azure workload identity (added by
+the `cert-manager/azure-workload-identity` component) and DNS-01 runs against
+Azure DNS.
+
+```yaml
+- name: pki-base
+  path: pki/base
+  components:
+    - cert-manager
+    - cert-manager/prometheus
+    - cert-manager/azure-workload-identity
+  substitutions:
+    cert_manager_client_id: <UAMI client id>
+    cert_manager_tenant_id: <tenant id>
+
+- name: pki-resources
+  path: pki/resources
+  dependsOn: [pki-base, policy-resources]
+  components:
+    - public-issuer/acme/azuredns
+  substitutions:
+    acme_server: https://acme-v02.api.letsencrypt.org/directory
+    acme_email: ops@example.com
+    acme_dns_zone: example.com
+    acme_dns_zone_resource_group: dns-rg
+    acme_dns_zone_subscription_id: <sub id>
+    cert_manager_client_id: <UAMI client id>
+```
+
+### addon-private-ca on top of any of the above
+
+Adds trust-manager and a CA-backed `private` ClusterIssuer. Layers on top of
+the platform's existing `pki-base` and `pki-resources`, adding components
+rather than replacing them.
+
+```yaml
+- name: pki-base
+  path: pki/base
+  components:
+    - trust-manager
+
+- name: pki-resources
+  path: pki/resources
+  dependsOn: [pki-base, policy-resources]
+  components:
+    - private-issuer/ca
+```
+
+## Substitutions
+
+| Name | Required when | Effect |
+|---|---|---|
+| `cert_manager_client_id` | `cert-manager/azure-workload-identity` is enabled | UAMI client ID stamped onto the cert-manager ServiceAccount and the ACME issuer's `managedIdentity.clientID`. |
+| `cert_manager_tenant_id` | `cert-manager/azure-workload-identity` is enabled | Azure tenant ID stamped onto the cert-manager ServiceAccount. |
+| `acme_server` | `public-issuer/acme/*` is enabled | ACME directory URL. Use staging in dev to avoid Let's Encrypt rate limits. |
+| `acme_email` | `public-issuer/acme/*` is enabled | Account email Let's Encrypt registers against; required by the ACME protocol. |
+| `acme_dns_zone` | `public-issuer/acme/*` is enabled | DNS zone the DNS-01 solver writes TXT records into. |
+| `acme_region` | `public-issuer/acme/route53` is enabled | AWS region for the Route 53 API call. |
+| `acme_hosted_zone_id` | `public-issuer/acme/route53` is enabled | Route 53 hosted zone ID; locks the solver to one zone. |
+| `acme_dns_zone_resource_group` | `public-issuer/acme/azuredns` is enabled | Azure resource group containing the DNS zone. |
+| `acme_dns_zone_subscription_id` | `public-issuer/acme/azuredns` is enabled | Azure subscription ID containing the DNS zone. |
+
+## Components
+
+### `pki/base/`
+
+| Component | Enable when | Effect |
+|---|---|---|
+| `cert-manager` | always (default platform path) | Helm release of cert-manager in `system-pki`. CRDs enabled. |
+| `cert-manager/single-node` | single-node clusters | Disables leader election on the controller and cainjector. |
+| `cert-manager/prometheus` | telemetry metrics enabled | Enables the chart's ServiceMonitor with the `kube-prometheus-stack` release label, and adds a Flux `dependsOn` so cert-manager waits for kube-prometheus-stack to be ready. |
+| `cert-manager/azure-workload-identity` | platform is Azure with a public domain | Adds Azure workload-identity labels and annotations to the cert-manager ServiceAccount and pods. |
+| `trust-manager` | `addons.private_ca.enabled == true` | Helm release of trust-manager in `system-pki-trust`. Flux waits for cert-manager. |
+| `trust-manager/single-node` | single-node + private-ca | Disables leader election on trust-manager. |
+
+### `pki/resources/`
+
+Each component creates exactly one ClusterIssuer (and supporting resources for
+the CA path). Components are mutually exclusive within their family — pick
+one private-issuer/* if any, and one public-issuer/* if any.
+
+| Component | ClusterIssuer name | Effect |
+|---|---|---|
+| `private-issuer/selfsigned` | `private` (selfSigned) | Bare self-signed issuer; useful for private-mode gateways without the full CA distribution. |
+| `private-issuer/ca` | `private` (CA) | Self-signed root + intermediate Certificate, trust-manager Bundle distributing the CA to namespaces labeled `use-custom-ca=true`, and a Kyverno ClusterPolicy that mounts the bundle into pods labeled `use-custom-ca=true`. |
+| `public-issuer/selfsigned` | `public-selfsigned` (selfSigned) | Self-signed public issuer; used as the initial bootstrap before a real public domain is configured. |
+| `public-issuer/acme/route53` | `public-acme` (ACME, DNS-01 via Route 53) | Let's Encrypt issuer that solves DNS-01 against a Route 53 hosted zone. |
+| `public-issuer/acme/azuredns` | `public-acme` (ACME, DNS-01 via Azure DNS) | Let's Encrypt issuer that solves DNS-01 against an Azure DNS zone. |
+
+`private-issuer/selfsigned` and `private-issuer/ca` both create a ClusterIssuer
+named `private` and conflict if both are enabled — pick one. The two
+`public-issuer/*` variants emit distinct names (`public-selfsigned` and
+`public-acme`) and can coexist, though typically only one is wired. The
+distinct public names are deliberate: swapping between them shows up to
+cert-manager as a Certificate spec change and triggers reissuance, where
+mutating one shared `public` issuer in place would not.
+
+## Dependencies
+
+| Stack | Reason |
+|---|---|
+| `policy-resources` *(when policies enabled)* | `private-issuer/ca` ships a Kyverno ClusterPolicy that mounts the CA bundle into opted-in pods. Flux fails the apply on `no matches for kind ClusterPolicy` if Kyverno's CRDs aren't installed. |
+| `telemetry-base` *(when telemetry metrics or logs enabled)* | `cert-manager/prometheus` enables a ServiceMonitor with `release: kube-prometheus-stack`; without telemetry-base the ServiceMonitor has no Prometheus to register against. |
+
+`pki-resources` always depends on `pki-base` (the operators must be running before any ClusterIssuer is created).
+
+## Operations
+
+Stack-specific failure modes; generic Flux/Renovate behaviour is documented
+at the repo level.
+
+- **`Certificate` stuck in `Issuing` for the ACME issuer** — DNS-01 challenge isn't solving. For Route 53 confirm Pod Identity is bound to the cert-manager ServiceAccount and the IAM policy covers the hosted zone. For Azure DNS confirm the UAMI client ID matches `cert_manager_client_id` and the role assignment on the resource group is in place.
+- **`HelmRelease/trust-manager` reports `no matches for kind Bundle`** — trust-manager hasn't installed or its CRDs aren't ready yet. Check the cert-manager Flux `dependsOn` chain (trust-manager waits for cert-manager).
+- **`HelmRelease/pki-resources` reports `no matches for kind ClusterPolicy`** — `private-issuer/ca` is enabled but `policy-resources` (Kyverno) hasn't installed. The hard `dependsOn` in `addon-private-ca` should prevent this; if it fires, confirm policies are not disabled.
+- **Switching from `public-selfsigned` to `public-acme` doesn't reissue** — cert-manager only reissues on Certificate spec changes. The Gateway cert references `gateway_cert_issuer`, which option-gateway switches based on `dns.public_domain`. If the substitution isn't flowing through, the spec doesn't change and the cert stays on the old issuer.
+
+cert-manager exposes Prometheus metrics when `cert-manager/prometheus` is
+enabled; a ServiceMonitor with `release: kube-prometheus-stack` registers it
+with the telemetry stack.
+
+## Security
+
+- cert-manager runs in `system-pki` with PSA `baseline`. trust-manager runs in `system-pki-trust` with PSA `restricted`.
+- The `private-ca` Certificate is self-signed (root) with `isCA: true`, 1-year duration and 30-day renewBefore. The signing key lives in the `private-ca-cert` Secret in `system-pki`.
+- The trust-manager Bundle distributes the CA only to namespaces labeled `use-custom-ca=true`. Workloads in unlabeled namespaces never see the bundle.
+- The `inject-private-ca` Kyverno ClusterPolicy only matches Pods labeled `use-custom-ca=true` and operates as a `mutate` rule — it does not block other workloads.
+- ACME identity:
+  - Route 53: Pod Identity association created by the cluster module, scoped to the hosted zone via `acme_hosted_zone_id`.
+  - Azure DNS: workload identity (UAMI), scoped to the resource group via `acme_dns_zone_resource_group`.
+
+## See also
+
+- [contexts/_template/facets/platform-base.yaml](../../contexts/_template/facets/platform-base.yaml) — base wiring of `pki-base`.
+- [contexts/_template/facets/addon-private-ca.yaml](../../contexts/_template/facets/addon-private-ca.yaml) — private-CA addon (trust-manager + private-issuer/ca).
+- [contexts/_template/facets/platform-aws.yaml](../../contexts/_template/facets/platform-aws.yaml) — AWS public-issuer wiring.
+- [contexts/_template/facets/platform-azure.yaml](../../contexts/_template/facets/platform-azure.yaml) — Azure public-issuer wiring.
+- Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
+- Related stacks: [policy](../policy/), [telemetry](../telemetry/), [gateway](../gateway/), [dns](../dns/).

--- a/kustomize/pki/README.md
+++ b/kustomize/pki/README.md
@@ -181,7 +181,7 @@ rather than replacing them.
 | Component | Enable when | Effect |
 |---|---|---|
 | `cert-manager` | always (default platform path) | Helm release of cert-manager in `system-pki`. CRDs enabled. |
-| `cert-manager/single-node` | `cluster.topology: single-node` | Disables leader election on the controller and cainjector. |
+| `cert-manager/single-node` | `topology: single-node` | Disables leader election on the controller and cainjector. |
 | `cert-manager/prometheus` | `telemetry.metrics.enabled: true` | Enables the chart's ServiceMonitor with the `kube-prometheus-stack` release label, and adds a Flux `dependsOn` so cert-manager waits for kube-prometheus-stack to be ready. |
 | `cert-manager/azure-workload-identity` | platform is Azure with a public domain | Adds Azure workload-identity labels and annotations to the cert-manager ServiceAccount and pods. |
 | `trust-manager` | `addons.private_ca.enabled == true` | Helm release of trust-manager in `system-pki-trust`. Flux waits for cert-manager. |

--- a/kustomize/pki/README.md
+++ b/kustomize/pki/README.md
@@ -1,12 +1,12 @@
 ---
-title: PKI stack
+title: PKI add-on
 description: cert-manager and trust-manager operators with private and public ClusterIssuers.
 ---
 
 # PKI
 
 cert-manager issues TLS certificates from one or more ClusterIssuers. trust-manager
-distributes the private CA bundle to opted-in namespaces. The stack is split into
+distributes the private CA bundle to opted-in namespaces. The add-on is split into
 two kustomizations so the operators (`pki/base`) bootstrap before any issuer
 (`pki/resources`) tries to create CRD instances.
 
@@ -42,7 +42,7 @@ private-ca addon is enabled.
 
 ## Recipes
 
-`pki-base` is always rendered (cert-manager is required by every other stack
+`pki-base` is always rendered (cert-manager is required by every other add-on
 that issues certs). `pki-resources` is rendered conditionally — platform and
 context-level facets contribute one issuer per cluster, and `addon-private-ca`
 adds another. Multiple facets can contribute components to the same `pki-base`
@@ -211,7 +211,7 @@ mutating one shared `public` issuer in place would not.
 
 ## Dependencies
 
-| Stack | Reason |
+| Add-on | Reason |
 |---|---|
 | `policy-resources` *(when policies enabled)* | `private-issuer/ca` ships a Kyverno ClusterPolicy that mounts the CA bundle into opted-in pods. Flux fails the apply on `no matches for kind ClusterPolicy` if Kyverno's CRDs aren't installed. |
 | `telemetry-base` *(when `telemetry.metrics.enabled: true` or `telemetry.logs.enabled: true`)* | `cert-manager/prometheus` enables a ServiceMonitor with `release: kube-prometheus-stack`; without telemetry-base the ServiceMonitor has no Prometheus to register against. |
@@ -220,7 +220,7 @@ mutating one shared `public` issuer in place would not.
 
 ## Operations
 
-Stack-specific failure modes; generic Flux/Renovate behaviour is documented
+Add-on-specific failure modes; generic Flux/Renovate behaviour is documented
 at the repo level.
 
 - **`Certificate` stuck in `Issuing` for the ACME issuer** — DNS-01 challenge isn't solving. For Route 53 confirm Pod Identity is bound to the cert-manager ServiceAccount and the IAM policy covers the hosted zone. For Azure DNS confirm the UAMI client ID matches `cert_manager_client_id` and the role assignment on the resource group is in place.
@@ -230,7 +230,7 @@ at the repo level.
 
 cert-manager exposes Prometheus metrics when `cert-manager/prometheus` is
 enabled; a ServiceMonitor with `release: kube-prometheus-stack` registers it
-with the telemetry stack.
+with the telemetry add-on.
 
 ## Security
 
@@ -249,4 +249,4 @@ with the telemetry stack.
 - [contexts/_template/facets/platform-aws.yaml](../../contexts/_template/facets/platform-aws.yaml) — AWS public-issuer wiring.
 - [contexts/_template/facets/platform-azure.yaml](../../contexts/_template/facets/platform-azure.yaml) — Azure public-issuer wiring.
 - Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
-- Related stacks: [policy](../policy/), [telemetry](../telemetry/), [gateway](../gateway/), [dns](../dns/).
+- Related add-ons: [policy](../policy/), [telemetry](../telemetry/), [gateway](../gateway/), [dns](../dns/).

--- a/kustomize/policy/README.md
+++ b/kustomize/policy/README.md
@@ -1,0 +1,181 @@
+---
+title: Policy stack
+description: Kyverno admission policies for image digest enforcement, resource limits, and the controllers that back them.
+---
+
+# Policy
+
+Kyverno is the cluster's admission policy engine. The `policy-base`
+Kustomization installs the Kyverno controllers; `policy-resources` applies
+the ClusterPolicy resources that enforce or audit cluster-wide rules.
+
+This stack is depended on by nearly every other stack — the namespace runs
+at PSA `baseline` and the cluster's mutation policies (private-CA injection,
+LBIPAM IP sharing on Cilium gateways, docker-desktop DNS rewriting) all
+require Kyverno's CRDs to apply.
+
+## Flow
+
+```mermaid
+flowchart LR
+    request[Pod / Service create or update]
+    api[K8s API server]
+    crds[(ClusterPolicy / Policy<br/>resources)]
+    reportcrds[(PolicyReport)]
+    cleanupcrd[(CleanupPolicy)]
+
+    subgraph systempolicy[system-policy]
+        admission[admission-controller]
+        bg[background-controller]
+        reports[reports-controller<br/>optional]
+        cleanup[cleanup-controller<br/>optional]
+    end
+
+    request --> api
+    api -.AdmissionReview.-> admission
+    admission -->|reads| crds
+    admission -->|allow / deny / mutate| api
+    bg -.periodic re-eval.-> crds
+    reports -.writes.-> reportcrds
+    cleanup -.cron.-> cleanupcrd
+```
+
+The `admission-controller` and `background-controller` always run when
+`policy-base` is installed. The `reports-controller` and `cleanup-controller`
+are off by default — they ship with the chart but are toggled on by
+`kyverno/reports` and `kyverno/cleanup` components when the operator opts in.
+
+## Recipes
+
+`policy-base` and `policy-resources` are gated on `policies.enabled` (default
+`true`). Setting `policies.enabled: false` skips both Kustomizations entirely;
+this is the opt-out for clusters that don't want admission control. It will
+break stacks that depend on `policy-resources` to install ClusterPolicies, so
+review consumers before disabling.
+
+### Default (admission + background only)
+
+Most clusters land here. `require-image-digest` enforces SHA256 digests on
+all pods in `system-*` namespaces; `resource-limits-requests` audits.
+
+```yaml
+- name: policy-base
+  path: policy/base
+  components:
+    - kyverno
+  timeout: 30m
+  interval: 5m
+
+- name: policy-resources
+  path: policy/resources
+  dependsOn: [policy-base]
+  components:
+    - kyverno/resource-limits-requests
+    - kyverno/require-image-digest
+  timeout: 5m
+  interval: 5m
+  retryInterval: 1m
+```
+
+### With reports and cleanup controllers
+
+Layer in the optional controllers when the operator wants
+PolicyReport / ClusterPolicyReport visibility (`policies.reporting: enabled`)
+or CleanupPolicy / ClusterCleanupPolicy CRD execution
+(`policies.cleanup: enabled`).
+
+```yaml
+- name: policy-base
+  path: policy/base
+  components:
+    - kyverno
+    - kyverno/reports
+    - kyverno/cleanup
+
+- name: policy-resources
+  path: policy/resources
+  dependsOn: [policy-base]
+  components:
+    - kyverno/resource-limits-requests
+    - kyverno/require-image-digest
+```
+
+### Disabling individual policies
+
+Keep Kyverno installed but skip a specific ClusterPolicy by setting
+`policies.resource_limits_requests: disabled` or
+`policies.require_image_digest: disabled` in the context values; the facet
+drops the corresponding component from `policy-resources.components`.
+
+## Substitutions
+
+This stack does not consume any blueprint substitutions. Policy bodies are
+hardcoded; gating happens at the component-selection layer in
+`platform-base`.
+
+## Components
+
+### `policy/base/`
+
+| Component | Enable when | Effect |
+|---|---|---|
+| `kyverno` | `policies.enabled` | Helm release of Kyverno v3.8.0 in `system-policy`. Installs admission-controller and background-controller. CRDs migrate via the chart's migration job. cleanup-controller and reports-controller are present but disabled (`enabled: false` in values). |
+| `kyverno/cleanup` | `policies.cleanup == 'enabled'` | Patches the kyverno HelmRelease to set `cleanupController.enabled: true`. The controller stays idle until CleanupPolicy / ClusterCleanupPolicy resources are created. |
+| `kyverno/reports` | `policies.reporting == 'enabled'` | Patches the kyverno HelmRelease to set `reportsController.enabled: true`. Adds background scans and emits PolicyReport / ClusterPolicyReport resources. Admission enforcement is unaffected. |
+
+### `policy/resources/`
+
+The base kustomization is empty by default — every policy is its own
+component. Ordering is irrelevant since each ClusterPolicy is independent.
+
+| Component | Enable when | Effect |
+|---|---|---|
+| `kyverno/require-image-digest` | `policies.require_image_digest != 'disabled'` | `ClusterPolicy/require-image-digest` (Enforce, background-on). Validates that every container image in `system-*` namespaces or namespaces labeled `policy.windsorcli.dev/managed: "true"` is pinned by `@sha256:digest`. Excludes namespaces labeled `policy.windsorcli.dev/managed: "false"`. |
+| `kyverno/resource-limits-requests` | `policies.resource_limits_requests != 'disabled'` | `ClusterPolicy/resource-limits-requests` (Audit, background-off). Checks every Pod in `system-*` namespaces has CPU and memory `requests` and `limits`. `kube-system` is excluded via `preconditions`. Audit means failures are logged via PolicyReport but do not block admission. |
+
+## Dependencies
+
+`policy-base` has no `dependsOn` — it must come up before nearly everything
+else. The Kyverno admission webhook intercepts every Pod creation, so any
+stack that depends on `policy-resources` is also implicitly waiting for
+admission webhooks to be ready (Flux's `dependsOn` on a Kustomization waits
+for the contained HelmRelease to reconcile, which waits for the chart's own
+readiness checks).
+
+`policy-resources` depends on `policy-base` (the Kyverno CRDs must exist
+before any ClusterPolicy is applied).
+
+Stacks that depend on `policy-resources`:
+
+- `pki-base` — when policies are enabled, pki-base waits so cert-manager pods come up after Kyverno admission is enforcing image-digest pinning (otherwise cert-manager pods would be admitted without digests on first reconcile and rejected on rollout).
+- `pki-resources` — `addon-private-ca` ships an `inject-private-ca` ClusterPolicy; without `policy-resources` the Kyverno CRDs aren't ready and the apply fails on `no matches for kind ClusterPolicy`.
+- `dns` — `addon-private-dns` ships `external-dns/localhost`'s ClusterPolicy on docker-desktop runtime.
+- `cni` — re-rolls Cilium pods after Kyverno admission is live; when Cilium is the gateway driver, also depends on policy-resources for the LBIPAM sharing ClusterPolicy in `cilium/gateway`.
+- `lb-base` — every platform that wires lb-base lists policy-resources as a dependency. The `system-lb` namespace runs at PSA `privileged` and Kyverno needs to be aware of it.
+- `csi` — `option-storage` lists policy-resources as a dependency so CSI's node-driver-registrar Pod admits cleanly under image-digest enforcement.
+
+## Operations
+
+Stack-specific failure modes; generic Flux/Renovate behaviour is documented
+at the repo level.
+
+- **Pod creation failing with `image must include @sha256 digest`** — `require-image-digest` is enforcing on a workload that doesn't pin its image. Either pin the image (preferred) or label the workload's namespace `policy.windsorcli.dev/managed: "false"` to opt out. Renovate's `# renovate: datasource=docker depName=...` markers above the `tag:` value let Renovate maintain pinned `tag@sha256:...` entries automatically.
+- **`HelmRelease/<anything>` reports `no matches for kind ClusterPolicy` or `Bundle`** — the consuming stack's `dependsOn` on `policy-resources` is missing or `policies.enabled` is false. Either restore the dep or accept that the dependent stack won't apply.
+- **PolicyReports not appearing despite policies on** — the `reports-controller` is off by default. Set `policies.reporting: enabled` to layer in the `kyverno/reports` component.
+- **Kyverno webhook causes API requests to time out** — the admission-controller is unhealthy. Check `kubectl get validatingwebhookconfiguration kyverno-resource-validating-webhook-cfg`; if the webhook is `failurePolicy: Fail` and Kyverno is down, every API write blocks. The Windsor helm-release values do not override `failurePolicy`; whatever the upstream chart and individual policies set applies. Review the per-policy `failurePolicy` carefully before adding new policies in `Enforce` mode.
+
+## Security
+
+- The `system-policy` namespace runs at PSA `baseline`.
+- Kyverno's controllers run with the chart's default RBAC: cluster-wide read on most resources (to evaluate policies), write on PolicyReport/ClusterPolicyReport (when reports-controller is on), and the validating/mutating admission webhooks are cluster-scoped.
+- Policy scope is gated on namespace labels:
+  - In-scope: namespaces matching `system-*` or labeled `policy.windsorcli.dev/managed: "true"`.
+  - Out-of-scope: namespaces labeled `policy.windsorcli.dev/managed: "false"` (explicit opt-out, takes precedence over inclusion).
+- All container images in `system-*` namespaces (every Windsor-managed system stack) must be `@sha256:` pinned. Renovate handles this automatically through the `# renovate:` markers in helm-release values.
+
+## See also
+
+- [contexts/_template/facets/platform-base.yaml](../../contexts/_template/facets/platform-base.yaml) — canonical wiring of `policy-base` and `policy-resources`, including conditional toggles for the optional controllers and per-policy gates.
+- [contexts/_template/facets/addon-private-ca.yaml](../../contexts/_template/facets/addon-private-ca.yaml) — example of a stack that ships a ClusterPolicy and `dependsOn: policy-resources`.
+- Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
+- Related stacks: [pki](../pki/), [cni](../cni/), [lb](../lb/), [dns](../dns/), [gateway](../gateway/).

--- a/kustomize/policy/README.md
+++ b/kustomize/policy/README.md
@@ -1,5 +1,5 @@
 ---
-title: Policy stack
+title: Policy add-on
 description: Kyverno admission policies for image digest enforcement, resource limits, and the controllers that back them.
 ---
 
@@ -9,7 +9,7 @@ Kyverno is the cluster's admission policy engine. The `policy-base`
 Kustomization installs the Kyverno controllers; `policy-resources` applies
 the ClusterPolicy resources that enforce or audit cluster-wide rules.
 
-This stack is depended on by nearly every other stack — the namespace runs
+This add-on is depended on by nearly every other add-on — the namespace runs
 at PSA `baseline` and the cluster's mutation policies (private-CA injection,
 LBIPAM IP sharing on Cilium gateways, docker-desktop DNS rewriting) all
 require Kyverno's CRDs to apply.
@@ -50,7 +50,7 @@ are off by default — they ship with the chart but are toggled on by
 `policy-base` and `policy-resources` are gated on `policies.enabled` (default
 `true`). Setting `policies.enabled: false` skips both Kustomizations entirely;
 this is the opt-out for clusters that don't want admission control. It will
-break stacks that depend on `policy-resources` to install ClusterPolicies, so
+break add-ons that depend on `policy-resources` to install ClusterPolicies, so
 review consumers before disabling.
 
 ### Default (admission + background only)
@@ -109,7 +109,7 @@ drops the corresponding component from `policy-resources.components`.
 
 ## Substitutions
 
-This stack does not consume any blueprint substitutions. Policy bodies are
+This add-on does not consume any blueprint substitutions. Policy bodies are
 hardcoded; gating happens at the component-selection layer in
 `platform-base`.
 
@@ -137,7 +137,7 @@ component. Ordering is irrelevant since each ClusterPolicy is independent.
 
 `policy-base` has no `dependsOn` — it must come up before nearly everything
 else. The Kyverno admission webhook intercepts every Pod creation, so any
-stack that depends on `policy-resources` is also implicitly waiting for
+add-on that depends on `policy-resources` is also implicitly waiting for
 admission webhooks to be ready (Flux's `dependsOn` on a Kustomization waits
 for the contained HelmRelease to reconcile, which waits for the chart's own
 readiness checks).
@@ -145,7 +145,7 @@ readiness checks).
 `policy-resources` depends on `policy-base` (the Kyverno CRDs must exist
 before any ClusterPolicy is applied).
 
-Stacks that depend on `policy-resources`:
+Add-ons that depend on `policy-resources`:
 
 - `pki-base` — when policies are enabled, pki-base waits so cert-manager pods come up after Kyverno admission is enforcing image-digest pinning (otherwise cert-manager pods would be admitted without digests on first reconcile and rejected on rollout).
 - `pki-resources` — `addon-private-ca` ships an `inject-private-ca` ClusterPolicy; without `policy-resources` the Kyverno CRDs aren't ready and the apply fails on `no matches for kind ClusterPolicy`.
@@ -156,11 +156,11 @@ Stacks that depend on `policy-resources`:
 
 ## Operations
 
-Stack-specific failure modes; generic Flux/Renovate behaviour is documented
+Add-on-specific failure modes; generic Flux/Renovate behaviour is documented
 at the repo level.
 
 - **Pod creation failing with `image must include @sha256 digest`** — `require-image-digest` is enforcing on a workload that doesn't pin its image. Either pin the image (preferred) or label the workload's namespace `policy.windsorcli.dev/managed: "false"` to opt out. Renovate's `# renovate: datasource=docker depName=...` markers above the `tag:` value let Renovate maintain pinned `tag@sha256:...` entries automatically.
-- **`HelmRelease/<anything>` reports `no matches for kind ClusterPolicy` or `Bundle`** — the consuming stack's `dependsOn` on `policy-resources` is missing or `policies.enabled` is false. Either restore the dep or accept that the dependent stack won't apply.
+- **`HelmRelease/<anything>` reports `no matches for kind ClusterPolicy` or `Bundle`** — the consuming add-on's `dependsOn` on `policy-resources` is missing or `policies.enabled` is false. Either restore the dep or accept that the dependent add-on won't apply.
 - **PolicyReports not appearing despite policies on** — the `reports-controller` is off by default. Set `policies.reporting: enabled` to layer in the `kyverno/reports` component.
 - **Kyverno webhook causes API requests to time out** — the admission-controller is unhealthy. Check `kubectl get validatingwebhookconfiguration kyverno-resource-validating-webhook-cfg`; if the webhook is `failurePolicy: Fail` and Kyverno is down, every API write blocks. The Windsor helm-release values do not override `failurePolicy`; whatever the upstream chart and individual policies set applies. Review the per-policy `failurePolicy` carefully before adding new policies in `Enforce` mode.
 
@@ -171,11 +171,11 @@ at the repo level.
 - Policy scope is gated on namespace labels:
   - In-scope: namespaces matching `system-*` or labeled `policy.windsorcli.dev/managed: "true"`.
   - Out-of-scope: namespaces labeled `policy.windsorcli.dev/managed: "false"` (explicit opt-out, takes precedence over inclusion).
-- All container images in `system-*` namespaces (every Windsor-managed system stack) must be `@sha256:` pinned. Renovate handles this automatically through the `# renovate:` markers in helm-release values.
+- All container images in `system-*` namespaces (every Windsor-managed system add-on) must be `@sha256:` pinned. Renovate handles this automatically through the `# renovate:` markers in helm-release values.
 
 ## See also
 
 - [contexts/_template/facets/platform-base.yaml](../../contexts/_template/facets/platform-base.yaml) — canonical wiring of `policy-base` and `policy-resources`, including conditional toggles for the optional controllers and per-policy gates.
-- [contexts/_template/facets/addon-private-ca.yaml](../../contexts/_template/facets/addon-private-ca.yaml) — example of a stack that ships a ClusterPolicy and `dependsOn: policy-resources`.
+- [contexts/_template/facets/addon-private-ca.yaml](../../contexts/_template/facets/addon-private-ca.yaml) — example of an add-on that ships a ClusterPolicy and `dependsOn: policy-resources`.
 - Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
-- Related stacks: [pki](../pki/), [cni](../cni/), [lb](../lb/), [dns](../dns/), [gateway](../gateway/).
+- Related add-ons: [pki](../pki/), [cni](../cni/), [lb](../lb/), [dns](../dns/), [gateway](../gateway/).

--- a/kustomize/telemetry/README.md
+++ b/kustomize/telemetry/README.md
@@ -1,0 +1,198 @@
+---
+title: Telemetry stack
+description: Cluster-wide metrics and log collection — Prometheus, fluent-bit, metrics-server.
+---
+
+# Telemetry
+
+The cluster's metrics and logs collection layer. Two parallel pipelines, both
+managed from `system-telemetry`:
+
+- **Metrics**: kube-prometheus-stack runs Prometheus, kube-state-metrics, and
+  node-exporter. Scrape targets across all stacks register via ServiceMonitor
+  and PodMonitor resources.
+- **Logs**: fluent-operator manages a fluent-bit DaemonSet that reads
+  container logs and (on Talos) the systemd journal. Logs are forwarded to a
+  sink owned by the **observability** stack (`fluentd` aggregator by default,
+  Elasticsearch when the alternative driver is selected).
+
+Grafana is intentionally not in this stack — it lives in `observability`,
+which is also responsible for the log sink. Telemetry collects; observability
+visualizes and stores.
+
+## Flow
+
+```mermaid
+flowchart LR
+    pods[Pod logs<br/>+ systemd journal]
+    targets[ServiceMonitors / PodMonitors<br/>cluster-wide]
+
+    subgraph systemtelemetry[system-telemetry]
+        prom[Prometheus<br/>via kube-prometheus-stack]
+        ksm[kube-state-metrics]
+        ne[node-exporter]
+        fb[fluent-bit DaemonSet<br/>via fluent-operator]
+        ms[metrics-server]
+    end
+
+    sink[fluentd or Elasticsearch<br/>_owned by observability_]
+    api[K8s metrics API]
+
+    targets --> prom
+    ksm --> prom
+    ne --> prom
+    pods --> fb
+    fb --> sink
+    ms --> api
+```
+
+`telemetry-base` installs the operators (Prometheus operator,
+fluent-operator). `telemetry-resources` adds the configuration that turns
+those operators into a working pipeline: a `FluentBit` CR with
+`ClusterFluentBitConfig`, fluent-bit `ClusterInput` / `ClusterFilter` /
+`ClusterOutput` resources for each log source and parser, a `metrics-server`
+release, and Prometheus scrape extras.
+
+## Recipes
+
+`telemetry-base` and `telemetry-resources` are gated on
+`telemetry_effective.metrics_enabled || telemetry_effective.logs_enabled`.
+Both default to `true` (`telemetry.metrics.enabled ?? true`,
+`telemetry.logs.enabled ?? true`).
+
+### Default (both pipelines on, fluentd logs driver)
+
+```yaml
+- name: telemetry-base
+  path: telemetry/base
+  components:
+    - prometheus
+    - prometheus/flux
+    - fluentbit
+  timeout: 30m
+  interval: 10m
+
+- name: telemetry-resources
+  path: telemetry/resources
+  dependsOn: [telemetry-base]
+  components:
+    - metrics-server
+    - prometheus
+    - prometheus/flux
+    - fluentbit
+    - fluentbit/containerd
+    - fluentbit/kubernetes
+    - fluentbit/parser
+    - fluentbit/systemd
+    - fluentbit/prometheus
+    - fluentbit/fluentd
+  timeout: 10m
+  interval: 5m
+```
+
+### Metrics-only (`telemetry.logs.enabled: false`)
+
+```yaml
+- name: telemetry-base
+  path: telemetry/base
+  components:
+    - prometheus
+    - prometheus/flux
+
+- name: telemetry-resources
+  path: telemetry/resources
+  dependsOn: [telemetry-base]
+  components:
+    - metrics-server
+    - prometheus
+    - prometheus/flux
+```
+
+### AKS (managed metrics-server)
+
+`platform-azure` overrides `telemetry_effective.metrics_server_enabled` to
+`false` because AKS ships metrics-server as a built-in addon. Same shape as
+the default minus the `metrics-server` component.
+
+### Logs-only / Elasticsearch sink
+
+When `addon-observability` selects `logs_driver: elasticsearch`, the
+`fluentbit/fluentd` ClusterOutput is dropped and addon-observability layers
+in `filebeat` (in `telemetry-base`) for direct Elasticsearch shipping. See
+`addon-observability` for the full layering.
+
+## Substitutions
+
+This stack does not consume any blueprint substitutions. The two
+platform-base globals (`private_domain`, `public_domain`) are exposed to
+every Kustomization but are not referenced inside any telemetry manifest.
+
+## Components
+
+### `telemetry/base/`
+
+| Component | Enable when | Effect |
+|---|---|---|
+| `prometheus` | `telemetry.metrics.enabled` | Helm release of `kube-prometheus-stack` v84.5.0 in `system-telemetry`. Includes Prometheus, prometheus-operator, kube-state-metrics, node-exporter. Grafana is disabled here (lives in `observability`). All `*SelectorNilUsesHelmValues` are set to `false` so cluster-wide ServiceMonitors and PodMonitors are picked up. |
+| `prometheus/flux` | `telemetry.metrics.enabled` | Patches kube-prometheus-stack to add kube-state-metrics RBAC and `customResourceState` config for Flux's CRDs (GitRepository, Kustomization, HelmRelease, etc.) so they show up in metrics. |
+| `fluentbit` | `telemetry.logs.enabled` | Helm release of `fluent-operator` v4.0.0 in `system-telemetry` with `containerRuntime: containerd`. The chart installs the operator and the FluentBit/FluentD CRDs; `fluentd.enable: false` and `fluentbit.enable: false` so no instances are created at this layer (instances come from `telemetry-resources`). |
+| `filebeat` | (only via `addon-observability` for the Elasticsearch sink) | Helm release of filebeat for direct Elasticsearch shipping. Not wired by `platform-base`. |
+
+### `telemetry/resources/`
+
+The base kustomization is empty; every component contributes its own
+manifests.
+
+| Component | Enable when | Effect |
+|---|---|---|
+| `metrics-server` | `telemetry.metrics.enabled` AND `metrics_server_enabled != false` | Helm release of `metrics-server`. Skipped on AKS (managed). |
+| `metrics-server/skip-tls` | (opt-in patch) | Patches metrics-server to add `--kubelet-insecure-tls`. Not wired by platform-base; available for clusters where kubelet certs aren't trusted by metrics-server. |
+| `prometheus` | `telemetry.metrics.enabled` | Patches kube-state-metrics RBAC to read Flux CRDs and adds a `customResourceState` config for them, so Flux resource state shows up as metrics. |
+| `prometheus/flux` | `telemetry.metrics.enabled` | Helm release of `flux2` v2.18.3 named `flux-pod-monitor` in `system-gitops`. All controllers are `create: false`; only the `prometheus.podMonitor` is created — a PodMonitor for scraping Flux's controller pods. The chart-as-PodMonitor-shim trick avoids hand-writing a PodMonitor against Flux's labels. |
+| `fluentbit` | `telemetry.logs.enabled` | Creates the `FluentBit` CR (DaemonSet) with `nodeAffinity` excluding nodes labeled `node-role.kubernetes.io/edge`, host-path positionDB at `/var/lib/fluent-bit/`, and a `ClusterFluentBitConfig` selecting all input / filter / output resources labeled `fluentbit.fluent.io/enabled: "true"`. |
+| `fluentbit/containerd` | `telemetry.logs.enabled` | Systemd journal ClusterInput reading from `/var/log/journal` filtered to `containerd.service` and `kubelet.service` (tagged `service.*`), plus a Lua ClusterFilter that processes the CRI line format on `kube.*` records. |
+| `fluentbit/kubernetes` | `telemetry.logs.enabled` | Tail ClusterInput on `/var/log/containers/*.log` using the `cri` parser (tagged `kube.*`), plus a kubernetes ClusterFilter that enriches each record with pod metadata (namespace, pod name, container) using the in-cluster service account. |
+| `fluentbit/parser` | `telemetry.logs.enabled` | Aggregate component bundling parsers for coredns, JSON-structured, klog, logfmt, nginx-access, rust-tracing, zerolog, plus service-name extraction, suppress filter, fallback parser, and a generic gRPC parser. Each parser is a ClusterFilter with a Lua script. |
+| `fluentbit/systemd` | `telemetry.logs.enabled` | Lua ClusterFilter for `service.*` tagged records (the systemd journal entries captured by `fluentbit/containerd`). Adds an ISO 8601 timestamp and maps systemd fields (`_HOSTNAME`, `SYSLOG_IDENTIFIER`) into a kubernetes-shaped record so downstream processing matches the format from the kubernetes filter. |
+| `fluentbit/prometheus` | `telemetry.logs.enabled` AND `telemetry.metrics.enabled` | ServiceMonitor for fluent-bit's own `/metrics` endpoint. |
+| `fluentbit/fluentd` | `telemetry.logs.enabled` AND `telemetry_effective.logs_driver == 'fluentd'` | ClusterOutput shipping all enriched logs to the fluentd aggregator (in the `observability` namespace). |
+
+## Dependencies
+
+`telemetry-base` has no `dependsOn` — it is foundational and installs early.
+
+`telemetry-resources` `dependsOn: telemetry-base` (the operator CRDs must
+exist before any FluentBit CR or ServiceMonitor is created).
+
+Stacks that depend on `telemetry-base`:
+
+- `pki-base` — when telemetry metrics or logs are enabled, pki-base waits so cert-manager's ServiceMonitor has a working Prometheus target from creation.
+- `cni` — same reason: cilium/prometheus and cilium/hubble ServiceMonitors need Prometheus to be live.
+- `observability` — depends on telemetry-base because grafana / fluentd / elasticsearch all need the operators or the log shipper this stack provides.
+
+## Operations
+
+Stack-specific failure modes; generic Flux/Renovate behaviour is documented
+at the repo level.
+
+- **No metrics in Grafana despite Prometheus running** — ServiceMonitor / PodMonitor resources aren't being picked up. The `*SelectorNilUsesHelmValues: false` settings in `prometheus/helm-release.yaml` mean an empty selector matches everything; if Prometheus is filtering, check the Prometheus CR's `serviceMonitorSelector` for unintended overrides.
+- **fluent-bit DaemonSet not running on edge nodes** — the FluentBit CR's nodeAffinity excludes nodes labeled `node-role.kubernetes.io/edge`. If you want logs from edge nodes, remove the affinity or relabel the nodes. This is intentional — edge nodes are typically resource-constrained.
+- **Logs collected but never delivered** — the fluent-bit → fluentd ClusterOutput is missing. Check the `fluentbit/fluentd` component is enabled (which requires `telemetry_effective.logs_driver == 'fluentd'`). When `logs_driver == 'none'`, fluent-bit runs without an output and buffers indefinitely.
+- **`HelmRelease/kube-prometheus-stack` reports `no matches for kind ServiceMonitor`** — the kube-prometheus-stack CRDs haven't installed yet. The chart installs them; if the apply is racing, re-reconcile.
+- **fluent-operator pods crash with `cannot create ConfigMap`** — RBAC issue. The operator needs to write the rendered fluent-bit config; check `system-telemetry`'s ServiceAccount and ClusterRole.
+- **node-exporter DaemonSet missing pods** — node taints. node-exporter's chart values set `replicas: 1` which is misleading (it's a DaemonSet); check that tolerations cover the cluster's taints.
+
+## Security
+
+- The `system-telemetry` namespace runs at PSA `privileged`. fluent-bit needs host paths (`/var/lib/fluent-bit/` for the position DB, `/var/log/containers/` for container logs, `/var/log/journal` for the systemd journal) and node-exporter needs host PID and host network.
+- kube-state-metrics is granted RBAC to read Flux's CRDs (GitRepository, Kustomization, HelmRelease, etc.) so Flux resource state is exposed as Prometheus metrics. The grant is read-only (`list`, `watch`).
+- The `flux-pod-monitor` release lives in `system-gitops` (not `system-telemetry`) — only a PodMonitor object is created, no controllers, so no additional permissions are granted to telemetry.
+- fluent-bit reads container logs from `/var/log/containers/*.log` (kubernetes input) and the systemd journal at `/var/log/journal` (containerd input). Pod logs may contain secrets if applications log them; consider this when configuring downstream sinks.
+
+## See also
+
+- [contexts/_template/facets/platform-base.yaml](../../contexts/_template/facets/platform-base.yaml) — canonical wiring of `telemetry-base` and `telemetry-resources`, including the `telemetry_effective` config resolution.
+- [contexts/_template/facets/addon-observability.yaml](../../contexts/_template/facets/addon-observability.yaml) — log sink (fluentd / quickwit / elasticsearch + filebeat) layered on top of telemetry.
+- [contexts/_template/facets/platform-azure.yaml](../../contexts/_template/facets/platform-azure.yaml) — `metrics_server_enabled: false` override for AKS.
+- Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
+- Related stacks: [observability](../observability/), [pki](../pki/), [cni](../cni/), [policy](../policy/).

--- a/kustomize/telemetry/README.md
+++ b/kustomize/telemetry/README.md
@@ -1,5 +1,5 @@
 ---
-title: Telemetry stack
+title: Telemetry add-on
 description: Cluster-wide metrics and log collection — Prometheus, fluent-bit, metrics-server.
 ---
 
@@ -9,14 +9,14 @@ The cluster's metrics and logs collection layer. Two parallel pipelines, both
 managed from `system-telemetry`:
 
 - **Metrics**: kube-prometheus-stack runs Prometheus, kube-state-metrics, and
-  node-exporter. Scrape targets across all stacks register via ServiceMonitor
+  node-exporter. Scrape targets across all add-ons register via ServiceMonitor
   and PodMonitor resources.
 - **Logs**: fluent-operator manages a fluent-bit DaemonSet that reads
   container logs and (on Talos) the systemd journal. Logs are forwarded to a
-  sink owned by the **observability** stack (`fluentd` aggregator by default,
+  sink owned by the **observability** add-on (`fluentd` aggregator by default,
   Elasticsearch when the alternative driver is selected).
 
-Grafana is intentionally not in this stack — it lives in `observability`,
+Grafana is intentionally not in this add-on — it lives in `observability`,
 which is also responsible for the log sink. Telemetry collects; observability
 visualizes and stores.
 
@@ -122,7 +122,7 @@ in `filebeat` (in `telemetry-base`) for direct Elasticsearch shipping. See
 
 ## Substitutions
 
-This stack does not consume any blueprint substitutions. The two
+This add-on does not consume any blueprint substitutions. The two
 platform-base globals (`private_domain`, `public_domain`) are exposed to
 every Kustomization but are not referenced inside any telemetry manifest.
 
@@ -163,15 +163,15 @@ manifests.
 `telemetry-resources` `dependsOn: telemetry-base` (the operator CRDs must
 exist before any FluentBit CR or ServiceMonitor is created).
 
-Stacks that depend on `telemetry-base`:
+Add-ons that depend on `telemetry-base`:
 
 - `pki-base` — when telemetry metrics or logs are enabled, pki-base waits so cert-manager's ServiceMonitor has a working Prometheus target from creation.
 - `cni` — same reason: cilium/prometheus and cilium/hubble ServiceMonitors need Prometheus to be live.
-- `observability` — depends on telemetry-base because grafana / fluentd / elasticsearch all need the operators or the log shipper this stack provides.
+- `observability` — depends on telemetry-base because grafana / fluentd / elasticsearch all need the operators or the log shipper this add-on provides.
 
 ## Operations
 
-Stack-specific failure modes; generic Flux/Renovate behaviour is documented
+Add-on-specific failure modes; generic Flux/Renovate behaviour is documented
 at the repo level.
 
 - **No metrics in Grafana despite Prometheus running** — ServiceMonitor / PodMonitor resources aren't being picked up. The `*SelectorNilUsesHelmValues: false` settings in `prometheus/helm-release.yaml` mean an empty selector matches everything; if Prometheus is filtering, check the Prometheus CR's `serviceMonitorSelector` for unintended overrides.
@@ -194,4 +194,4 @@ at the repo level.
 - [contexts/_template/facets/addon-observability.yaml](../../contexts/_template/facets/addon-observability.yaml) — log sink (fluentd / quickwit / elasticsearch + filebeat) layered on top of telemetry.
 - [contexts/_template/facets/platform-azure.yaml](../../contexts/_template/facets/platform-azure.yaml) — `metrics_server_enabled: false` override for AKS.
 - Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
-- Related stacks: [observability](../observability/), [pki](../pki/), [cni](../cni/), [policy](../policy/).
+- Related add-ons: [observability](../observability/), [pki](../pki/), [cni](../cni/), [policy](../policy/).

--- a/kustomize/telemetry/README.md
+++ b/kustomize/telemetry/README.md
@@ -56,9 +56,8 @@ release, and Prometheus scrape extras.
 ## Recipes
 
 `telemetry-base` and `telemetry-resources` are gated on
-`telemetry_effective.metrics_enabled || telemetry_effective.logs_enabled`.
-Both default to `true` (`telemetry.metrics.enabled ?? true`,
-`telemetry.logs.enabled ?? true`).
+`telemetry.metrics.enabled` or `telemetry.logs.enabled`. Both default to
+`true`.
 
 ### Default (both pipelines on, fluentd logs driver)
 
@@ -110,9 +109,9 @@ Both default to `true` (`telemetry.metrics.enabled ?? true`,
 
 ### AKS (managed metrics-server)
 
-`platform-azure` overrides `telemetry_effective.metrics_server_enabled` to
-`false` because AKS ships metrics-server as a built-in addon. Same shape as
-the default minus the `metrics-server` component.
+On `platform: azure`, the `metrics-server` component is dropped because
+AKS ships metrics-server as a built-in addon. Same shape as the default
+recipe minus `metrics-server`.
 
 ### Logs-only / Elasticsearch sink
 
@@ -155,7 +154,7 @@ manifests.
 | `fluentbit/parser` | `telemetry.logs.enabled` | Aggregate component bundling parsers for coredns, JSON-structured, klog, logfmt, nginx-access, rust-tracing, zerolog, plus service-name extraction, suppress filter, fallback parser, and a generic gRPC parser. Each parser is a ClusterFilter with a Lua script. |
 | `fluentbit/systemd` | `telemetry.logs.enabled` | Lua ClusterFilter for `service.*` tagged records (the systemd journal entries captured by `fluentbit/containerd`). Adds an ISO 8601 timestamp and maps systemd fields (`_HOSTNAME`, `SYSLOG_IDENTIFIER`) into a kubernetes-shaped record so downstream processing matches the format from the kubernetes filter. |
 | `fluentbit/prometheus` | `telemetry.logs.enabled` AND `telemetry.metrics.enabled` | ServiceMonitor for fluent-bit's own `/metrics` endpoint. |
-| `fluentbit/fluentd` | `telemetry.logs.enabled` AND `telemetry_effective.logs_driver == 'fluentd'` | ClusterOutput shipping all enriched logs to the fluentd aggregator (in the `observability` namespace). |
+| `fluentbit/fluentd` | `telemetry.logs.enabled` AND `telemetry.logs.driver: fluentd` (the default) | ClusterOutput shipping all enriched logs to the fluentd aggregator (in the `observability` namespace). |
 
 ## Dependencies
 
@@ -177,7 +176,7 @@ at the repo level.
 
 - **No metrics in Grafana despite Prometheus running** — ServiceMonitor / PodMonitor resources aren't being picked up. The `*SelectorNilUsesHelmValues: false` settings in `prometheus/helm-release.yaml` mean an empty selector matches everything; if Prometheus is filtering, check the Prometheus CR's `serviceMonitorSelector` for unintended overrides.
 - **fluent-bit DaemonSet not running on edge nodes** — the FluentBit CR's nodeAffinity excludes nodes labeled `node-role.kubernetes.io/edge`. If you want logs from edge nodes, remove the affinity or relabel the nodes. This is intentional — edge nodes are typically resource-constrained.
-- **Logs collected but never delivered** — the fluent-bit → fluentd ClusterOutput is missing. Check the `fluentbit/fluentd` component is enabled (which requires `telemetry_effective.logs_driver == 'fluentd'`). When `logs_driver == 'none'`, fluent-bit runs without an output and buffers indefinitely.
+- **Logs collected but never delivered** — the fluent-bit → fluentd ClusterOutput is missing. Check the `fluentbit/fluentd` component is enabled (it requires `telemetry.logs.driver: fluentd`, which is the default). When `telemetry.logs.driver: none`, fluent-bit runs without an output and buffers indefinitely.
 - **`HelmRelease/kube-prometheus-stack` reports `no matches for kind ServiceMonitor`** — the kube-prometheus-stack CRDs haven't installed yet. The chart installs them; if the apply is racing, re-reconcile.
 - **fluent-operator pods crash with `cannot create ConfigMap`** — RBAC issue. The operator needs to write the rendered fluent-bit config; check `system-telemetry`'s ServiceAccount and ClusterRole.
 - **node-exporter DaemonSet missing pods** — node taints. node-exporter's chart values set `replicas: 1` which is misleading (it's a DaemonSet); check that tolerations cover the cluster's taints.
@@ -191,7 +190,7 @@ at the repo level.
 
 ## See also
 
-- [contexts/_template/facets/platform-base.yaml](../../contexts/_template/facets/platform-base.yaml) — canonical wiring of `telemetry-base` and `telemetry-resources`, including the `telemetry_effective` config resolution.
+- [contexts/_template/facets/platform-base.yaml](../../contexts/_template/facets/platform-base.yaml) — canonical wiring of `telemetry-base` and `telemetry-resources`, including the `telemetry_effective` internal config that folds `telemetry.*` values together with addon-observability overrides.
 - [contexts/_template/facets/addon-observability.yaml](../../contexts/_template/facets/addon-observability.yaml) — log sink (fluentd / quickwit / elasticsearch + filebeat) layered on top of telemetry.
 - [contexts/_template/facets/platform-azure.yaml](../../contexts/_template/facets/platform-azure.yaml) — `metrics_server_enabled: false` override for AKS.
 - Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/

--- a/scripts/sync-kustomize-reference.mjs
+++ b/scripts/sync-kustomize-reference.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+/**
+ * Materialize each kustomize stack README.md into docs/reference/kustomize/
+ * for windsorcli.github.io ingest.
+ *
+ * Run from repo root: node scripts/sync-kustomize-reference.mjs
+ *
+ * Also imported by windsorcli.github.io/scripts/vendor-docs.mjs (keep mapping logic in sync).
+ */
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function walkReadmes(dir, acc = []) {
+  for (const ent of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, ent.name);
+    if (ent.isDirectory()) walkReadmes(p, acc);
+    else if (ent.name === 'README.md') acc.push(p);
+  }
+  return acc;
+}
+
+function titleFromReadme(kRoot, readmePath) {
+  const body = readFileSync(readmePath, 'utf8');
+  const m = body.match(/^---\s*[\s\S]*?title:\s*(.+?)\s*$/m);
+  if (m) return m[1].replace(/^["']|["']$/g, '').trim();
+  const h1 = body.replace(/^---[\s\S]*?---\s*/, '').match(/^#\s+(.+)/m);
+  if (h1) return h1[1].trim();
+  const rel = relative(kRoot, dirname(readmePath));
+  if (!rel || rel === '.') return 'Kustomize (overview)';
+  const parts = rel.split(/[/\\]/);
+  return parts[parts.length - 1].replace(/-/g, ' ');
+}
+
+function ensureFrontmatter(kRoot, srcPath, body) {
+  if (body.trimStart().startsWith('---')) return body;
+  const title = titleFromReadme(kRoot, srcPath);
+  const rel = relative(kRoot, dirname(srcPath)) || '.';
+  const desc = `Operator notes from kustomize/${rel} (generated; edit README in kustomize/).`;
+  return `---\ntitle: ${JSON.stringify(title)}\ndescription: ${JSON.stringify(desc)}\n---\n\n${body}`;
+}
+
+function destPathForReadme(kRoot, outRoot, readmePath) {
+  const parent = dirname(readmePath);
+  const rel = relative(kRoot, parent);
+  if (!rel || rel === '.') {
+    return join(outRoot, 'index.md');
+  }
+  const segments = rel.split(/[/\\]/).filter(Boolean);
+  const base = segments.pop();
+  const sub = segments;
+  return join(outRoot, ...sub, `${base}.md`);
+}
+
+export function hasMarkdownUnder(dir) {
+  if (!existsSync(dir)) return false;
+  const stack = [dir];
+  while (stack.length) {
+    const d = stack.pop();
+    for (const ent of readdirSync(d, { withFileTypes: true })) {
+      const p = join(d, ent.name);
+      if (ent.isDirectory()) stack.push(p);
+      else if (ent.name.endsWith('.md')) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * @param {string} kustomizeRoot absolute path to …/kustomize
+ * @param {string} outputKustomizeDir absolute path to output tree (…/docs/reference/kustomize or vendored equivalent)
+ * @returns {number} files written
+ */
+export function materializeKustomizeReadmes(kustomizeRoot, outputKustomizeDir) {
+  if (!existsSync(kustomizeRoot)) return 0;
+
+  mkdirSync(outputKustomizeDir, { recursive: true });
+  const readmes = walkReadmes(kustomizeRoot);
+  let n = 0;
+  for (const readme of readmes) {
+    const raw = readFileSync(readme, 'utf8');
+    const out = destPathForReadme(kustomizeRoot, outputKustomizeDir, readme);
+    mkdirSync(dirname(out), { recursive: true });
+    writeFileSync(out, ensureFrontmatter(kustomizeRoot, readme, raw), 'utf8');
+    n += 1;
+  }
+  return n;
+}
+
+/** Default: sync into this repo’s docs/reference/kustomize (destructive refresh). */
+export function syncIntoCoreRepo(coreRepoRoot = join(__dirname, '..')) {
+  const kRoot = join(coreRepoRoot, 'kustomize');
+  const outRoot = join(coreRepoRoot, 'docs', 'reference', 'kustomize');
+
+  if (!existsSync(kRoot)) {
+    console.error('sync-kustomize-reference: no kustomize/ directory');
+    process.exit(1);
+  }
+
+  rmSync(outRoot, { recursive: true, force: true });
+  mkdirSync(outRoot, { recursive: true });
+
+  const readmes = walkReadmes(kRoot);
+  if (readmes.length === 0) {
+    console.warn('sync-kustomize-reference: no README.md under kustomize/');
+    return 0;
+  }
+
+  for (const readme of readmes) {
+    const raw = readFileSync(readme, 'utf8');
+    const out = destPathForReadme(kRoot, outRoot, readme);
+    mkdirSync(dirname(out), { recursive: true });
+    writeFileSync(out, ensureFrontmatter(kRoot, readme, raw), 'utf8');
+    console.log(
+      `sync-kustomize-reference: ${relative(coreRepoRoot, readme)} → ${relative(coreRepoRoot, out)}`,
+    );
+  }
+  console.log(
+    `sync-kustomize-reference: wrote ${readmes.length} file(s) under docs/reference/kustomize/`,
+  );
+  return readmes.length;
+}
+
+const entryFile = fileURLToPath(import.meta.url);
+if (process.argv[1] && resolve(process.argv[1]) === entryFile) {
+  syncIntoCoreRepo();
+}


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> Isolated documentation infrastructure change; no behavioral changes to deployed workloads and no breaking modifications to existing Kustomize or Terraform resources.
>
> **Overview**
>
> Introduces a docs pipeline for Windsor Core's kustomize add-ons: each `kustomize/<stack>/README.md` is now the authoritative source, and a new Node.js sync script (`scripts/sync-kustomize-reference.mjs`) materializes them into `docs/reference/kustomize/` for website ingest. The `.gitignore` is updated to track `docs/reference/` while continuing to ignore the rest of `docs/`, and a new `docs:reference:kustomize` Taskfile target wraps the local sync path. The `docs-author` skill and PR checklist are updated to reflect the new workflow.
>
> The script exports two entry points: `materializeKustomizeReadmes` for additive use by the website's vendor pipeline, and `syncIntoCoreRepo` for the local destructive-refresh path. The single functional manifest change is a new `kustomize/lb/resources/metallb/kustomization.yaml` Component stub. Two open findings: `materializeKustomizeReadmes` accumulates stale files when a stack is retired (covered by an inline thread), and `actions/setup-node` in the new CI step is unpinned unlike every other action in the file.
>
> The sync script has no automated tests; correctness currently relies on the generated output being visually verified in this PR.
>
> Reviewed by Claude for commit `d67a59f`.
<!-- /claude-code-review:summary -->
