### PR TITLE
fix(cilium): align hubble TLS method with Flux patch to prevent Helm ownership churn

### DIFF
--- a/terraform/cni/cilium/main.tf
+++ b/terraform/cni/cilium/main.tf
@@ -104,6 +104,18 @@ resource "helm_release" "cilium" {
         }
         hostRoot = "/sys/fs/cgroup"
       }
+    },
+
+    # Must match the Flux patch (kustomize/cni/cilium/hubble/patches/helm-release.yaml).
+    # Mismatch flips chart-templating of cilium-ca on each apply and churns Helm ownership.
+    {
+      hubble = {
+        tls = {
+          auto = {
+            method = "cronJob"
+          }
+        }
+      }
     }
   ))]
 }

--- a/terraform/cni/cilium/main.tf
+++ b/terraform/cni/cilium/main.tf
@@ -51,6 +51,11 @@ resource "helm_release" "cilium" {
   wait      = true
   timeout   = 600
 
+  # Adopt resources that exist in the cluster without Helm ownership labels (e.g.
+  # cilium-ca, recreated by the chart's certgen Job when running with
+  # hubble.tls.auto.method=cronJob) instead of failing on upgrade.
+  take_ownership = true
+
   values = [yamlencode(merge(
     {
       # IPAM mode is baked into node state; changing it post-install forces pod IP churn.
@@ -103,18 +108,6 @@ resource "helm_release" "cilium" {
           enabled = false
         }
         hostRoot = "/sys/fs/cgroup"
-      }
-    },
-
-    # Must match the Flux patch (kustomize/cni/cilium/hubble/patches/helm-release.yaml).
-    # Mismatch flips chart-templating of cilium-ca on each apply and churns Helm ownership.
-    {
-      hubble = {
-        tls = {
-          auto = {
-            method = "cronJob"
-          }
-        }
       }
     }
   ))]

--- a/terraform/cni/cilium/test.tftest.hcl
+++ b/terraform/cni/cilium/test.tftest.hcl
@@ -73,6 +73,11 @@ run "minimal_configuration" {
     condition     = yamldecode(helm_release.cilium.values[0]).cgroup == null
     error_message = "cgroup should be null when auto-mount is on (chart default)"
   }
+
+  assert {
+    condition     = yamldecode(helm_release.cilium.values[0]).hubble.tls.auto.method == "cronJob"
+    error_message = "hubble.tls.auto.method should be 'cronJob' to match the Flux patch and keep cilium-ca off the chart template"
+  }
 }
 
 # Verifies privileged=false swaps full-privileged mode for an explicit Linux

--- a/terraform/cni/cilium/test.tftest.hcl
+++ b/terraform/cni/cilium/test.tftest.hcl
@@ -75,8 +75,8 @@ run "minimal_configuration" {
   }
 
   assert {
-    condition     = yamldecode(helm_release.cilium.values[0]).hubble.tls.auto.method == "cronJob"
-    error_message = "hubble.tls.auto.method should be 'cronJob' to match the Flux patch and keep cilium-ca off the chart template"
+    condition     = helm_release.cilium.take_ownership == true
+    error_message = "take_ownership should be true so the bootstrap upgrade can adopt unowned resources like cilium-ca instead of erroring"
   }
 }
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> Isolated Terraform value addition that aligns with an existing Flux patch, preventing a recurring Helm ownership conflict on a single resource.
>
> **Overview**
>
> This fix adds `hubble.tls.auto.method = "cronJob"` to the Cilium Terraform Helm values so the chart-rendered template matches what the Flux kustomize patch (`kustomize/cni/cilium/hubble/patches/helm-release.yaml`) already applies at runtime. Without this alignment, each `terraform apply` would flip the value back to Helm's default, causing Flux to detect drift and re-patch, which in turn triggered ownership churn on the `cilium-ca` secret.
>
> The value is unconditional and the comment in `main.tf` explicitly ties it to the Flux patch path, making the coupling visible to future maintainers. A matching test assertion in `test.tftest.hcl` guards against accidental removal.
>
> Reviewed by Claude for commit `51b3247`.

<!-- /claude-code-review:summary -->
