### PR TITLE
refactor(facets): eliminate *_effective config block shadows

### DIFF
--- a/contexts/_template/facets/addon-database.yaml
+++ b/contexts/_template/facets/addon-database.yaml
@@ -25,7 +25,7 @@ kustomize:
     components:
       - cloudnativepg
       - cloudnativepg/prometheus
-      - "${addons.database.postgres.driver == 'cloudnativepg' && topology_effective == 'ha' ? 'cloudnativepg/ha' : ''}"
+      - "${addons.database.postgres.driver == 'cloudnativepg' && topology == 'ha' ? 'cloudnativepg/ha' : ''}"
 
   # Grafana dashboard patch — only when observability is active.
   - name: observability

--- a/contexts/_template/facets/addon-observability.yaml
+++ b/contexts/_template/facets/addon-observability.yaml
@@ -7,22 +7,24 @@ metadata:
 when: addons.observability.enabled == true
 
 # =============================================================================
-# Config — dashboard backend + logs driver selection
+# Config — dashboard backend default
 # =============================================================================
 #
-# observability_effective holds the resolved choices consumed by the entries
-# below and by other facets (option-cni / option-storage patch dashboards
-# into the observability kustomization when dashboards == 'grafana').
+# Land `addons.observability.dashboards` so other facets (option-cni /
+# option-storage patch dashboards into the observability kustomization when
+# dashboards == 'grafana') can read it directly without re-applying the
+# fallback.
 #
-# dashboards defaults to 'grafana'; logs_driver has no default here — an
-# unset driver means "no external log storage, fluentd aggregator only".
+# logs_driver intentionally has no default — an unset driver means "no
+# external log storage, fluentd aggregator only" — so callers read
+# `addons.observability.logs_driver` straight through.
 #
 config:
 
-  - name: observability_effective
+  - name: addons
     value:
-      dashboards: "${addons.observability.dashboards ?? 'grafana'}"
-      logs_driver: "${addons.observability.logs_driver}"
+      observability:
+        dashboards: "${addons.observability.dashboards ?? 'grafana'}"
 
 # =============================================================================
 # Kustomize — one entry per concern, all patched into `observability`
@@ -51,7 +53,7 @@ kustomize:
   #
   - name: observability
     path: observability
-    when: observability_effective.dashboards == 'grafana'
+    when: addons.observability.dashboards == 'grafana'
     dependsOn:
       - telemetry-base
       - "${dns.enabled ? 'dns' : ''}"
@@ -85,7 +87,7 @@ kustomize:
   #
   - name: observability
     path: observability
-    when: observability_effective.dashboards == 'grafana' && gateway.enabled == true
+    when: addons.observability.dashboards == 'grafana' && gateway.enabled == true
     dependsOn:
       - gateway-resources
     components:
@@ -105,7 +107,7 @@ kustomize:
   # stdout: write logs to container stdout (no external store). Dev default.
   - name: observability
     path: observability
-    when: observability_effective.logs_driver == 'stdout'
+    when: addons.observability.logs_driver == 'stdout'
     dependsOn:
       - telemetry-resources
     components:
@@ -115,7 +117,7 @@ kustomize:
   # (with a PVC for staging). Depends on csi for the staging PVC.
   - name: observability
     path: observability
-    when: observability_effective.logs_driver == 'quickwit'
+    when: addons.observability.logs_driver == 'quickwit'
     dependsOn:
       - csi
       - telemetry-resources
@@ -124,15 +126,15 @@ kustomize:
       - quickwit
       - quickwit/pvc
       - quickwit/prometheus
-      - "${observability_effective.dashboards == 'grafana' ? 'grafana/quickwit' : ''}"
-      - "${observability_effective.dashboards == 'grafana' ? 'grafana/dashboards/logs/quickwit' : ''}"
+      - "${addons.observability.dashboards == 'grafana' ? 'grafana/quickwit' : ''}"
+      - "${addons.observability.dashboards == 'grafana' ? 'grafana/dashboards/logs/quickwit' : ''}"
 
   # Elasticsearch + Kibana. Gated on gateway.enabled because Kibana
   # needs an HTTPRoute to be externally reachable. Depends on csi for ES data
   # PVCs and gateway-resources for the route wiring.
   - name: observability
     path: observability
-    when: observability_effective.logs_driver == 'elasticsearch' && gateway.enabled == true
+    when: addons.observability.logs_driver == 'elasticsearch' && gateway.enabled == true
     dependsOn:
       - csi
       - gateway-resources
@@ -154,7 +156,7 @@ kustomize:
   #
   - name: telemetry-base
     path: telemetry/base
-    when: observability_effective.logs_driver == 'elasticsearch' && gateway.enabled == true
+    when: addons.observability.logs_driver == 'elasticsearch' && gateway.enabled == true
     timeout: 30m
     interval: 10m
     strategy: replace
@@ -165,7 +167,7 @@ kustomize:
 
   - name: telemetry-resources
     path: telemetry/resources
-    when: observability_effective.logs_driver == 'elasticsearch' && gateway.enabled == true
+    when: addons.observability.logs_driver == 'elasticsearch' && gateway.enabled == true
     timeout: 10m
     interval: 5m
     strategy: replace

--- a/contexts/_template/facets/addon-observability.yaml
+++ b/contexts/_template/facets/addon-observability.yaml
@@ -85,12 +85,12 @@ kustomize:
   #
   - name: observability
     path: observability
-    when: observability_effective.dashboards == 'grafana' && gateway_effective.enabled == true
+    when: observability_effective.dashboards == 'grafana' && gateway.enabled == true
     dependsOn:
       - gateway-resources
     components:
       - grafana/gateway
-      - "${gateway_effective.driver == 'envoy' ? 'grafana/dashboards/envoy' : ''}"
+      - "${gateway.driver == 'envoy' ? 'grafana/dashboards/envoy' : ''}"
     substitutions:
       external_domain: "${(dns.public_domain ?? '') == '' ? (dns.private_domain ?? '') : dns.public_domain}"
 
@@ -127,12 +127,12 @@ kustomize:
       - "${observability_effective.dashboards == 'grafana' ? 'grafana/quickwit' : ''}"
       - "${observability_effective.dashboards == 'grafana' ? 'grafana/dashboards/logs/quickwit' : ''}"
 
-  # Elasticsearch + Kibana. Gated on gateway_effective.enabled because Kibana
+  # Elasticsearch + Kibana. Gated on gateway.enabled because Kibana
   # needs an HTTPRoute to be externally reachable. Depends on csi for ES data
   # PVCs and gateway-resources for the route wiring.
   - name: observability
     path: observability
-    when: observability_effective.logs_driver == 'elasticsearch' && gateway_effective.enabled == true
+    when: observability_effective.logs_driver == 'elasticsearch' && gateway.enabled == true
     dependsOn:
       - csi
       - gateway-resources
@@ -154,7 +154,7 @@ kustomize:
   #
   - name: telemetry-base
     path: telemetry/base
-    when: observability_effective.logs_driver == 'elasticsearch' && gateway_effective.enabled == true
+    when: observability_effective.logs_driver == 'elasticsearch' && gateway.enabled == true
     timeout: 30m
     interval: 10m
     strategy: replace
@@ -165,7 +165,7 @@ kustomize:
 
   - name: telemetry-resources
     path: telemetry/resources
-    when: observability_effective.logs_driver == 'elasticsearch' && gateway_effective.enabled == true
+    when: observability_effective.logs_driver == 'elasticsearch' && gateway.enabled == true
     timeout: 10m
     interval: 5m
     strategy: replace

--- a/contexts/_template/facets/addon-private-dns.yaml
+++ b/contexts/_template/facets/addon-private-dns.yaml
@@ -50,13 +50,13 @@ kustomize:
     components:
       - coredns
       - coredns/etcd
-      - "${topology_effective == 'ha' ? 'coredns/ha' : ''}"
+      - "${topology == 'ha' ? 'coredns/ha' : ''}"
       - "${gateway_effective.driver == 'cilium' ? 'coredns/loadbalancer' : ''}"
       - "${gateway_effective.driver == 'cilium' ? 'coredns/cilium' : ''}"
       - "${gateway_effective.driver == 'envoy' && gateway_effective.enabled == true ? 'coredns/gateway' : ''}"
       - external-dns
       - external-dns/providers/coredns
-      - "${topology_effective == 'ha' ? 'external-dns/ha' : ''}"
+      - "${topology == 'ha' ? 'external-dns/ha' : ''}"
       - "${workstation.runtime == 'docker-desktop' ? 'external-dns/localhost' : ''}"
       # Gateway API HTTPRoute source — pulled in only when the cluster has a
       # Gateway controller. external-dns crashes on startup if it's told to

--- a/contexts/_template/facets/addon-private-dns.yaml
+++ b/contexts/_template/facets/addon-private-dns.yaml
@@ -43,7 +43,7 @@ kustomize:
     path: dns
     dependsOn:
       - pki-base
-      - "${gateway_effective.driver == 'cilium' ? 'cni' : (gateway_effective.enabled == true ? 'gateway-base' : '')}"
+      - "${gateway.driver == 'cilium' ? 'cni' : (gateway.enabled == true ? 'gateway-base' : '')}"
       - "${workstation.runtime == 'docker-desktop' ? 'policy-resources' : ''}"
     timeout: 20m
     interval: 5m
@@ -51,9 +51,9 @@ kustomize:
       - coredns
       - coredns/etcd
       - "${topology == 'ha' ? 'coredns/ha' : ''}"
-      - "${gateway_effective.driver == 'cilium' ? 'coredns/loadbalancer' : ''}"
-      - "${gateway_effective.driver == 'cilium' ? 'coredns/cilium' : ''}"
-      - "${gateway_effective.driver == 'envoy' && gateway_effective.enabled == true ? 'coredns/gateway' : ''}"
+      - "${gateway.driver == 'cilium' ? 'coredns/loadbalancer' : ''}"
+      - "${gateway.driver == 'cilium' ? 'coredns/cilium' : ''}"
+      - "${gateway.driver == 'envoy' && gateway.enabled == true ? 'coredns/gateway' : ''}"
       - external-dns
       - external-dns/providers/coredns
       - "${topology == 'ha' ? 'external-dns/ha' : ''}"
