### PR TITLE
chore(facets): remove CPU and memory fallbacks in configuration files

### DIFF
--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -186,8 +186,8 @@ terraform:
       # scheduler probes flap. Clamp to 2 there; docker stays CPU-derived.
       concurrency: >-
         ${platform == 'incus' ? 2 : max(2, min(
-          floor((cluster.controlplanes.cpu ?? 4) / 2),
-          floor((cluster.controlplanes.memory ?? 4) / 2),
+          floor(cluster.controlplanes.cpu / 2),
+          floor(cluster.controlplanes.memory / 2),
           10
         ))}
       git_username: ${workstation.git.username ?? "local"}
@@ -300,12 +300,12 @@ terraform:
           storage_pool: "${(workstation.runtime ?? '') == 'colima' ? 'local' : 'default'}"
           root_disk_size: ${string(cluster.controlplanes.root_disk_size ?? 30) + "GB"}
           limits:
-            cpu: ${string(cluster.controlplanes.cpu ?? 2)}
-            memory: ${string(cluster.controlplanes.memory ?? 2) + "GB"}
+            cpu: ${string(cluster.controlplanes.cpu)}
+            memory: ${string(cluster.controlplanes.memory) + "GB"}
           disks: ${talos_common.controlplane_disks}
           config:
             user.hostname: ${values(cluster.controlplanes.nodes)[0].hostname ?? "controlplane-1"}
-            environment.TALOSSKU: ${string(cluster.controlplanes.cpu ?? 2) + "CPU-" + string((cluster.controlplanes.memory ?? 2) * 1024) + "RAM"}
+            environment.TALOSSKU: ${string(cluster.controlplanes.cpu) + "CPU-" + string(cluster.controlplanes.memory * 1024) + "RAM"}
             raw.qemu: -boot order=c,menu=off
         - name: worker
           role: worker
@@ -317,12 +317,12 @@ terraform:
           storage_pool: "${(workstation.runtime ?? '') == 'colima' ? 'local' : 'default'}"
           root_disk_size: ${string(cluster.workers.root_disk_size ?? 50) + "GB"}
           limits:
-            cpu: ${string(cluster.workers.cpu ?? 4)}
-            memory: ${string(cluster.workers.memory ?? 4) + "GB"}
+            cpu: ${string(cluster.workers.cpu)}
+            memory: ${string(cluster.workers.memory) + "GB"}
           disks: ${talos_common.worker_disks}
           config:
             user.hostname: "${cluster.workers.nodes != null ? (values(cluster.workers.nodes)[0].hostname ?? 'worker-1') : 'worker-1'}"
-            environment.TALOSSKU: "${string(cluster.workers.cpu ?? 4) + 'CPU-' + string((cluster.workers.memory ?? 4) * 1024) + 'RAM'}"
+            environment.TALOSSKU: "${string(cluster.workers.cpu) + 'CPU-' + string(cluster.workers.memory * 1024) + 'RAM'}"
             raw.qemu: -boot order=c,menu=off
 
   # Docker: run Talos controlplane/worker containers on the workstation
@@ -344,15 +344,15 @@ terraform:
         controlplanes:
           count: ${cluster.controlplanes.count ?? 1}
           image: ${cluster.controlplanes.image ?? talos.docker_image}
-          cpu: ${cluster.controlplanes.cpu ?? 2}
-          memory: ${cluster.controlplanes.memory ?? 2}
+          cpu: ${cluster.controlplanes.cpu}
+          memory: ${cluster.controlplanes.memory}
           hostports: "${workstation.runtime == \"docker-desktop\" ? (cluster.controlplanes.hostports ?? [\"8080:30080/tcp\", \"8443:30443/tcp\"]) : []}"
           volumes: ${cluster.controlplanes.volumes ?? []}
         workers:
           count: ${cluster.workers.count ?? 0}
           image: ${cluster.workers.image ?? talos.docker_image}
-          cpu: ${cluster.workers.cpu ?? 4}
-          memory: ${cluster.workers.memory ?? 4}
+          cpu: ${cluster.workers.cpu}
+          memory: ${cluster.workers.memory}
           hostports: "${workstation.runtime == \"docker-desktop\" ? (cluster.workers.hostports ?? [\"8080:30080/tcp\", \"8443:30443/tcp\"]) : []}"
           volumes: ${cluster.workers.volumes ?? []}
 

--- a/contexts/_template/facets/platform-incus.yaml
+++ b/contexts/_template/facets/platform-incus.yaml
@@ -101,12 +101,12 @@ terraform:
           storage_pool: "default"
           root_disk_size: ${string(cluster.controlplanes.root_disk_size ?? 30) + "GB"}
           limits:
-            cpu: ${string(cluster.controlplanes.cpu ?? 2)}
-            memory: ${string(cluster.controlplanes.memory ?? 2) + "GB"}
+            cpu: ${string(cluster.controlplanes.cpu)}
+            memory: ${string(cluster.controlplanes.memory) + "GB"}
           disks: ${talos_common.controlplane_disks}
           config:
             user.hostname: ${values(cluster.controlplanes.nodes)[0].hostname ?? "controlplane-1"}
