### PR TITLE
feat(facet): Include default backend flag

### DIFF
--- a/contexts/_template/facets/platform-aws.yaml
+++ b/contexts/_template/facets/platform-aws.yaml
@@ -6,6 +6,11 @@ metadata:
 
 when: platform == 'aws'
 
+# Terraform remote state lives in the S3 bucket provisioned by the `backend`
+# component below. Downstream components configure their backend pointed at
+# that bucket; the `backend` component itself uses local state.
+backend: backend
+
 # =============================================================================
 # Terraform — S3 state backend, VPC, EKS, optional Cilium bootstrap
 # =============================================================================

--- a/contexts/_template/facets/platform-azure.yaml
+++ b/contexts/_template/facets/platform-azure.yaml
@@ -6,6 +6,11 @@ metadata:
 
 when: platform == 'azure'
 
+# Terraform remote state lives in the Azure Storage account provisioned by
+# the `backend` component below. Downstream components configure their
+# backend pointed at it; the `backend` component itself uses local state.
+backend: backend
+
 # =============================================================================
 # Config — platform-specific overrides
 # =============================================================================

--- a/contexts/_template/facets/platform-docker.yaml
+++ b/contexts/_template/facets/platform-docker.yaml
@@ -4,9 +4,11 @@ metadata:
   name: docker
   description: "Docker provider basic infrastructure for local development"
 
-# Docker is only supported with Talos as the cluster driver. Without a
-# workstation runtime, this facet is a no-op scaffold used for schema tests.
-when: "platform == 'docker' && cluster.driver == 'talos'"
+# Docker is only supported with Talos as the cluster driver and a workstation
+# runtime. With cluster disabled or workstation runtime unset, this facet is
+# a true no-op — nothing materializes that would reference its config or the
+# `backend: cluster` setting below.
+when: "platform == 'docker' && cluster.driver == 'talos' && (cluster.enabled ?? true) && (workstation.runtime ?? '') != ''"
 
 # Terraform remote state lives in the local Talos cluster (Kubernetes
 # backend, secrets-as-state). The `cluster` component itself uses local

--- a/contexts/_template/facets/platform-docker.yaml
+++ b/contexts/_template/facets/platform-docker.yaml
@@ -8,6 +8,11 @@ metadata:
 # workstation runtime, this facet is a no-op scaffold used for schema tests.
 when: "platform == 'docker' && cluster.driver == 'talos'"
 
+# Terraform remote state lives in the local Talos cluster (Kubernetes
+# backend, secrets-as-state). The `cluster` component itself uses local
+# state since it's the one that creates the cluster.
+backend: cluster
+
 # =============================================================================
 # Config — docker-specific Talos values
 # =============================================================================

--- a/contexts/_template/facets/platform-hyperv.yaml
+++ b/contexts/_template/facets/platform-hyperv.yaml
@@ -9,6 +9,11 @@ metadata:
 # workstation-overlay path here.
 when: "platform == 'hyperv' && cluster.driver == 'talos'"
 
+# Terraform remote state lives in the local Talos cluster (Kubernetes
+# backend, secrets-as-state). The `cluster` component itself uses local
+# state since it's the one that creates the cluster.
+backend: cluster
+
 # =============================================================================
 # Config — Hyper-V-specific Talos values
 # =============================================================================

--- a/contexts/_template/facets/platform-incus.yaml
+++ b/contexts/_template/facets/platform-incus.yaml
@@ -9,6 +9,11 @@ metadata:
 # owns compute/cluster and this facet contributes config only.
 when: "platform == 'incus' && cluster.driver == 'talos'"
 
+# Terraform remote state lives in the local Talos cluster (Kubernetes
+# backend, secrets-as-state). The `cluster` component itself uses local
+# state since it's the one that creates the cluster.
+backend: cluster
+
 # =============================================================================
 # Config — Incus-specific Talos values
 # =============================================================================

--- a/contexts/_template/facets/platform-metal.yaml
+++ b/contexts/_template/facets/platform-metal.yaml
@@ -9,6 +9,11 @@ metadata:
 # creation — everything upstream is the operator's responsibility.
 when: platform == 'metal'
 
+# Terraform remote state lives in the local Talos cluster (Kubernetes
+# backend, secrets-as-state). The `cluster` component itself uses local
+# state since it's the one that creates the cluster.
+backend: cluster
+
 # =============================================================================
 # Config
 # =============================================================================


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> Additive config-only changes to template facets; no executable code changes, no migration needed for existing deployments.
>
> **Overview**
>
> Introduces a `backend` field to all six platform facets in `contexts/_template/`, declaring which Terraform state component each platform uses. Cloud platforms (AWS, Azure) point to a dedicated `backend` component backed by S3 or Azure Storage; on-premises platforms (Docker, Hyper-V, Incus, Metal) point to `cluster`, using the Talos Kubernetes secrets backend.
>
> The Docker facet's `when` condition is also tightened to require a non-empty `workstation.runtime`, preventing the facet from activating in schema-only test contexts — a path the previous code explicitly supported as a no-op scaffold. The metal facet adds `backend: cluster` without the `cluster.driver == 'talos'` guard that its hyperv and incus peers carry, a minor inconsistency.
>
> Reviewed by Claude for commit `c903730`.

<!-- /claude-code-review:summary -->