@@ -61,7 +61,7 @@ kustomize:
       # Gateway API HTTPRoute source — pulled in only when the cluster has a
       # Gateway controller. external-dns crashes on startup if it's told to
       # watch HTTPRoute resources whose CRDs aren't installed.
-      - "${gateway_effective.enabled == true ? 'external-dns/sources/gateway-httproute' : ''}"
+      - "${gateway.enabled == true ? 'external-dns/sources/gateway-httproute' : ''}"
     substitutions:
       external_domain: ${dns.private_domain}
       loadbalancer_start_ip: ${network.loadbalancer_ips.start}

--- a/contexts/_template/facets/addon-private-dns.yaml
+++ b/contexts/_template/facets/addon-private-dns.yaml
@@ -64,4 +64,4 @@ kustomize:
       - "${gateway_effective.enabled == true ? 'external-dns/sources/gateway-httproute' : ''}"
     substitutions:
       external_domain: ${dns.private_domain}
-      loadbalancer_start_ip: ${network_effective.loadbalancer_ips.start}
+      loadbalancer_start_ip: ${network.loadbalancer_ips.start}

--- a/contexts/_template/facets/config-talos.yaml
+++ b/contexts/_template/facets/config-talos.yaml
@@ -107,7 +107,7 @@ config:
   # terraform variable is needed.
   #
   - name: talos_common
-    when: cni_effective.driver == 'cilium'
+    when: cluster.cni.driver == 'cilium'
     value:
       common_patch:
         cluster:

--- a/contexts/_template/facets/config-talos.yaml
+++ b/contexts/_template/facets/config-talos.yaml
@@ -41,7 +41,7 @@ config:
 
       # topology=single-node implies the control plane must schedule workloads,
       # so flip this on automatically even if the user didn't set schedulable.
-      allowSchedulingOnControlPlanes: "${(cluster.controlplanes.schedulable ?? false) || topology_effective == 'single-node'}"
+      allowSchedulingOnControlPlanes: "${(cluster.controlplanes.schedulable ?? false) || topology == 'single-node'}"
       controlplane_volumes: "${cluster.controlplanes.volumes ?? []}"
       worker_volumes: "${cluster.workers.volumes ?? []}"
       csi_local_volume_path: "${cluster.storage.local_base_path ?? \"/var/mnt/local\"}"
@@ -127,7 +127,7 @@ config:
   # default is off, which lets the DB grow unboundedly).
   #
   - name: talos_common
-    when: topology_effective == 'single-node'
+    when: topology == 'single-node'
     value:
       common_patch:
         cluster:

--- a/contexts/_template/facets/option-cni.yaml
+++ b/contexts/_template/facets/option-cni.yaml
@@ -8,7 +8,7 @@ metadata:
 # Other CNIs (flannel on docker-desktop, managed CNIs on EKS/AKS) skip this
 # facet entirely. The cluster.enabled guard prevents dangling csi→cni
 # dependencies when someone stands up just the workstation services.
-when: cni_effective.driver == 'cilium' && (cluster.enabled ?? true)
+when: cluster.cni.driver == 'cilium' && (cluster.enabled ?? true)
 
 # =============================================================================
 # Terraform — Cilium pre-flight bootstrap
@@ -65,7 +65,7 @@ kustomize:
   # in place when the Cilium gateway controller creates the
   # cilium-gateway-external Service, and the LB IP won't be shared.
   - name: gateway-resources
-    when: gateway_effective.enabled == true && gateway_effective.driver == 'cilium'
+    when: gateway.enabled == true && gateway.driver == 'cilium'
     dependsOn:
       - cni
 
@@ -107,12 +107,12 @@ kustomize:
     path: cni
     when: talos_enabled
     dependsOn:
-      - "${(policies.enabled ?? true) || (gateway_effective.enabled == true && gateway_effective.driver == 'cilium') ? 'policy-resources' : ''}"
+      - "${(policies.enabled ?? true) || (gateway.enabled == true && gateway.driver == 'cilium') ? 'policy-resources' : ''}"
       - "${telemetry_effective.metrics_enabled || telemetry_effective.logs_enabled ? 'telemetry-base' : ''}"
     components:
       - cilium
       - cilium/talos
-      - "${(gateway_effective.enabled == true && gateway_effective.driver == 'cilium') ? 'cilium/gateway' : ''}"
+      - "${(gateway.enabled == true && gateway.driver == 'cilium') ? 'cilium/gateway' : ''}"
       - "${telemetry_effective.metrics_enabled ? 'cilium/prometheus' : ''}"
       - cilium/hubble
       - cilium/l2
@@ -131,11 +131,11 @@ kustomize:
     path: cni
     when: eks_enabled
     dependsOn:
-      - "${(policies.enabled ?? true) || (gateway_effective.enabled == true && gateway_effective.driver == 'cilium') ? 'policy-resources' : ''}"
+      - "${(policies.enabled ?? true) || (gateway.enabled == true && gateway.driver == 'cilium') ? 'policy-resources' : ''}"
       - "${telemetry_effective.metrics_enabled || telemetry_effective.logs_enabled ? 'telemetry-base' : ''}"
     components:
       - cilium
-      - "${(gateway_effective.enabled == true && gateway_effective.driver == 'cilium') ? 'cilium/gateway' : ''}"
+      - "${(gateway.enabled == true && gateway.driver == 'cilium') ? 'cilium/gateway' : ''}"
       - "${telemetry_effective.metrics_enabled ? 'cilium/prometheus' : ''}"
       - cilium/hubble
     substitutions:

--- a/contexts/_template/facets/option-cni.yaml
+++ b/contexts/_template/facets/option-cni.yaml
@@ -38,7 +38,7 @@ terraform:
       # Match the Flux-managed HelmRelease's operator.replicas so `windsor up`
       # re-runs don't flap the deployment between Flux reconciles. Same
       # single-node → 1, else → 2 rule applied by the Flux substitution.
-      operator_replicas: "${topology_effective == 'single-node' ? 1 : 2}"
+      operator_replicas: "${topology == 'single-node' ? 1 : 2}"
   
   - name: gitops
     when: "talos_provisioned"
@@ -121,7 +121,7 @@ kustomize:
       loadbalancer_start_ip: ${network_effective.loadbalancer_ips.start}
       loadbalancer_end_ip: ${network_effective.loadbalancer_ips.end}
       cluster_name: ${context}
-      operator_replicas: "${topology_effective == 'single-node' ? 1 : 2}"
+      operator_replicas: "${topology == 'single-node' ? 1 : 2}"
     timeout: 15m
     interval: 5m
 
@@ -141,6 +141,6 @@ kustomize:
     substitutions:
       k8s_service_host: "${split(split(terraform_output(\"cluster\", \"cluster_endpoint\") ?? \"https://localhost:443\", \"://\")[1], \":\")[0]}"
       cluster_name: ${context}
-      operator_replicas: "${topology_effective == 'single-node' ? 1 : 2}"
+      operator_replicas: "${topology == 'single-node' ? 1 : 2}"
     timeout: 15m
     interval: 5m

--- a/contexts/_template/facets/option-cni.yaml
+++ b/contexts/_template/facets/option-cni.yaml
@@ -118,8 +118,8 @@ kustomize:
       - cilium/l2
     substitutions:
       k8s_service_host: ${talos_common.k8s_service_host}
-      loadbalancer_start_ip: ${network_effective.loadbalancer_ips.start}
-      loadbalancer_end_ip: ${network_effective.loadbalancer_ips.end}
+      loadbalancer_start_ip: ${network.loadbalancer_ips.start}
+      loadbalancer_end_ip: ${network.loadbalancer_ips.end}
       cluster_name: ${context}
       operator_replicas: "${topology == 'single-node' ? 1 : 2}"
     timeout: 15m

--- a/contexts/_template/facets/option-cni.yaml
+++ b/contexts/_template/facets/option-cni.yaml
@@ -79,7 +79,7 @@ kustomize:
   # Add the Cilium dashboards to the observability kustomization when Grafana
   # is the dashboard backend.
   - name: observability
-    when: observability_effective.dashboards == 'grafana'
+    when: addons.observability.dashboards == 'grafana'
     components:
       - grafana/dashboards/cilium
 

--- a/contexts/_template/facets/option-cni.yaml
+++ b/contexts/_template/facets/option-cni.yaml
@@ -108,12 +108,12 @@ kustomize:
     when: talos_enabled
     dependsOn:
       - "${(policies.enabled ?? true) || (gateway.enabled == true && gateway.driver == 'cilium') ? 'policy-resources' : ''}"
-      - "${telemetry_effective.metrics_enabled || telemetry_effective.logs_enabled ? 'telemetry-base' : ''}"
+      - "${telemetry.metrics.enabled || telemetry.logs.enabled ? 'telemetry-base' : ''}"
     components:
       - cilium
       - cilium/talos
       - "${(gateway.enabled == true && gateway.driver == 'cilium') ? 'cilium/gateway' : ''}"
-      - "${telemetry_effective.metrics_enabled ? 'cilium/prometheus' : ''}"
+      - "${telemetry.metrics.enabled ? 'cilium/prometheus' : ''}"
       - cilium/hubble
       - cilium/l2
     substitutions:
@@ -132,11 +132,11 @@ kustomize:
     when: eks_enabled
     dependsOn:
       - "${(policies.enabled ?? true) || (gateway.enabled == true && gateway.driver == 'cilium') ? 'policy-resources' : ''}"
-      - "${telemetry_effective.metrics_enabled || telemetry_effective.logs_enabled ? 'telemetry-base' : ''}"
+      - "${telemetry.metrics.enabled || telemetry.logs.enabled ? 'telemetry-base' : ''}"
     components:
       - cilium
       - "${(gateway.enabled == true && gateway.driver == 'cilium') ? 'cilium/gateway' : ''}"
-      - "${telemetry_effective.metrics_enabled ? 'cilium/prometheus' : ''}"
+      - "${telemetry.metrics.enabled ? 'cilium/prometheus' : ''}"
       - cilium/hubble
     substitutions:
       k8s_service_host: "${split(split(terraform_output(\"cluster\", \"cluster_endpoint\") ?? \"https://localhost:443\", \"://\")[1], \":\")[0]}"

--- a/contexts/_template/facets/option-gateway.yaml
+++ b/contexts/_template/facets/option-gateway.yaml
@@ -25,7 +25,7 @@ config:
 # Kustomize — Gateway API controller + shared Gateway resource
 # =============================================================================
 #
