### PR TITLE
fix(observability,telemetry): quickwit securityContext, node-exporter distroless

### DIFF
--- a/kustomize/observability/quickwit/pvc/patches/helm-release.yaml
+++ b/kustomize/observability/quickwit/pvc/patches/helm-release.yaml
@@ -17,7 +17,6 @@ spec:
       runAsNonRoot: false
       runAsUser: 0
       runAsGroup: 0
-      allowPrivilegeEscalation: true
     securityContext:
       runAsNonRoot: false
       runAsUser: 0

--- a/kustomize/telemetry/base/prometheus/helm-release.yaml
+++ b/kustomize/telemetry/base/prometheus/helm-release.yaml
@@ -68,3 +68,5 @@ spec:
         # renovate: datasource=docker depName=quay.io/prometheus/node-exporter package=quay.io/prometheus/node-exporter
         tag: v1.11.1@sha256:0f422f62c15f154af8d8572b23d623aebfb10cec73a5c654d18f911f3f9df241
         digest: ""
+        # chart defaults this to true and would append `-distroless` to tag, breaking the digest pinning
+        distroless: false


### PR DESCRIPTION
- drop invalid pod-level allowPrivilegeEscalation from kustomize/observability/quickwit/pvc/patches/helm-release.yaml; helm-controller 1.5.x server-side apply rejects it as not declared in the pod-level schema
- set prometheus-node-exporter.image.distroless false in kustomize/telemetry/base/prometheus/helm-release.yaml; chart was appending -distroless after the SHA-pinned digest hex, producing an OCI ref newer containerd rejects

<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> Two isolated Helm release configuration fixes, each reversible with a one-line revert and touching no shared infrastructure.
>
> **Overview**
>
> This PR resolves two independent reconciliation blockers. The first removes `allowPrivilegeEscalation` from Quickwit's pod-level security context (`podSecurityContext`), where it is schema-invalid under the SSA validation introduced in helm-controller 1.5.x — the field remains correctly set at the container level (`securityContext`) so runtime behavior is unchanged. The second explicitly sets `distroless: false` on the prometheus-node-exporter image, preventing the chart from appending a `-distroless` suffix to the digest-pinned tag and producing an OCI reference that newer containerd builds reject.
>
> Both changes are minimal and self-documenting, and neither alters security posture or resource behavior beyond restoring the originally intended configuration.
>
> Reviewed by Claude for commit `ec1ce8e`.

<!-- /claude-code-review:summary -->
