### PR TITLE
fix: update cert-manager DNS zone handling for Azure and AWS configurations

### DIFF
--- a/contexts/_template/facets/platform-aws.yaml
+++ b/contexts/_template/facets/platform-aws.yaml
@@ -81,7 +81,7 @@ terraform:
       private_subnet_ids: ${terraform_output('network', 'private_subnet_ids')}
       manage_log_group: ${!(ephemeral ?? false)}
       create_cert_manager_role: "${(dns.public_domain ?? '') != ''}"
-      cert_manager_hosted_zone_ids: "${(dns.public_domain ?? '') != '' && (terraform_output('dns-zone', 'zone_id') ?? '') != '' ? [terraform_output('dns-zone', 'zone_id')] : []}"
+      cert_manager_hosted_zone_ids: "${(terraform_output('dns-zone', 'zone_id') ?? '') != '' ? [terraform_output('dns-zone', 'zone_id')] : []}"
       # cluster.pools is the portable node-pool shape (class + count|min/max +
       # lifecycle). When unset, the cluster module falls back to its
       # var.node_groups default — no behavior change for existing configs.

--- a/contexts/_template/facets/platform-azure.yaml
+++ b/contexts/_template/facets/platform-azure.yaml
@@ -200,22 +200,15 @@ kustomize:
       acme_server: "${dev == true ? 'https://acme-staging-v02.api.letsencrypt.org/directory' : 'https://acme-v02.api.letsencrypt.org/directory'}"
       acme_email: "${email ?? ''}"
       acme_dns_zone: "${dns.public_domain ?? ''}"
-      # Deferred terraform_outputs from the dns-zone stack — the cert-manager
-      # azureDNS solver needs (zone_name, RG, sub) to call the management API,
-      # plus (tenant_id, client_id) of the cert-manager UAMI to authenticate.
-      # Gated on dns.public_domain because the dns-zone stack only composes
-      # when public_domain is set; calling terraform_output on a missing
-      # component is a hard error that ?? doesn't catch. In private mode the
-      # private-issuer/selfsigned component selected above doesn't read these.
-      acme_dns_zone_resource_group: "${(dns.public_domain ?? '') != '' ? (terraform_output('dns-zone', 'resource_group_name') ?? '') : ''}"
-      acme_dns_zone_subscription_id: "${(dns.public_domain ?? '') != '' ? (terraform_output('dns-zone', 'subscription_id') ?? '') : ''}"
-      # cert-manager UAMI outputs only exist when create_cert_manager_identity
-      # fires (gated on dns.public_domain in the cluster step). Calling
-      # terraform_output for an absent output is a hard error that ?? can't
-      # catch — gate eagerly. Selfsigned issuer in private mode doesn't read
-      # these.
-      cert_manager_client_id: "${(dns.public_domain ?? '') != '' ? (terraform_output('cluster', 'cert_manager_client_id') ?? '') : ''}"
-      cert_manager_tenant_id: "${(dns.public_domain ?? '') != '' ? (terraform_output('cluster', 'tenant_id') ?? '') : ''}"
+      # Deferred terraform_outputs from the dns-zone and cluster stacks. When
+      # those stacks aren't composed (e.g. dns.public_domain unset, or
+      # create_cert_manager_identity didn't fire) the harness returns null
+      # uniformly and ?? falls back to ''. The selfsigned-issuer path in
+      # private mode doesn't read these substitutions.
+      acme_dns_zone_resource_group: "${terraform_output('dns-zone', 'resource_group_name') ?? ''}"
+      acme_dns_zone_subscription_id: "${terraform_output('dns-zone', 'subscription_id') ?? ''}"
+      cert_manager_client_id: "${terraform_output('cluster', 'cert_manager_client_id') ?? ''}"
+      cert_manager_tenant_id: "${terraform_output('cluster', 'tenant_id') ?? ''}"
 
   # ---------------------------------------------------------------------------
   # DNS — external-dns + Azure DNS record automation

--- a/contexts/_template/facets/platform-azure.yaml
+++ b/contexts/_template/facets/platform-azure.yaml
@@ -200,11 +200,13 @@ kustomize:
       acme_server: "${dev == true ? 'https://acme-staging-v02.api.letsencrypt.org/directory' : 'https://acme-v02.api.letsencrypt.org/directory'}"
       acme_email: "${email ?? ''}"
       acme_dns_zone: "${dns.public_domain ?? ''}"
-      # Deferred terraform_outputs from the dns-zone and cluster stacks. When
-      # those stacks aren't composed (e.g. dns.public_domain unset, or
-      # create_cert_manager_identity didn't fire) the harness returns null
-      # uniformly and ?? falls back to ''. The selfsigned-issuer path in
-      # private mode doesn't read these substitutions.
+      # Deferred terraform_outputs from the dns-zone and cluster stacks.
+      # terraform_output() returns nil whenever the requested output is
+      # absent — component never composed, output not exported, or
+      # mid-destroy — so ?? '' covers dns.public_domain-unset and
+      # create_cert_manager_identity-not-fired without an outer guard.
+      # Real state-read errors still propagate. Selfsigned-issuer in
+      # private mode doesn't read these; empty values are inert there.
       acme_dns_zone_resource_group: "${terraform_output('dns-zone', 'resource_group_name') ?? ''}"
       acme_dns_zone_subscription_id: "${terraform_output('dns-zone', 'subscription_id') ?? ''}"
       cert_manager_client_id: "${terraform_output('cluster', 'cert_manager_client_id') ?? ''}"


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> Modifies shared platform facets that affect all cert-manager DNS configurations; correctness depends on a harness guarantee that is not demonstrated in this diff.
>
> **Overview**
>
> Simplifies cert-manager DNS zone expressions in both the AWS and Azure platform facets by removing explicit `dns.public_domain` guard conditions that previously wrapped `terraform_output` calls. The stripped guards are replaced by a single `?? ''` fallback, predicated on the claim that the Windsor harness now returns `null` uniformly for missing stack outputs rather than throwing a hard error.
>
> The removed code's inline comments explicitly warned that `terraform_output` on an absent component was "a hard error that `??` doesn't catch." The new comment asserts that behavior has changed, but nothing in this diff or the empty PR body substantiates the assertion. If the harness still throws, any environment where `dns.public_domain` is unset will fail at render time with no fallback path.
>
> Reviewed by Claude for commit `4708dd1`.
<!-- /claude-code-review:summary -->