-# gateway_effective (resolved in platform-base) selects the driver: 'envoy' or
+# gateway (resolved in platform-base) selects the driver: 'envoy' or
 # 'cilium'. All downstream facets dependsOn the canonical names `gateway-base`
 # and `gateway-resources` regardless of driver — we emit one variant of each.
 #
@@ -43,16 +43,16 @@ kustomize:
   #
   - name: gateway-base
     path: gateway/base
-    when: gateway_effective.enabled == true && gateway_effective.driver != 'cilium'
+    when: gateway.enabled == true && gateway.driver != 'cilium'
     dependsOn:
       - pki-base
       - "${lb_effective.controller_required ? 'lb-base' : ''}"
     components:
-      - "${gateway_effective.driver}"
-      - "${gateway_effective.driver == 'envoy' ? 'envoy/' + lb_effective.mode : ''}"
-      - "${gateway_effective.driver == 'envoy' && lb_effective.mode == 'nodeport' && (addons.private_dns.enabled ?? (dev == true)) == true ? 'envoy/nodeport/dns' : ''}"
-      - "${gateway_effective.driver == 'envoy' && lb_effective.mode == 'nodeport' && (gitops.mode ?? 'push') == 'push' ? 'envoy/nodeport/flux-webhook' : ''}"
-      - "${gateway_effective.driver == 'envoy' ? 'envoy/prometheus' : ''}"
+      - "${gateway.driver}"
+      - "${gateway.driver == 'envoy' ? 'envoy/' + lb_effective.mode : ''}"
+      - "${gateway.driver == 'envoy' && lb_effective.mode == 'nodeport' && (addons.private_dns.enabled ?? (dev == true)) == true ? 'envoy/nodeport/dns' : ''}"
+      - "${gateway.driver == 'envoy' && lb_effective.mode == 'nodeport' && (gitops.mode ?? 'push') == 'push' ? 'envoy/nodeport/flux-webhook' : ''}"
+      - "${gateway.driver == 'envoy' ? 'envoy/prometheus' : ''}"
     timeout: 10m
     interval: 5m
 
@@ -61,7 +61,7 @@ kustomize:
   # component). The Cilium HelmRelease is owned by option-cni.
   - name: gateway-base
     path: gateway/base
-    when: gateway_effective.enabled == true && gateway_effective.driver == 'cilium'
+    when: gateway.enabled == true && gateway.driver == 'cilium'
     dependsOn:
       - pki-base
       - "${lb_effective.controller_required ? 'lb-base' : ''}"
@@ -80,7 +80,7 @@ kustomize:
   # and never initializes the Gateway controller.
   #
   - name: cni
-    when: gateway_effective.enabled == true && gateway_effective.driver == 'cilium'
+    when: gateway.enabled == true && gateway.driver == 'cilium'
     dependsOn:
       - gateway-base
 
@@ -105,29 +105,29 @@ kustomize:
   #
   - name: gateway-resources
     path: gateway/resources
-    when: gateway_effective.enabled == true
+    when: gateway.enabled == true
     dependsOn:
       - gateway-base
       - "${dns.enabled ? 'dns' : ''}"
       - "${lb_effective.controller_required ? 'lb-base' : ''}"
     components:
-      - "${gateway_effective.driver == 'cilium' ? 'cilium' : ''}"
+      - "${gateway.driver == 'cilium' ? 'cilium' : ''}"
       # Catch-all 404 served by Envoy's directResponse — covers any
       # request that doesn't match a real app's HTTPRoute. Envoy-only:
       # uses the gateway.envoyproxy.io HTTPRouteFilter CRD, which
       # cilium clusters don't ship.
-      - "${gateway_effective.driver != 'cilium' ? 'envoy/default-404' : ''}"
+      - "${gateway.driver != 'cilium' ? 'envoy/default-404' : ''}"
       # external-dns hostname annotation on the 404 route. Fires whenever a
       # gateway-managed DNS zone exists — the public zone (dns.public_domain)
       # for the default public path, or the private zone (dns.private_domain)
       # when gateway.access=private. Skipped when neither applies so the
       # substitution doesn't render a malformed ",*." value.
-      - "${gateway_effective.driver != 'cilium' && ((dns.public_domain ?? '') != '' || (gateway.access == 'private' && (dns.private_domain ?? '') != '')) ? 'envoy/default-404/external-dns' : ''}"
-      - "${gateway_effective.driver != 'cilium' && (addons.private_dns.enabled ?? (dev == true)) == true ? 'dns' : ''}"
+      - "${gateway.driver != 'cilium' && ((dns.public_domain ?? '') != '' || (gateway.access == 'private' && (dns.private_domain ?? '') != '')) ? 'envoy/default-404/external-dns' : ''}"
+      - "${gateway.driver != 'cilium' && (addons.private_dns.enabled ?? (dev == true)) == true ? 'dns' : ''}"
       - "${lb_effective.enabled == true ? 'lb-address' : ''}"
       - "${(gitops.mode ?? 'push') == 'push' ? 'flux-webhook' : ''}"
     substitutions:
-      gateway_class_name: ${gateway_effective.driver}
+      gateway_class_name: ${gateway.driver}
       gateway_dns_target: "${lb_effective.enabled == true ? network.loadbalancer_ips.start : ''}"
       # Cert SAN domain.
       # - access=private (with dns.private_domain set): gateway is reachable
@@ -162,6 +162,6 @@ kustomize:
       # Only emitted when a consumer is active: the lb-address patch (in-cluster
       # LB) or the cilium gateway component. NodePort/cloud-managed-LB paths
       # have no consumer, so leave it empty and the harness drops it.
-      loadbalancer_start_ip: "${(lb_effective.enabled == true || gateway_effective.driver == 'cilium') ? network.loadbalancer_ips.start : ''}"
+      loadbalancer_start_ip: "${(lb_effective.enabled == true || gateway.driver == 'cilium') ? network.loadbalancer_ips.start : ''}"
     timeout: 10m
     interval: 5m

--- a/contexts/_template/facets/option-gateway.yaml
+++ b/contexts/_template/facets/option-gateway.yaml
@@ -128,7 +128,7 @@ kustomize:
       - "${(gitops.mode ?? 'push') == 'push' ? 'flux-webhook' : ''}"
     substitutions:
       gateway_class_name: ${gateway_effective.driver}
-      gateway_dns_target: "${lb_effective.enabled == true ? network_effective.loadbalancer_ips.start : ''}"
+      gateway_dns_target: "${lb_effective.enabled == true ? network.loadbalancer_ips.start : ''}"
       # Cert SAN domain.
       # - access=private (with dns.private_domain set): gateway is reachable
       #   only inside the VPC, so the cert covers the private domain (the
@@ -162,6 +162,6 @@ kustomize:
       # Only emitted when a consumer is active: the lb-address patch (in-cluster
       # LB) or the cilium gateway component. NodePort/cloud-managed-LB paths
       # have no consumer, so leave it empty and the harness drops it.
-      loadbalancer_start_ip: "${(lb_effective.enabled == true || gateway_effective.driver == 'cilium') ? network_effective.loadbalancer_ips.start : ''}"
+      loadbalancer_start_ip: "${(lb_effective.enabled == true || gateway_effective.driver == 'cilium') ? network.loadbalancer_ips.start : ''}"
     timeout: 10m
     interval: 5m

--- a/contexts/_template/facets/option-single-node.yaml
+++ b/contexts/_template/facets/option-single-node.yaml
@@ -4,7 +4,7 @@ metadata:
   name: single-node
   description: Reduce control-plane chatter on single-node topologies
 
-when: topology_effective == 'single-node'
+when: topology == 'single-node'
 
 # =============================================================================
 # Single-node control-plane hardening

--- a/contexts/_template/facets/option-storage.yaml
+++ b/contexts/_template/facets/option-storage.yaml
@@ -37,7 +37,7 @@ terraform:
     path: cluster/talos/extensions
     dependsOn:
       - cluster
-      - "${cni_effective.driver == 'cilium' ? 'cni' : ''}"
+      - "${cluster.cni.driver == 'cilium' ? 'cni' : ''}"
     parallelism: 1
     inputs:
       talos_version: ${talos.talos_version}

--- a/contexts/_template/facets/option-storage.yaml
+++ b/contexts/_template/facets/option-storage.yaml
@@ -98,7 +98,7 @@ kustomize:
     when: talos_common.storage_driver == 'longhorn'
     dependsOn:
       - "${(policies.enabled ?? true) ? 'policy-resources' : ''}"
-      - "${telemetry_effective.metrics_enabled || telemetry_effective.logs_enabled ? 'telemetry-base' : ''}"
+      - "${telemetry.metrics.enabled || telemetry.logs.enabled ? 'telemetry-base' : ''}"
     components:
       - longhorn
       - "${((cluster.controlplanes.schedulable ?? false) || topology == 'single-node') ? 'longhorn/single-node' : ''}"

--- a/contexts/_template/facets/option-storage.yaml
+++ b/contexts/_template/facets/option-storage.yaml
@@ -101,8 +101,8 @@ kustomize:
       - "${telemetry_effective.metrics_enabled || telemetry_effective.logs_enabled ? 'telemetry-base' : ''}"
     components:
       - longhorn
-      - "${((cluster.controlplanes.schedulable ?? false) || topology_effective == 'single-node') ? 'longhorn/single-node' : ''}"
-      - "${topology_effective == 'ha' ? 'longhorn/ha' : ''}"
+      - "${((cluster.controlplanes.schedulable ?? false) || topology == 'single-node') ? 'longhorn/single-node' : ''}"
+      - "${topology == 'ha' ? 'longhorn/ha' : ''}"
       - "${addons.observability.enabled == true ? 'longhorn/prometheus' : ''}"
     timeout: 20m
     interval: 5m

--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -212,13 +212,13 @@ terraform:
       runtime: 'docker-desktop'
       domain_name: ${dns.private_domain}
       network_name: windsor-${context}
