### PR TITLE
chore(helm): remove allowPrivilegeEscalation from quickwit security context and set distroless to false for prometheus node-exporter

### DIFF
--- a/kustomize/observability/quickwit/pvc/patches/helm-release.yaml
+++ b/kustomize/observability/quickwit/pvc/patches/helm-release.yaml
@@ -17,7 +17,6 @@ spec:
       runAsNonRoot: false
       runAsUser: 0
       runAsGroup: 0
-      allowPrivilegeEscalation: true
     securityContext:
       runAsNonRoot: false
       runAsUser: 0

--- a/kustomize/telemetry/base/prometheus/helm-release.yaml
+++ b/kustomize/telemetry/base/prometheus/helm-release.yaml
@@ -68,3 +68,5 @@ spec:
         # renovate: datasource=docker depName=quay.io/prometheus/node-exporter package=quay.io/prometheus/node-exporter
         tag: v1.11.1@sha256:0f422f62c15f154af8d8572b23d623aebfb10cec73a5c654d18f911f3f9df241
         digest: ""
+        # chart defaults this to true and would append `-distroless` to tag, breaking the digest pinning
+        distroless: false


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> Two small, independent helm-values fixes that unblock upstream dependency updates without changing application runtime behavior.
>
> **Overview**
>
> The Quickwit change removes an explicit `allowPrivilegeEscalation: true` from the container security context. Because the container already runs as UID 0, Kubernetes defaults privilege escalation to allowed anyway, so the effective security posture is identical. The removal satisfies stricter schema validation introduced in a newer helm-controller version.
>
> The node-exporter change adds `distroless: false` to prevent the Prometheus chart from appending `-distroless` to the image tag. Without this flag the chart would construct a reference like `v1.11.1-distroless@sha256:...`, which would not match the digest pinned to the non-distroless image — causing a reconciliation failure. The inline comment captures the reason clearly.
>
> Reviewed by Claude for commit `326f2d3`.
<!-- /claude-code-review:summary -->
