### PR TITLE
fix(cluster/talos): ignore talos_version drift on machine_secrets

### DIFF
--- a/terraform/cluster/talos/main.tf
+++ b/terraform/cluster/talos/main.tf
@@ -32,6 +32,11 @@ resource "talos_machine_secrets" "this" {
   count = var.machine_secrets == null ? 1 : 0
 
   talos_version = "v${var.talos_version}"
+
+  lifecycle {
+    # Workaround for siderolabs/terraform-provider-talos#352 — remove once fixed.
+    ignore_changes = [talos_version]
+  }
 }
 
 # State address migration: this resource used to be unconditional (no count


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> Single-resource lifecycle addition that suppresses spurious provider-side drift on cluster PKI secrets; no effect on running clusters.
>
> **Overview**
>
> Introduces an `ignore_changes = [talos_version]` lifecycle rule on `talos_machine_secrets.this` as a workaround for a known bug in the upstream Talos Terraform provider (siderolabs/terraform-provider-talos#352). Without it, `terraform plan` incorrectly reports drift on the `talos_version` attribute after every apply, prompting unnecessary cycles against a resource that holds cluster PKI material.
>
> The change is intentionally conservative: regenerating machine secrets on a version bump would destroy and recreate all cluster PKI, which would break existing nodes. The inline comment marks this as a temporary workaround to remove once the upstream issue is resolved. The `lifecycle` block has no effect on clusters that already supply `var.machine_secrets` directly (where `count = 0`).
>
> Reviewed by Claude for commit `2087ac2`.

<!-- /claude-code-review:summary -->