-            environment.TALOSSKU: ${string(cluster.controlplanes.cpu ?? 2) + "CPU-" + string((cluster.controlplanes.memory ?? 2) * 1024) + "RAM"}
+            environment.TALOSSKU: ${string(cluster.controlplanes.cpu) + "CPU-" + string(cluster.controlplanes.memory * 1024) + "RAM"}
             raw.qemu: -boot order=c,menu=off
         - name: worker
           role: worker
@@ -118,12 +118,12 @@ terraform:
           storage_pool: "default"
           root_disk_size: ${string(cluster.workers.root_disk_size ?? 50) + "GB"}
           limits:
-            cpu: ${string(cluster.workers.cpu ?? 4)}
-            memory: ${string(cluster.workers.memory ?? 4) + "GB"}
+            cpu: ${string(cluster.workers.cpu)}
+            memory: ${string(cluster.workers.memory) + "GB"}
           disks: ${talos_common.worker_disks}
           config:
             user.hostname: "${len(cluster.workers.nodes ?? {}) > 0 ? (values(cluster.workers.nodes)[0].hostname ?? 'worker-1') : 'worker-1'}"
-            environment.TALOSSKU: "${string(cluster.workers.cpu ?? 4) + 'CPU-' + string((cluster.workers.memory ?? 4) * 1024) + 'RAM'}"
+            environment.TALOSSKU: "${string(cluster.workers.cpu) + 'CPU-' + string(cluster.workers.memory * 1024) + 'RAM'}"
             raw.qemu: -boot order=c,menu=off
 
   # ---------------------------------------------------------------------------
@@ -164,7 +164,7 @@ terraform:
     dependsOn:
       - cluster
     inputs:
-      concurrency: ${max(2, min(floor((cluster.controlplanes.cpu ?? 4) / 2), floor((cluster.controlplanes.memory ?? 4) / 2), 10))}
+      concurrency: ${max(2, min(floor(cluster.controlplanes.cpu / 2), floor(cluster.controlplanes.memory / 2), 10))}
     destroy: false
 
 # =============================================================================

--- a/contexts/_template/facets/platform-metal.yaml
+++ b/contexts/_template/facets/platform-metal.yaml
@@ -66,7 +66,7 @@ terraform:
     dependsOn:
       - cluster
     inputs:
-      concurrency: ${max(2, min(floor((cluster.controlplanes.cpu ?? 4) / 2), floor((cluster.controlplanes.memory ?? 4) / 2), 10))}
+      concurrency: ${max(2, min(floor(cluster.controlplanes.cpu / 2), floor(cluster.controlplanes.memory / 2), 10))}
     destroy: false
 
 # =============================================================================

--- a/contexts/_template/schema.yaml
+++ b/contexts/_template/schema.yaml
@@ -79,9 +79,11 @@ $defs:
       description: Cloud provider instance type
     cpu:
       type: integer
+      default: 4
       description: CPU cores per node
     memory:
       type: integer
+      default: 8
       description: Memory in GB per node
     root_disk_size:
       type: integer

--- a/contexts/_template/schema.yaml
+++ b/contexts/_template/schema.yaml
@@ -80,11 +80,11 @@ $defs:
     cpu:
       type: integer
       default: 4
-      description: CPU cores per node
+      description: CPU cores per node. Default 4 applies to both controlplane and worker pools.
     memory:
       type: integer
       default: 8
-      description: Memory in GB per node
+      description: Memory in GB per node. Default 8 applies to both controlplane and worker pools.
     root_disk_size:
       type: integer
       description: Root/OS disk size in GB


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> This PR changes default resource values that affect all platforms and any deployment not explicitly setting CPU or memory, making it worth a careful read before merging.
>
> **Overview**
>
> Centralizes scattered `?? <literal>` fallbacks — previously embedded inline in CEL expressions across the incus, metal, and workstation facets — into authoritative `default:` entries in the shared schema. This removes duplication and makes the intended defaults easier to find and change in one place. A follow-on commit improved the schema field descriptions to reflect the new defaults inline.
>
> The new unified defaults (`cpu: 4`, `memory: 8`) replace what were previously asymmetric per-context values: controlplane expressions used `?? 2` for both CPU and memory, while worker expressions used `?? 4`. Any deployment not explicitly setting node resources will now provision controlplanes with double the CPU (2→4) and four times the memory (2→8 GB) compared to before; worker memory also doubles (4→8 GB). These are implicit behavioral changes and operators should audit their configurations before upgrading.
>
> No test-file changes accompany this PR, so the net effect on rendered YAML for a default config is not directly verified in CI.
>
> Reviewed by Claude for commit `2c2acfc`.
<!-- /claude-code-review:summary -->