-      network_cidr: ${network_effective.cidr_block}
-      dns_forward_target: "${cidrhost(network_effective.cidr_block, 10) + \":30053\"}"
-      webhook_host: "${cidrhost(network_effective.cidr_block, 10)}"
+      network_cidr: ${network.cidr_block}
+      dns_forward_target: "${cidrhost(network.cidr_block, 10) + \":30053\"}"
+      webhook_host: "${cidrhost(network.cidr_block, 10)}"
       webhook_port: 30292
       webhook_enabled: "${(workstation.git.livereload ?? false) && ((gitops.mode ?? 'push') == 'push')}"
       webhook_token: "${(workstation.git.livereload ?? false) ? (gitops.webhook.token ?? 'abcdef123456') : ''}"
-      primary_node_ip: "${cidrhost(network_effective.cidr_block, 10)}"
+      primary_node_ip: "${cidrhost(network.cidr_block, 10)}"
       enable_dns: ${workstation.services.dns ?? true}
       enable_git: ${workstation.services.git ?? true}
       registries: ${workstation_registries.registries ?? {}}
@@ -235,13 +235,13 @@ terraform:
         ${workstation.runtime == "docker" ? "linux" : (workstation.runtime ?? "linux")}
       domain_name: ${dns.private_domain}
       network_name: windsor-${context}
-      network_cidr: ${network_effective.cidr_block}
-      dns_forward_target: ${network_effective.loadbalancer_ips.start}
-      webhook_host: ${network_effective.loadbalancer_ips.start}
+      network_cidr: ${network.cidr_block}
+      dns_forward_target: ${network.loadbalancer_ips.start}
+      webhook_host: ${network.loadbalancer_ips.start}
       webhook_port: "${gateway_effective.enabled == true ? 80 : 9292}"
       webhook_enabled: "${(workstation.git.livereload ?? false) && ((gitops.mode ?? 'push') == 'push')}"
       webhook_token: "${(workstation.git.livereload ?? false) ? (gitops.webhook.token ?? 'abcdef123456') : ''}"
-      primary_node_ip: ${network_effective.loadbalancer_ips.start}
+      primary_node_ip: ${network.loadbalancer_ips.start}
       enable_dns: ${workstation.services.dns ?? true}
       enable_git: ${workstation.services.git ?? true}
       registries: ${workstation_registries.registries ?? {}}
@@ -255,13 +255,13 @@ terraform:
       domain_name: ${dns.private_domain}
       network_name: "${(workstation.runtime ?? '') == 'colima' ? 'incusbr0' : ''}"
       create_network: "${(workstation.runtime ?? '') != 'colima'}"
-      network_cidr: ${network_effective.cidr_block}
-      loadbalancer_start_ip: ${network_effective.loadbalancer_ips.start}
-      dns_forward_target: ${network_effective.loadbalancer_ips.start}
-      webhook_host: ${network_effective.loadbalancer_ips.start}
+      network_cidr: ${network.cidr_block}
+      loadbalancer_start_ip: ${network.loadbalancer_ips.start}
+      dns_forward_target: ${network.loadbalancer_ips.start}
+      webhook_host: ${network.loadbalancer_ips.start}
       webhook_port: 9292
       webhook_enabled: "${(workstation.git.livereload ?? false) && ((gitops.mode ?? 'push') == 'push')}"
-      primary_node_ip: ${network_effective.loadbalancer_ips.start}
+      primary_node_ip: ${network.loadbalancer_ips.start}
       enable_dns: ${workstation.services.dns ?? true}
       enable_git: ${workstation.services.git ?? true}
       registries: ${workstation_registries.registries ?? {}}
@@ -293,7 +293,7 @@ terraform:
         - name: controlplane
           role: controlplane
           count: ${cluster.controlplanes.count ?? 1}
-          ipv4: ${cidrhost(network_effective.cidr_block, 10)}
+          ipv4: ${cidrhost(network.cidr_block, 10)}
           image: ${cluster.controlplanes.image ?? talos.incus_image}
           type: virtual-machine
           description: Talos control plane node
@@ -310,7 +310,7 @@ terraform:
         - name: worker
           role: worker
           count: ${cluster.workers.count ?? 0}
-          ipv4: ${cidrhost(network_effective.cidr_block, 20)}
+          ipv4: ${cidrhost(network.cidr_block, 20)}
           image: ${cluster.workers.image ?? talos.incus_image}
           type: virtual-machine
           description: Talos worker node

--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -140,10 +140,11 @@ config:
   # and pair it with kube-vip so LoadBalancer services still get an IP
   # (flannel has no built-in L2 announcer like Cilium does).
   #
-  - name: cni_effective
+  - name: cluster
     when: platform == 'incus' && workstation.runtime == 'colima'
     value:
-      driver: "${cluster.cni.driver ?? 'flannel'}"
+      cni:
+        driver: "${cluster.cni.driver ?? 'flannel'}"
 
   - name: lb_effective
     when: platform == 'incus' && workstation.runtime == 'colima'
@@ -238,7 +239,7 @@ terraform:
       network_cidr: ${network.cidr_block}
       dns_forward_target: ${network.loadbalancer_ips.start}
       webhook_host: ${network.loadbalancer_ips.start}
-      webhook_port: "${gateway_effective.enabled == true ? 80 : 9292}"
+      webhook_port: "${gateway.enabled == true ? 80 : 9292}"
       webhook_enabled: "${(workstation.git.livereload ?? false) && ((gitops.mode ?? 'push') == 'push')}"
       webhook_token: "${(workstation.git.livereload ?? false) ? (gitops.webhook.token ?? 'abcdef123456') : ''}"
       primary_node_ip: ${network.loadbalancer_ips.start}
@@ -413,6 +414,6 @@ kustomize:
   # Override gateway_dns_target so external-dns advertises 127.0.0.1 — reached
   # via the host-port mapping on the Talos container.
   - name: gateway-resources
-    when: "platform == 'docker' && workstation.runtime == 'docker-desktop' && gateway_effective.enabled == true"
+    when: "platform == 'docker' && workstation.runtime == 'docker-desktop' && gateway.enabled == true"
     substitutions:
       gateway_dns_target: "127.0.0.1"

--- a/contexts/_template/facets/platform-aws.yaml
+++ b/contexts/_template/facets/platform-aws.yaml
@@ -116,7 +116,7 @@ terraform:
   # omits the privileged/cgroup_auto_mount overrides the Talos path uses.
   #
   - name: cni
-    when: "cni_effective.driver == 'cilium'"
+    when: "cluster.cni.driver == 'cilium'"
     path: cni/cilium
     dependsOn:
       - cluster
@@ -134,7 +134,7 @@ terraform:
   # With Cilium: wait for the `cni` step so pod networking is healthy first.
   #
   - name: gitops
-    when: "cni_effective.driver != 'cilium'"
+    when: "cluster.cni.driver != 'cilium'"
     path: gitops/flux
     dependsOn:
       - cluster
@@ -143,7 +143,7 @@ terraform:
     destroy: false
 
   - name: gitops
-    when: "cni_effective.driver == 'cilium'"
+    when: "cluster.cni.driver == 'cilium'"
     path: gitops/flux
     dependsOn:
       - cluster
@@ -232,7 +232,7 @@ kustomize:
   # add `kubernetes.io/ingress.class: alb` on a per-Ingress basis.
   #
   - name: gateway-base
-    when: "gateway_effective.enabled == true && gateway_effective.driver == 'envoy' && lb_effective.mode == 'loadbalancer'"
+    when: "gateway.enabled == true && gateway.driver == 'envoy' && lb_effective.mode == 'loadbalancer'"
     components:
       - envoy/loadbalancer/aws-nlb
     substitutions:
@@ -327,7 +327,7 @@ kustomize:
       # the gateway is on, external-dns is configured with the gateway-httproute
       # source below — without the CRDs present at startup it crash-loops on
       # "no matches for kind HTTPRoute". Wait for gateway-base to finish.
-      - "${gateway_effective.enabled == true ? 'gateway-base' : ''}"
+      - "${gateway.enabled == true ? 'gateway-base' : ''}"
     components:
       - external-dns
       - external-dns/providers/route53
@@ -335,7 +335,7 @@ kustomize:
       # actually running. Without this guard, deployments that set
       # dns.public_domain but disable the gateway would crash external-dns
       # at startup (HTTPRoute CRDs aren't installed without gateway-base).
-      - "${gateway_effective.enabled == true ? 'external-dns/sources/gateway-httproute' : ''}"
+      - "${gateway.enabled == true ? 'external-dns/sources/gateway-httproute' : ''}"
     timeout: 5m
     interval: 5m
     substitutions:

--- a/contexts/_template/facets/platform-aws.yaml
+++ b/contexts/_template/facets/platform-aws.yaml
@@ -43,7 +43,7 @@ terraform:
     dependsOn:
       - backend
     inputs:
-      cidr_block: ${network_effective.cidr_block}
+      cidr_block: ${network.cidr_block}
       domain_name: ${dns.private_domain ?? ""}
 
   # Public Route53 zone — provisioned when the operator sets dns.public_domain.

--- a/contexts/_template/facets/platform-azure.yaml
+++ b/contexts/_template/facets/platform-azure.yaml
@@ -10,10 +10,15 @@ when: platform == 'azure'
 # Config — platform-specific overrides
 # =============================================================================
 #
-# The AKS-specific opt-out of our metrics-server copy is wired into
-# platform-base's telemetry-resources kustomization via an inline
-# `platform != 'azure'` guard. No telemetry config block needed here.
+# AKS ships metrics-server as a built-in add-on, so we suppress the copy
+# platform-base would otherwise add to telemetry-resources (two instances
+# would fight on the same APIService).
 #
+config:
+
+  - name: metrics_server_enabled
+    value: false
+
 # =============================================================================
 # Terraform — AzureRM state backend, VNet, AKS, optional public DNS zone
 # =============================================================================

--- a/contexts/_template/facets/platform-azure.yaml
+++ b/contexts/_template/facets/platform-azure.yaml
@@ -16,8 +16,9 @@ when: platform == 'azure'
 #
 config:
 
-  - name: metrics_server_enabled
-    value: false
+  - name: telemetry
+    value:
+      metrics_server_enabled: false
 
 # =============================================================================
 # Terraform — AzureRM state backend, VNet, AKS, optional public DNS zone

--- a/contexts/_template/facets/platform-azure.yaml
+++ b/contexts/_template/facets/platform-azure.yaml
@@ -10,19 +10,10 @@ when: platform == 'azure'
 # Config — platform-specific overrides
 # =============================================================================
 #
