### PR TITLE
chore(ci): CI stability

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -393,7 +393,9 @@ jobs:
       - name: Windsor Up
         id: windsor_up
         if: steps.infra_diff.outputs.skip != 'true'
-        timeout-minutes: 14
+        # Upgrade mode may reboot the Talos node (e.g. on a Talos version bump);
+        # post-reboot pod restart burst takes longer to settle than a fresh install.
+        timeout-minutes: ${{ matrix.mode == 'upgrade' && 20 || 14 }}
         run: windsor up --verbose --wait
 
       - name: HEAD — Wait for GitRepository revision bump

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -225,6 +225,16 @@ jobs:
           echo "1" | sudo tee /proc/sys/net/bridge/bridge-nf-call-iptables
           echo "1" | sudo tee /proc/sys/net/bridge/bridge-nf-call-ip6tables
 
+      # Reclaim ~30 GB by removing pre-installed toolchains the runner ships
+      # but this repo never uses (.NET, Android SDK, Haskell). Without this the
+      # kubelet inside the Talos VM hits its ephemeral-storage eviction threshold
+      # during k8s/Cilium image pulls and evicts the Flux controller pods.
+      - name: Free disk space
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+          df -h /
+
       # Move docker data-root to /mnt (66GB available vs ~10GB default) and
       # cap json-file logging at 10m × 3 to prevent runaway disk growth.
       - name: Configure Docker for increased storage


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> Isolated changes to a single CI workflow file; no application code, Terraform modules, or Kustomize stacks are touched.
>
> **Overview**
>
> Refines the integration CI job in two ways. First, a new "Free disk space" step strips the `.NET`, Android SDK, and GHC Haskell toolchains — unused by this repo — from the GitHub-hosted runner before any heavy workloads start, reclaiming roughly 30 GB on the root filesystem. The stated motivation is preventing the Talos VM's kubelet from hitting its ephemeral-storage eviction threshold while pulling Cilium and Kubernetes images, which was causing Flux controller pods to be evicted mid-test.
>
> Second, the Windsor Up timeout is changed from a fixed 14 minutes to a matrix-conditional expression: upgrade mode gets 20 minutes to accommodate a potential Talos node reboot and the subsequent pod restart burst, while install mode keeps the original 14-minute ceiling. The GitHub Actions expression `matrix.mode == 'upgrade' && 20 || 14` is the standard ternary idiom for this context and evaluates correctly.
>
> Both changes carry explanatory comments at the point of use and are easily reverted if they introduce unexpected behavior.
>
> Reviewed by Claude for commit `8ab667b`.

<!-- /claude-code-review:summary -->
