### PR TITLE
chore(deps): add alertmanager configuration with version v0.32.1

### DIFF
--- a/kustomize/telemetry/base/prometheus/helm-release.yaml
+++ b/kustomize/telemetry/base/prometheus/helm-release.yaml
@@ -51,6 +51,13 @@ spec:
         serviceMonitorSelector: { }
         podMonitorNamespaceSelector: { }
         podMonitorSelector: { }
+    alertmanager:
+      alertmanagerSpec:
+        # renovate: datasource=github-releases depName=prometheus/alertmanager package=prometheus/alertmanager
+        version: v0.32.1
+        image:
+          # renovate: datasource=docker depName=quay.io/prometheus/alertmanager package=quay.io/prometheus/alertmanager
+          tag: v0.32.1@sha256:51a825c2a40acc3e338fdd00d622e01ec090f72be2b3ea46be0839cd47a4d286
     nodeExporter:
       enabled: true
       replicas: 1


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> Isolated image version pin within a single HelmRelease values block; no existing configuration is altered and the change is trivially reversible.
>
> **Overview**
>
> Introduces image version pinning for Alertmanager (v0.32.1) in the kube-prometheus-stack HelmRelease, following the dual-annotation pattern already established for Prometheus and Node Exporter in the same file. The image tag embeds a SHA256 digest, which anchors the exact layer content and prevents silent image substitution.
>
> Both `version` and `image.tag` are managed by independent Renovate datasources (github-releases and docker). If a future version bump produces two separate PRs that merge at different times, the operator's reported version and the running image could briefly disagree. This pattern is pre-existing and consistent across the file; the inline comment on line 57 flags it for awareness.
>
> Reviewed by Claude for commit `3c3380a`.
<!-- /claude-code-review:summary -->