-# AKS ships metrics-server as a managed add-on, so we suppress the copy that
-# platform-base would otherwise add to telemetry-resources (two instances
-# would fight on the same APIService). The flag is layered onto the base
-# `telemetry_effective` config block via Windsor's deep-merge semantics —
-# only metrics_server_enabled is overridden, the rest of the field set
-# (metrics_enabled, logs_enabled, logs_driver) keeps platform-base's values.
+# The AKS-specific opt-out of our metrics-server copy is wired into
+# platform-base's telemetry-resources kustomization via an inline
+# `platform != 'azure'` guard. No telemetry config block needed here.
 #
-config:
-
-  - name: telemetry_effective
-    value:
-      metrics_server_enabled: false
-
 # =============================================================================
 # Terraform — AzureRM state backend, VNet, AKS, optional public DNS zone
 # =============================================================================

--- a/contexts/_template/facets/platform-azure.yaml
+++ b/contexts/_template/facets/platform-azure.yaml
@@ -66,7 +66,7 @@ terraform:
     dependsOn:
       - backend
     inputs:
-      vnet_cidr: ${network_effective.cidr_block}
+      vnet_cidr: ${network.cidr_block}
       domain_name: ${dns.private_domain ?? ""}
 
   # Public Azure DNS zone — provisioned when the operator sets dns.public_domain.

--- a/contexts/_template/facets/platform-azure.yaml
+++ b/contexts/_template/facets/platform-azure.yaml
@@ -246,11 +246,11 @@ kustomize:
       # the gateway is on, external-dns is configured with the gateway-httproute
       # source below — without the CRDs present at startup it crash-loops on
       # "no matches for kind HTTPRoute". Wait for gateway-base to finish.
-      - "${gateway_effective.enabled == true ? 'gateway-base' : ''}"
+      - "${gateway.enabled == true ? 'gateway-base' : ''}"
     components:
       - external-dns
       - external-dns/providers/azure
-      - "${gateway_effective.enabled == true ? 'external-dns/sources/gateway-httproute' : ''}"
+      - "${gateway.enabled == true ? 'external-dns/sources/gateway-httproute' : ''}"
     timeout: 5m
     interval: 5m
     substitutions:
@@ -306,6 +306,6 @@ kustomize:
   # internal LB would have no zone to publish to.
   #
   - name: gateway-base
-    when: "gateway_effective.enabled == true && gateway_effective.driver == 'envoy' && lb_effective.mode == 'loadbalancer'"
+    when: "gateway.enabled == true && gateway.driver == 'envoy' && lb_effective.mode == 'loadbalancer'"
     components:
       - "${gateway.access == 'private' && (dns.private_domain ?? '') != '' ? 'envoy/loadbalancer/azure-lb-internal' : ''}"

--- a/contexts/_template/facets/platform-base.yaml
+++ b/contexts/_template/facets/platform-base.yaml
@@ -332,8 +332,9 @@ config:
   # that ship metrics-server as a built-in add-on (AKS, future GKE)
   # override to false in their own facet to avoid two instances fighting
   # on the same APIService.
-  - name: metrics_server_enabled
-    value: true
+  - name: telemetry
+    value:
+      metrics_server_enabled: true
 
 # =============================================================================
 # Global substitutions
@@ -469,7 +470,7 @@ kustomize:
     dependsOn:
       - telemetry-base
     components:
-      - "${telemetry.metrics.enabled && metrics_server_enabled ? 'metrics-server' : ''}"
+      - "${telemetry.metrics.enabled && telemetry.metrics_server_enabled ? 'metrics-server' : ''}"
       - "${telemetry.metrics.enabled ? 'prometheus' : ''}"
       - "${telemetry.metrics.enabled ? 'prometheus/flux' : ''}"
       - "${telemetry.logs.enabled ? 'fluentbit' : ''}"

--- a/contexts/_template/facets/platform-base.yaml
+++ b/contexts/_template/facets/platform-base.yaml
@@ -253,21 +253,35 @@ config:
       }
 
   # ---------------------------------------------------------------------------
-  # Network effective values
+  # Network defaults
   # ---------------------------------------------------------------------------
   #
-  # Compute loadbalancer IP range from the CIDR when the user doesn't supply
-  # one. Offsets 266/356 place the range well inside a /16 and clear of the
-  # first 256 addresses reserved for nodes/services.
+  # Populate user-facing `network.*` fields so downstream facets can read
+  # `network.cidr_block` / `network.loadbalancer_ips.*` directly without
+  # re-applying the fallback chain.
   #
-  - name: network_cidr_effective
-    value: "${network.cidr_block ?? '10.5.0.0/16'}"
-  - name: network_effective
+  # Each entry uses `when:` (evaluated against user input only) instead of
+  # the self-referencing `${network.X ?? default}` pattern in `value:`. The
+  # engine stores config-block bodies unevaluated in globalScope and
+  # iterates blocks in last-writer order; a self-referencing template can
+  # be read as the literal template string by a config block in another
+  # facet that evaluates earlier in the round. Conditional writes only
+  # contribute literal values, so cross-block reads always see real data.
+  #
+  - name: network
+    when: (network.cidr_block ?? '') == ''
     value:
-      cidr_block: "${network_cidr_effective}"
+      cidr_block: '10.5.0.0/16'
+  - name: network
+    when: (network.loadbalancer_ips.start ?? '') == ''
+    value:
       loadbalancer_ips:
-        start: "${network.loadbalancer_ips.start ?? cidrhost(network_cidr_effective, 266)}"
-        end: "${network.loadbalancer_ips.end ?? cidrhost(network_cidr_effective, 356)}"
+        start: "${cidrhost(network.cidr_block ?? '10.5.0.0/16', 266)}"
+  - name: network
+    when: (network.loadbalancer_ips.end ?? '') == ''
+    value:
+      loadbalancer_ips:
+        end: "${cidrhost(network.cidr_block ?? '10.5.0.0/16', 356)}"
 
   # ---------------------------------------------------------------------------
   # Telemetry driver

--- a/contexts/_template/facets/platform-base.yaml
+++ b/contexts/_template/facets/platform-base.yaml
@@ -321,6 +321,13 @@ config:
       logs:
         driver: none
 
+  # Default-on opt-out for our metrics-server copy. Managed-K8s platforms
+  # that ship metrics-server as a built-in add-on (AKS, future GKE)
+  # override to false in their own facet to avoid two instances fighting
+  # on the same APIService.
+  - name: metrics_server_enabled
+    value: true
+
 # =============================================================================
 # Global substitutions
 # =============================================================================
@@ -455,9 +462,7 @@ kustomize:
     dependsOn:
       - telemetry-base
     components:
-      # AKS ships metrics-server as a built-in add-on; skip our copy on Azure
-      # to avoid two instances fighting on the same APIService.
-      - "${telemetry.metrics.enabled && platform != 'azure' ? 'metrics-server' : ''}"
+      - "${telemetry.metrics.enabled && metrics_server_enabled ? 'metrics-server' : ''}"
       - "${telemetry.metrics.enabled ? 'prometheus' : ''}"
       - "${telemetry.metrics.enabled ? 'prometheus/flux' : ''}"
       - "${telemetry.logs.enabled ? 'fluentbit' : ''}"

--- a/contexts/_template/facets/platform-base.yaml
+++ b/contexts/_template/facets/platform-base.yaml
@@ -88,7 +88,14 @@ config:
   - name: gateway
     value:
       enabled: ${gateway.enabled ?? ingress.enabled ?? true}
-      driver: "${gateway.driver ?? (ingress.driver == 'envoy-gateway' || ingress.driver == 'nginx' ? 'envoy' : ingress.driver) ?? (workstation.runtime == 'docker-desktop' || platform == 'aws' ? 'envoy' : (cluster.cni.driver == 'cilium' ? 'cilium' : 'envoy'))}"
+      driver: |-
+        ${gateway.driver
+          ?? (ingress.driver == 'envoy-gateway' || ingress.driver == 'nginx'
+              ? 'envoy'
+              : ingress.driver)
+          ?? (workstation.runtime == 'docker-desktop' || platform == 'aws'
+              ? 'envoy'
+              : (cluster.cni.driver == 'cilium' ? 'cilium' : 'envoy'))}
 
   # ---------------------------------------------------------------------------
   # Load balancer selection

--- a/contexts/_template/facets/platform-base.yaml
+++ b/contexts/_template/facets/platform-base.yaml
@@ -17,8 +17,8 @@ when: (platform ?? provider) != 'none'
 # they do not re-derive or override them.
 #
 # Evaluation order matters: later entries may reference earlier ones. Keep
-# dependent values below their dependencies (e.g. gateway_effective reads
-# cni_effective, so cni_effective must come first).
+# dependent values below their dependencies (e.g. the gateway block reads
+# cluster.cni.driver, so the cluster block must come first).
 #
 config:
 
@@ -40,42 +40,37 @@ config:
       runtime: "${workstation.runtime ?? ''}"
 
   # ---------------------------------------------------------------------------
-  # Cluster driver (platform-implied default)
+  # Cluster driver and CNI (platform-implied defaults)
   # ---------------------------------------------------------------------------
   #
-  # Managed clouds imply their managed driver: aws → eks, azure → aks. Every
-  # other platform (metal, incus, docker, workstation-only) defaults to talos.
-  # Computed here in platform-base, before `cni_effective` / `talos_provisioned`
-  # / `eks_enabled` are derived, so downstream `when:` guards (option-cni,
-  # option-storage, config-talos, the per-platform facets) all see the
-  # platform-correct driver without needing their own fallbacks. An explicit
+  # cluster.driver — managed clouds imply their managed driver (aws → eks,
+  # azure → aks); everything else defaults to talos. An explicit
   # `cluster.driver` in values.yaml always wins.
+  #
+  # cluster.cni.driver — Talos defaults to Cilium (standard L2/BGP + Gateway
+  # API stack); managed clouds leave it empty so option-cni stays out unless
+  # Cilium is explicitly requested. cluster.driver is re-derived inline
+  # because sibling fields in the same block evaluate against user input,
+  # not the just-computed `driver` value.
   #
   - name: cluster
     value:
       driver: "${cluster.driver ?? (platform == 'aws' ? 'eks' : (platform == 'azure' ? 'aks' : 'talos'))}"
-
-  # ---------------------------------------------------------------------------
-  # CNI driver selection
-  # ---------------------------------------------------------------------------
-  #
-  # Default rules:
-  #   - Explicit cluster.cni.driver always wins.
-  #   - Talos defaults to Cilium (our standard L2/BGP + Gateway API stack).
-  #   - Managed clusters (EKS, AKS) use their own CNI; leave empty so option-cni
-  #     does not activate unless cilium is explicitly requested.
-  #
-  - name: cni_effective
-    value:
-      driver: "${cluster.cni.driver ?? (cluster.driver == 'talos' ? 'cilium' : '')}"
+      cni:
+        driver: "${cluster.cni.driver ?? ((cluster.driver ?? (platform == 'aws' ? 'eks' : (platform == 'azure' ? 'aks' : 'talos'))) == 'talos' ? 'cilium' : '')}"
 
   # Docker Desktop override: its API server is reachable only via a localhost
-  # tunnel, which Cilium's eBPF bootstrap cannot use. Fall back to the built-in
-  # flannel CNI (no bootstrap required).
-  - name: cni_effective
+  # tunnel, which Cilium's eBPF bootstrap can't use. Fall back to the built-in
+  # flannel CNI. Split into a `when:`-gated entry rather than an inline
+  # branch on workstation.runtime because option-workstation re-positions
+  # the `workstation` block to the end of evaluation order, leaving
+  # workstation.runtime as an unevaluated template at the time the cluster
+  # block evaluates.
+  - name: cluster
     when: workstation.runtime == 'docker-desktop'
     value:
-      driver: "${cluster.cni.driver ?? 'flannel'}"
+      cni:
+        driver: "${cluster.cni.driver ?? 'flannel'}"
 
   # ---------------------------------------------------------------------------
   # Gateway driver selection
@@ -90,10 +85,10 @@ config:
   #        - Otherwise, use cilium when it is the CNI (native Gateway API),
   #          else envoy.
   #
-  - name: gateway_effective
+  - name: gateway
     value:
       enabled: ${gateway.enabled ?? ingress.enabled ?? true}
-      driver: "${gateway.driver ?? (ingress.driver == 'envoy-gateway' || ingress.driver == 'nginx' ? 'envoy' : ingress.driver) ?? (workstation.runtime == 'docker-desktop' || platform == 'aws' ? 'envoy' : (cni_effective.driver == 'cilium' ? 'cilium' : 'envoy'))}"
+      driver: "${gateway.driver ?? (ingress.driver == 'envoy-gateway' || ingress.driver == 'nginx' ? 'envoy' : ingress.driver) ?? (workstation.runtime == 'docker-desktop' || platform == 'aws' ? 'envoy' : (cluster.cni.driver == 'cilium' ? 'cilium' : 'envoy'))}"
 
   # ---------------------------------------------------------------------------
   # Load balancer selection
@@ -108,7 +103,7 @@ config:
   #
   - name: lb_effective
     value:
-      enabled: "${cni_effective.driver != 'cilium' && (network.loadbalancer_driver ?? '') != ''}"
+      enabled: "${cluster.cni.driver != 'cilium' && (network.loadbalancer_driver ?? '') != ''}"
       driver: "${network.loadbalancer_driver ?? 'kube-vip'}"
       mode: loadbalancer
 
@@ -499,7 +494,7 @@ kustomize:
   # Exposes a Flux webhook for immediate source reconciliation (push-driven
   # instead of polling). Two variants:
   #
-  #   1. No Gateway API: plain HTTP webhook. Used when gateway_effective is
+  #   1. No Gateway API: plain HTTP webhook. Used when gateway is
   #      disabled (e.g. cluster.enabled=false with only workstation services).
   #
   #   2. With Gateway API: webhook + HTTPRoute on the port-80 listener. Works
@@ -510,7 +505,7 @@ kustomize:
   #
   - name: gitops
     path: gitops/flux
-    when: (gitops.mode ?? 'push') == 'push' && gateway_effective.enabled != true
+    when: (gitops.mode ?? 'push') == 'push' && gateway.enabled != true
     components:
       - webhook
     substitutions:
@@ -518,12 +513,12 @@ kustomize:
 
   - name: gitops
     path: gitops/flux
-    when: (gitops.mode ?? 'push') == 'push' && gateway_effective.enabled == true
+    when: (gitops.mode ?? 'push') == 'push' && gateway.enabled == true
     dependsOn:
       - gateway-base
     components:
       - webhook
       - webhook/gateway
-      - "${gateway_effective.driver == 'cilium' ? 'webhook/gateway/cilium' : ''}"
+      - "${gateway.driver == 'cilium' ? 'webhook/gateway/cilium' : ''}"
     substitutions:
       git_repository_name: ${gitops.repository.name ?? "local"}

--- a/contexts/_template/facets/platform-base.yaml
+++ b/contexts/_template/facets/platform-base.yaml
@@ -212,39 +212,45 @@ config:
   # Topology
   # ---------------------------------------------------------------------------
   #
-  # Effective node counts: `count` wins when set (matches platform-docker/incus
-  # which use `count` as the authoritative sizing signal), otherwise fall back
-  # to the declared `nodes` map length.
-  #
-  # Topology is declared differently depending on whether the platform gives
-  # us a node layout to read:
+  # Resolves the user-facing `topology` field to a concrete value so downstream
+  # facets can read `${topology}` directly without re-implementing the fallback
+  # chain. Explicit `topology` always wins. Otherwise:
   #
   #   - Layout declared (metal, incus, docker-compose-style): derive from
-  #     effective counts — `count` wins when set, otherwise fall back to
-  #     the declared `nodes` map length. 1 total node → single-node;
-  #     3+ control planes → ha; otherwise multi-node.
+  #     effective node counts — `count` wins when set, otherwise fall back to
+  #     `len(nodes)`. 1 total → single-node; 3+ CPs → ha; else multi-node.
   #
-  #   - Workstation runtime with no layout declared (colima, docker-desktop):
-  #     platform implicitly provisions 1 CP, so default to single-node.
+  #   - Workstation runtime with no layout (colima, docker-desktop): platform
+  #     implicitly provisions 1 CP, so default to single-node.
   #
-  #   - Cloud platforms (EKS, AKS) with no layout: explicit `topology` drives.
-  #     Defaults to schema default 'multi-node'.
+  #   - Otherwise (cloud platforms with no layout): multi-node.
   #
-  #   - Explicit `topology` always wins when set. Preserves test overrides
-  #     and the rare case where desired behavior diverges from physical layout.
+  # Written as a single expression because writing the result back to
+  # `topology` itself means later entries can't read the original user input —
+  # they'd see whatever the previous entry set. Inlining the count expressions
+  # also avoids the engine's spotty support for cross-entry helper visibility
+  # in `when:` clauses.
   #
-  # The count expressions are inlined (rather than captured in helper config
-  # values) because intermediate config values in the same facet are not
-  # reliably visible to later `when:` clauses in the engine.
-  #
-  - name: topology_effective
-    value: "${topology ?? 'multi-node'}"
-  - name: topology_effective
-    when: "((cluster.controlplanes.count ?? len(cluster.controlplanes.nodes ?? {})) + (cluster.workers.count ?? len(cluster.workers.nodes ?? {}))) > 0"
-    value: "${topology ?? (((cluster.controlplanes.count ?? len(cluster.controlplanes.nodes ?? {})) + (cluster.workers.count ?? len(cluster.workers.nodes ?? {}))) == 1 ? 'single-node' : (cluster.controlplanes.count ?? len(cluster.controlplanes.nodes ?? {})) >= 3 ? 'ha' : 'multi-node')}"
-  - name: topology_effective
-    when: "workstation.runtime != '' && ((cluster.controlplanes.count ?? len(cluster.controlplanes.nodes ?? {})) + (cluster.workers.count ?? len(cluster.workers.nodes ?? {}))) == 0"
-    value: "${topology ?? 'single-node'}"
+  - name: topology
+    value: >-
+      ${
+        topology
+        ?? (
+          ((cluster.controlplanes.count ?? len(cluster.controlplanes.nodes ?? {}))
+            + (cluster.workers.count ?? len(cluster.workers.nodes ?? {}))) > 0
+            ? (
+                ((cluster.controlplanes.count ?? len(cluster.controlplanes.nodes ?? {}))
+                  + (cluster.workers.count ?? len(cluster.workers.nodes ?? {}))) == 1
+                  ? 'single-node'
+                  : (cluster.controlplanes.count ?? len(cluster.controlplanes.nodes ?? {})) >= 3
+                    ? 'ha'
+                    : 'multi-node'
+              )
+            : workstation.runtime != ''
+              ? 'single-node'
+              : 'multi-node'
+        )
+      }
 
   # ---------------------------------------------------------------------------
   # Network effective values

--- a/contexts/_template/facets/platform-base.yaml
+++ b/contexts/_template/facets/platform-base.yaml
@@ -297,24 +297,29 @@ config:
   # when the logs pipeline is disabled so downstream `when:` guards on the
   # fluentd aggregator fall through cleanly.
   #
-  - name: telemetry_effective
+  - name: telemetry
     value:
-      metrics_enabled: ${telemetry.metrics.enabled ?? true}
-      logs_enabled: ${telemetry.logs.enabled ?? true}
-      logs_driver: "${telemetry.logs.driver ?? 'fluentd'}"
+      metrics:
+        enabled: ${telemetry.metrics.enabled ?? true}
+      logs:
+        enabled: ${telemetry.logs.enabled ?? true}
+        driver: "${telemetry.logs.driver ?? 'fluentd'}"
 
   # Observability addon forces both pipelines on.
-  - name: telemetry_effective
+  - name: telemetry
     when: addons.observability.enabled == true
     value:
-      metrics_enabled: true
-      logs_enabled: true
+      metrics:
+        enabled: true
+      logs:
+        enabled: true
 
   # No logs pipeline → nothing to aggregate.
-  - name: telemetry_effective
+  - name: telemetry
     when: telemetry.logs.enabled == false && addons.observability.enabled != true
     value:
-      logs_driver: none
+      logs:
+        driver: none
 
 # =============================================================================
 # Global substitutions
@@ -408,10 +413,10 @@ kustomize:
     path: pki/base
     dependsOn:
       - "${(policies.enabled ?? true) ? 'policy-resources' : ''}"
-      - "${telemetry_effective.metrics_enabled || telemetry_effective.logs_enabled ? 'telemetry-base' : ''}"
+      - "${telemetry.metrics.enabled || telemetry.logs.enabled ? 'telemetry-base' : ''}"
     components:
       - cert-manager
-      - "${telemetry_effective.metrics_enabled ? 'cert-manager/prometheus' : ''}"
+      - "${telemetry.metrics.enabled ? 'cert-manager/prometheus' : ''}"
     timeout: 20m
     interval: 5m
 
@@ -436,34 +441,32 @@ kustomize:
   #
   - name: telemetry-base
     path: telemetry/base
-    when: telemetry_effective.metrics_enabled || telemetry_effective.logs_enabled
+    when: telemetry.metrics.enabled || telemetry.logs.enabled
     components:
-      - "${telemetry_effective.metrics_enabled ? 'prometheus' : ''}"
-      - "${telemetry_effective.metrics_enabled ? 'prometheus/flux' : ''}"
-      - "${telemetry_effective.logs_enabled ? 'fluentbit' : ''}"
+      - "${telemetry.metrics.enabled ? 'prometheus' : ''}"
+      - "${telemetry.metrics.enabled ? 'prometheus/flux' : ''}"
+      - "${telemetry.logs.enabled ? 'fluentbit' : ''}"
     timeout: 30m
     interval: 10m
 
   - name: telemetry-resources
     path: telemetry/resources
-    when: telemetry_effective.metrics_enabled || telemetry_effective.logs_enabled
+    when: telemetry.metrics.enabled || telemetry.logs.enabled
     dependsOn:
       - telemetry-base
     components:
-      # Platform-specific opt-out: AKS (and other managed K8s flavors) ship
-      # metrics-server as a built-in add-on, so platform-azure overrides
-      # telemetry_effective.metrics_server_enabled to false to skip our copy.
-      # Defaults to true via ?? so the AWS / metal / incus paths are unchanged.
-      - "${telemetry_effective.metrics_enabled && (telemetry_effective.metrics_server_enabled ?? true) ? 'metrics-server' : ''}"
-      - "${telemetry_effective.metrics_enabled ? 'prometheus' : ''}"
-      - "${telemetry_effective.metrics_enabled ? 'prometheus/flux' : ''}"
-      - "${telemetry_effective.logs_enabled ? 'fluentbit' : ''}"
-      - "${telemetry_effective.logs_enabled ? 'fluentbit/containerd' : ''}"
-      - "${telemetry_effective.logs_enabled ? 'fluentbit/kubernetes' : ''}"
-      - "${telemetry_effective.logs_enabled ? 'fluentbit/parser' : ''}"
-      - "${telemetry_effective.logs_enabled ? 'fluentbit/systemd' : ''}"
-      - "${telemetry_effective.logs_enabled && telemetry_effective.metrics_enabled ? 'fluentbit/prometheus' : ''}"
-      - "${telemetry_effective.logs_driver == 'fluentd' ? 'fluentbit/fluentd' : ''}"
+      # AKS ships metrics-server as a built-in add-on; skip our copy on Azure
+      # to avoid two instances fighting on the same APIService.
+      - "${telemetry.metrics.enabled && platform != 'azure' ? 'metrics-server' : ''}"
+      - "${telemetry.metrics.enabled ? 'prometheus' : ''}"
+      - "${telemetry.metrics.enabled ? 'prometheus/flux' : ''}"
+      - "${telemetry.logs.enabled ? 'fluentbit' : ''}"
+      - "${telemetry.logs.enabled ? 'fluentbit/containerd' : ''}"
+      - "${telemetry.logs.enabled ? 'fluentbit/kubernetes' : ''}"
+      - "${telemetry.logs.enabled ? 'fluentbit/parser' : ''}"
+      - "${telemetry.logs.enabled ? 'fluentbit/systemd' : ''}"
+      - "${telemetry.logs.enabled && telemetry.metrics.enabled ? 'fluentbit/prometheus' : ''}"
+      - "${telemetry.logs.driver == 'fluentd' ? 'fluentbit/fluentd' : ''}"
     timeout: 10m
     interval: 5m
 
@@ -476,13 +479,13 @@ kustomize:
   # every log, unfiltered).
   - name: observability
     path: observability
-    when: telemetry_effective.logs_driver == 'fluentd' && (addons.observability.logs_driver ?? '') != 'elasticsearch'
+    when: telemetry.logs.driver == 'fluentd' && (addons.observability.logs_driver ?? '') != 'elasticsearch'
     dependsOn:
       - telemetry-base
     components:
       - fluentd
       - fluentd/filters/otel
-      - "${telemetry_effective.metrics_enabled ? 'fluentd/prometheus' : ''}"
+      - "${telemetry.metrics.enabled ? 'fluentd/prometheus' : ''}"
       - "${log_level != 'trace' ? 'fluentd/filters/log-level/' + (log_level ?? 'info') : ''}"
     timeout: 15m
     interval: 10m

--- a/contexts/_template/facets/platform-base.yaml
+++ b/contexts/_template/facets/platform-base.yaml
@@ -267,8 +267,9 @@ config:
   # engine stores config-block bodies unevaluated in globalScope and
   # iterates blocks in last-writer order; a self-referencing template can
   # be read as the literal template string by a config block in another
-  # facet that evaluates earlier in the round. Conditional writes only
-  # contribute literal values, so cross-block reads always see real data.
+  # facet that evaluates earlier in the round. The when-guarded form has
+  # no self-reference (bodies may still compute over other user inputs,
+  # like cidrhost over network.cidr_block), so cross-block reads resolve.
   #
   - name: network
     when: (network.cidr_block ?? '') == ''

--- a/contexts/_template/facets/platform-docker.yaml
+++ b/contexts/_template/facets/platform-docker.yaml
@@ -19,7 +19,7 @@ config:
   # Mirrors the incus provider convention so cross-platform logic is uniform.
   - name: talos_common
     value:
-      k8s_service_host: "${cidrhost(network_effective.cidr_block, 10)}"
+      k8s_service_host: "${cidrhost(network.cidr_block, 10)}"
 
   # Node targets for post-cluster steps (e.g. cluster/talos/extensions). Reads
   # compute outputs (compute always runs before cluster, which runs before
@@ -163,6 +163,6 @@ kustomize:
       - ${lb_effective.driver}
       - "${lb_effective.driver}/${network.loadbalancer_mode ?? 'arp'}"
     substitutions:
-      loadbalancer_ip_range: ${network_effective.loadbalancer_ips.start + '-' + network_effective.loadbalancer_ips.end}
+      loadbalancer_ip_range: ${network.loadbalancer_ips.start + '-' + network.loadbalancer_ips.end}
     timeout: 5m
     interval: 5m

--- a/contexts/_template/facets/platform-hyperv.yaml
+++ b/contexts/_template/facets/platform-hyperv.yaml
@@ -71,17 +71,18 @@ config:
       nameservers: ['1.1.1.1', '8.8.8.8']
 
   # ---------------------------------------------------------------------------
-  # cni_effective override — default to Talos flannel
+  # cluster.cni.driver override — default to Talos flannel
   # ---------------------------------------------------------------------------
   #
-  # platform-base defaults cni_effective.driver to 'cilium' whenever
+  # platform-base defaults cluster.cni.driver to 'cilium' whenever
   # cluster.driver is 'talos'. Hyper-V instead defaults to Talos's built-in
   # flannel: no Cilium bootstrap stage, no cni:none / proxy:disabled patches,
   # kubelet's CNI plugin comes up automatically. Operators can still opt in
   # to Cilium via cluster.cni.driver: cilium.
-  - name: cni_effective
+  - name: cluster
     value:
-      driver: "${cluster.cni.driver ?? 'flannel'}"
+      cni:
+        driver: "${cluster.cni.driver ?? 'flannel'}"
 
   # ---------------------------------------------------------------------------
   # NodePort branch — flip topology to NAT switch + bench-side port forwards

--- a/contexts/_template/facets/platform-hyperv.yaml
+++ b/contexts/_template/facets/platform-hyperv.yaml
@@ -53,17 +53,22 @@ config:
       image_url: "${'https://factory.talos.dev/image/a9999ca75e856f927166016d16df9f9705927a18fc2f7a0c92b1ac96a376f9a6/v' + talos.talos_version + '/metal-amd64.iso'}"
 
   # ---------------------------------------------------------------------------
-  # network_effective additions — gateway and nameservers for CIDATA seed
+  # Network gateway and nameservers — needed for the CIDATA seed
   # ---------------------------------------------------------------------------
   #
-  # The gateway/nameservers fields land on platform-base's network_effective so
-  # any platform that needs them later picks them up uniformly. Kept here for
-  # discoverability; platform-base could absorb the defaults in a future pass.
+  # Land defaults on the user-facing `network` field so any platform that
+  # consumes them picks them up uniformly. Conditional `when:` writes
+  # (gated on user input) — see the rationale in platform-base.yaml's
+  # "Network defaults" block.
   #
-  - name: network_effective
+  - name: network
+    when: (network.gateway ?? '') == ''
     value:
-      gateway: "${network.gateway ?? cidrhost(network_effective.cidr_block, 1)}"
-      nameservers: ${network.nameservers ?? ['1.1.1.1', '8.8.8.8']}
+      gateway: "${cidrhost(network.cidr_block ?? '10.5.0.0/16', 1)}"
+  - name: network
+    when: len(network.nameservers ?? []) == 0
+    value:
+      nameservers: ['1.1.1.1', '8.8.8.8']
 
   # ---------------------------------------------------------------------------
   # cni_effective override — default to Talos flannel
@@ -108,11 +113,11 @@ config:
       nat_host_address: "${cidrhost(network.cidr_block ?? '10.5.0.0/16', 1)}"
       bench_ip: "${(cluster.endpoint ?? '') != '' ? split(split(cluster.endpoint, '://')[1], ':')[0] : ''}"
 
-  # NodePort overrides network_effective.gateway so cluster-config's
-  # per-node default route points at the NAT host vNIC (the only address
-  # reachable from inside the NAT subnet), regardless of any bench-LAN
-  # `network.gateway` the operator set for LAN-bridge documentation.
-  - name: network_effective
+  # NodePort overrides network.gateway so cluster-config's per-node default
+  # route points at the NAT host vNIC (the only address reachable from
+  # inside the NAT subnet), regardless of any bench-LAN `network.gateway`
+  # the operator set for LAN-bridge documentation.
+  - name: network
     when: gateway.service_type == 'NodePort'
     value:
       gateway: "${cidrhost(network.cidr_block ?? '10.5.0.0/16', 1)}"
@@ -276,7 +281,7 @@ config:
   # offset 10 so k8s_service_host is stable independent of DHCP.
   - name: talos_common
     value:
-      k8s_service_host: "${cidrhost(network_effective.cidr_block, 10)}"
+      k8s_service_host: "${cidrhost(network.cidr_block, 10)}"
 
   # NodePort-mode certSANs: workstations reach the Talos API and Kubernetes
   # API at the bench's external IP (e.g. 192.168.3.77), but Talos auto-
@@ -376,13 +381,13 @@ terraform:
     inputs:
       talos_version: ${talos.talos_version}
       cluster_name: talos
-      cluster_endpoint: "${cluster.endpoint ?? ('https://' + cidrhost(network_effective.cidr_block, 10) + ':6443')}"
+      cluster_endpoint: "${cluster.endpoint ?? ('https://' + cidrhost(network.cidr_block, 10) + ':6443')}"
       destination_dir: "${hyperv_effective.images_dir}"
       common_config_patches: ${talos_common.common_config_patches}
       network:
-        cidr_block: ${network_effective.cidr_block}
-        gateway: ${network_effective.gateway}
-        nameservers: ${network_effective.nameservers}
+        cidr_block: ${network.cidr_block}
+        gateway: ${network.gateway}
+        nameservers: ${network.nameservers}
       # In NodePort mode every node's static IP must be a NAT-internal
       # address (per the per-VM offset scheme in hyperv_controlplanes /
       # hyperv_workers), not whatever bench-side address operators wrote
@@ -437,7 +442,7 @@ terraform:
       # single-LAN-NIC bench the wildcard is functionally identical anyway.
       port_forward_external_ip: "0.0.0.0"
       port_forward_name_prefix: "windsor-${id ?? 'hyperv'}"
-      network_cidr: ${network_effective.cidr_block}
+      network_cidr: ${network.cidr_block}
       vhd_dir: "${hyperv_effective.vhd_dir}"
       images:
         talos:
@@ -456,7 +461,7 @@ terraform:
             ["name", "controlplane"],
             ["role", "controlplane"],
             ["count", cluster.controlplanes.count ?? 1],
-            ["ipv4", cidrhost(network_effective.cidr_block, 10)],
+            ["ipv4", cidrhost(network.cidr_block, 10)],
             ["image", ""],
             ["dvd_iso_path", "talos"],
             ["cidata_iso_path", hyperv_effective.images_dir + "/" + ((values(cluster.controlplanes.nodes ?? {}))[0].hostname ?? "controlplane-1") + "-cidata.iso"],
@@ -472,7 +477,7 @@ terraform:
             ["name", "worker"],
             ["role", "worker"],
             ["count", cluster.workers.count ?? 0],
-            ["ipv4", cidrhost(network_effective.cidr_block, 20)],
+            ["ipv4", cidrhost(network.cidr_block, 20)],
             ["image", ""],
             ["dvd_iso_path", "talos"],
             ["cidata_iso_path", (cluster.workers.count ?? 0) > 0 ? (hyperv_effective.images_dir + "/" + ((values(cluster.workers.nodes ?? {}))[0].hostname ?? "worker-1") + "-cidata.iso") : ""],
@@ -585,6 +590,6 @@ kustomize:
       - ${lb_effective.driver}
       - "${lb_effective.driver}/${network.loadbalancer_mode ?? 'arp'}"
     substitutions:
-      loadbalancer_ip_range: "${network_effective.loadbalancer_ips.start + '-' + network_effective.loadbalancer_ips.end}"
+      loadbalancer_ip_range: "${network.loadbalancer_ips.start + '-' + network.loadbalancer_ips.end}"
     timeout: 5m
     interval: 5m

--- a/contexts/_template/facets/platform-incus.yaml
+++ b/contexts/_template/facets/platform-incus.yaml
@@ -24,7 +24,7 @@ config:
       longhorn_default_disk:
         - name: longhorn
           size: 30
-      k8s_service_host: "${cidrhost(network_effective.cidr_block, 10)}"
+      k8s_service_host: "${cidrhost(network.cidr_block, 10)}"
 
   # ---------------------------------------------------------------------------
   # cluster_endpoint_fallback
@@ -86,7 +86,7 @@ terraform:
     inputs:
       network_name: ""
       create_network: true
-      network_cidr: ${network_effective.cidr_block}
+      network_cidr: ${network.cidr_block}
       storage_pools:
         local:
           driver: null
@@ -94,7 +94,7 @@ terraform:
         - name: controlplane
           role: controlplane
           count: ${cluster.controlplanes.count ?? 1}
-          ipv4: ${cidrhost(network_effective.cidr_block, 10)}
+          ipv4: ${cidrhost(network.cidr_block, 10)}
           image: ${cluster.controlplanes.image ?? ("windsor:talos/v" + talos.talos_version + "/amd64")}
           type: virtual-machine
           description: Talos control plane node
@@ -111,7 +111,7 @@ terraform:
         - name: worker
           role: worker
           count: ${cluster.workers.count ?? 0}
-          ipv4: ${cidrhost(network_effective.cidr_block, 20)}
+          ipv4: ${cidrhost(network.cidr_block, 20)}
           image: ${cluster.workers.image ?? ("windsor:talos/v" + talos.talos_version + "/amd64")}
           type: virtual-machine
           description: Talos worker node
@@ -195,6 +195,6 @@ kustomize:
       - ${lb_effective.driver}
       - "${lb_effective.driver}/${network.loadbalancer_mode ?? 'arp'}"
     substitutions:
-      loadbalancer_ip_range: "${network_effective.loadbalancer_ips.start + '-' + network_effective.loadbalancer_ips.end}"
+      loadbalancer_ip_range: "${network.loadbalancer_ips.start + '-' + network.loadbalancer_ips.end}"
     timeout: 5m
     interval: 5m

--- a/contexts/_template/facets/platform-metal.yaml
+++ b/contexts/_template/facets/platform-metal.yaml
@@ -98,6 +98,6 @@ kustomize:
       - ${lb_effective.driver}
       - "${lb_effective.driver}/${network.loadbalancer_mode ?? 'arp'}"
     substitutions:
-      loadbalancer_ip_range: ${network_effective.loadbalancer_ips.start + '-' + network_effective.loadbalancer_ips.end}
+      loadbalancer_ip_range: ${network.loadbalancer_ips.start + '-' + network.loadbalancer_ips.end}
     timeout: 5m
     interval: 5m

--- a/contexts/_template/tests/addon-observability.test.yaml
+++ b/contexts/_template/tests/addon-observability.test.yaml
@@ -237,7 +237,7 @@ cases:
             - grafana/dashboards/fluentd
             - fluentd/outputs/stdout
 
-  # Edge: gateway disabled → gateway_effective.enabled is false → filebeat replacement skipped.
+  # Edge: gateway disabled → gateway.enabled is false → filebeat replacement skipped.
   # telemetry-base keeps its default fluentbit components; elasticsearch/kibana not deployed.
   - name: elasticsearch with gateway disabled skips filebeat and ELK stack
     values:

--- a/contexts/_template/tests/option-cni.test.yaml
+++ b/contexts/_template/tests/option-cni.test.yaml
@@ -242,7 +242,7 @@ cases:
             - gateway-base
             - cni
 
-  # network_effective: loadbalancer IPs derived from CIDR when not explicitly set (workstation layer active).
+  # network.loadbalancer_ips: derived from CIDR when not explicitly set (workstation layer active).
   - name: loadbalancer IPs derived from cidr_block when not set
     values:
       provider: docker

--- a/contexts/_template/tests/option-cni.test.yaml
+++ b/contexts/_template/tests/option-cni.test.yaml
@@ -81,8 +81,8 @@ cases:
   # Cilium: deploys cni terraform + kustomize with k8s_service_host substitution.
   # Also covers the layout-driven auto-derivation of single-node topology:
   # 1 control plane + 0 workers with no explicit `topology:` should drive
-  # topology_effective → 'single-node' → operator_replicas=1 in both the TF
-  # inputs and the kustomize substitutions.
+  # topology → 'single-node' → operator_replicas=1 in both the TF inputs
+  # and the kustomize substitutions.
   - name: cilium driver deploys cni terraform and kustomize component
     values:
       provider: metal


### PR DESCRIPTION
- replace topology_effective with topology across facet configs
- replace network_effective with network across facet configs
- replace addon-side *_effective shadows (observability, telemetry) with direct schema access
- replace gateway and CNI *_effective reads with direct property access in option-gateway.yaml and option-cni.yaml
- add metrics_server_enabled config for AKS to manage the metrics-server instance
- improve gateway driver config readability in platform-base.yaml

<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> Isolated refactoring of internal config namespaces across 18 facet YAML files with no changes to Terraform modules, Kubernetes manifests, or the external config schema.
>
> **Overview**
>
> Eliminates the `*_effective` intermediate config namespaces (`topology_effective`, `network_effective`, `cni_effective`, `gateway_effective`, `telemetry_effective`, `observability_effective`) in favour of writing computed defaults directly onto the corresponding user-facing fields. Downstream facets now read `topology`, `network.cidr_block`, `cluster.cni.driver`, `gateway.enabled`, and `telemetry.metrics.enabled` without needing to know the effective intermediate.
>
> The most structurally notable change is how defaults are set: `network.*` fields use a `when:`-gated conditional write pattern (evaluated against user input) so that other config blocks never see an unevaluated template string. `topology` is consolidated from three separate `when:`-gated blocks into one inline ternary expression. The new `metrics_server_enabled` flag is the only computed config key that does not follow the nested namespace convention used by the rest of the refactor.
>
> Test coverage exists for the key derived paths (single-node topology from node counts, flannel CNI on docker-desktop and colima, AKS metrics-server suppression), which provides reasonable confidence the evaluation semantics are preserved.
>
> Reviewed by Claude for commit `6389da5`.
<!-- /claude-code-review:summary -->
