### PR TITLE
chore(docs): add CNI add-on documentation and validation scripts

### DIFF
--- a/.claude/skills/docs-author/SKILL.md
+++ b/.claude/skills/docs-author/SKILL.md
@@ -44,21 +44,46 @@ Exact glob roots are finalized with the website `docs:vendor` script; treat the 
 - Generate from modules in this repo with `task docs` (terraform-docs injected between `<!-- BEGIN_TF_DOCS -->` / `<!-- END_TF_DOCS -->` markers in each module's `README.md`). Commit the regenerated `terraform/<module-path>/README.md` (`cluster/talos`, `gitops/flux`, etc.). The site ingest pipeline mirrors these into `docs/reference/terraform/<module-path>/` per the path mapping above; contributors don't write into `docs/reference/` directly.
 - Inputs, outputs, and gotchas belong here; high-level “what is Terraform in Windsor” stays on the site under `/docs/components/terraform`.
 
-## Kustomize stack operator guide (per top-level stack)
+## Kustomize add-on README (per `kustomize/<add-on>/`)
 
-For each significant stack under `kustomize/` (e.g. dns, csi), maintain **one** operator-oriented README (source location agreed with ingest—often `kustomize/<stack>/README.md` normalized into `docs/reference/kustomize/<stack>.md`, or authored directly under `docs/reference/kustomize/`).
+Each add-on gets one `kustomize/<add-on>/README.md` plus one `kustomize/<add-on>/.docs.yaml` descriptor. The README is hand-authored; the Substitutions / Components / Dependencies tables are generated from the descriptor by `scripts/kustomize-docs.sh` (wired through `task docs:kustomize`) and live between `<!-- BEGIN_KUSTOMIZE_DOCS -->` / `<!-- END_KUSTOMIZE_DOCS -->` markers. CI runs `task docs:kustomize:check` to fail on drift.
 
-Use this section order where applicable:
+Fixed section order (target ~120 lines):
 
-1. **Purpose** — what this subtree owns.
-2. **Dependencies** — other stacks, CRDs, cloud prereqs.
-3. **Blueprint wiring** — minimal `blueprint.yaml` fragment (`source` pointing at this blueprint, `path`, `components`).
-4. **Substitutions / vars** — table: name, default, required, effect.
-5. **Components** — Kustomize `components/` and when to enable each.
-6. **Operations** — upgrade, rollback, common failures, observability.
-7. **Security** — RBAC, secrets, network policy when relevant.
+```
+2-sentence lede
+## Architecture       single Mermaid (sane-default config) + 2-4 interpretive sentences
+## Recipes            terse YAML per variant, one-line header per recipe
+## Operations         bulleted "if X then Y" failure modes
+## Security           2-4 bullets (PSA, capabilities, secret handling)
+<!-- BEGIN_KUSTOMIZE_DOCS -->
+generated tables                                  # never hand-edit
+<!-- END_KUSTOMIZE_DOCS -->
+## See also           cross-links
+```
 
-Align structure with existing kustomize conventions: see `.claude/skills/kustomize-author/SKILL.md`. Terraform module docs should align with `.claude/skills/terraform-style/SKILL.md` where applicable.
+Diagram conventions: architecture (static structure), not flow. One diagram per add-on showing the sane-default config; variants live in Recipes, not in extra diagrams. LR direction, namespace subgraphs always shown, nodes labeled by kind (`HelmRelease cilium`, not `cilium`), no color.
+
+`.docs.yaml` shape (kept single-line — Markdown tables don't render multi-line cells without `<br/>`):
+
+```yaml
+substitutions:
+  <name>:
+    required_when: <string>         # default "always"
+    description: "<single line>"
+
+components:
+  <name>:
+    enable_when: <string>           # default "always"
+    description: "<single line>"
+
+dependencies:
+  <add-on>:
+    required_when: <string>         # default "always"
+    reason: "<single line>"
+```
+
+Reference: [kustomize/cni/](../../../kustomize/cni/) is the pilot — copy its `README.md` + `.docs.yaml` pair as a template when authoring a new add-on. Align with `.claude/skills/kustomize-author/SKILL.md` for the underlying Kustomize layout.
 
 ## Compatibility
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,8 @@ env:
   SUPPORT_BUNDLE_VERSION: v0.129.0
   # renovate: datasource=github-releases depName=flux package=fluxcd/flux2
   FLUX_VERSION: v2.8.8
+  # renovate: datasource=github-releases depName=yq package=mikefarah/yq
+  YQ_VERSION: v4.53.2
 
 jobs:
 
@@ -102,6 +104,22 @@ jobs:
             echo "Run 'task dashboards' locally and commit the changes."
             exit 1
           fi
+
+      # yq is the YAML reader the kustomize-docs generator depends on. Local
+      # devs get it via aqua; CI installs the same pinned version directly.
+      - name: Install yq
+        run: |
+          cd "$(mktemp -d)" &&
+          curl -fsSLO "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" &&
+          sudo install -m 0755 -o root -g root yq_linux_amd64 /usr/local/bin/yq &&
+          cd - &&
+          rm -rf "$OLDPWD" &&
+          yq --version
+
+      # Fail if kustomize/<add-on>/.docs.yaml has diverged from the rendered
+      # BEGIN_KUSTOMIZE_DOCS / END_KUSTOMIZE_DOCS region in README.md.
+      - name: Validate kustomize add-on docs
+        run: task docs:kustomize:check
 
       - name: Checkov GitHub Action
         uses: bridgecrewio/checkov-action@68260132005eaae0e6f84c7a73cc3b1532f678bf # v12.3058.0

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -93,3 +93,13 @@ tasks:
             echo "Generating docs for $dir"
             docker run --rm -v "$(pwd):/src" -w "/src/$dir" quay.io/terraform-docs/terraform-docs:0.20.0 markdown table --output-file README.md --output-mode inject .
           done
+
+  docs:kustomize:
+    desc: Generate the Substitutions/Components/Dependencies tables inside every kustomize/<add-on>/README.md from its .docs.yaml descriptor
+    cmds:
+      - scripts/kustomize-docs.sh --all
+
+  docs:kustomize:check:
+    desc: Fail if docs:kustomize would produce drift (CI use)
+    cmds:
+      - scripts/kustomize-docs.sh --check

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -28,6 +28,7 @@ packages:
   - name: getsops/sops@v3.13.1
   - name: 1password/cli@v2.30.3
   - name: evilmartians/lefthook@v2.1.8
+  - name: mikefarah/yq@v4.53.2
   - name: bridgecrewio/checkov@3.2.529
   - name: kubernetes-sigs/krew@v0.5.0
   - name: Azure/kubelogin@v0.2.17

--- a/kustomize/cni/.docs.yaml
+++ b/kustomize/cni/.docs.yaml
@@ -1,0 +1,49 @@
+# Descriptor consumed by scripts/kustomize-docs.sh to populate the
+# BEGIN_KUSTOMIZE_DOCS / END_KUSTOMIZE_DOCS region of README.md.
+# Edit this file (not the README tables) when substitutions, components,
+# or dependencies change.
+
+substitutions:
+  k8s_service_host:
+    required_when: always
+    description: "API server hostname Cilium reaches before its eBPF service rules are active. On Talos resolves to a fixed offset from the cluster CIDR; on EKS parsed from the cluster Terraform output. User-facing knob is `cluster.endpoint`."
+  cluster_name:
+    required_when: always
+    description: "Cilium cluster identity stamped onto Hubble flows, metrics, and (if enabled) ClusterMesh routing. Sourced from the Windsor context name (top-level `id` in `values.yaml`)."
+  operator_replicas:
+    required_when: always
+    description: "1 on single-node clusters (avoids pending pods + Lease churn), 2 otherwise. Set from `topology`."
+  loadbalancer_start_ip:
+    required_when: "`cilium/l2` is enabled (Talos)"
+    description: "Start of the LBIPAM IP pool. Stamped onto `CiliumLoadBalancerIPPool/default`."
+  loadbalancer_end_ip:
+    required_when: "`cilium/l2` is enabled (Talos)"
+    description: "End of the LBIPAM IP pool."
+
+components:
+  cilium:
+    enable_when: always
+    description: "Helm release of Cilium in `system-cni`, targeting `kube-system`. `kubeProxyReplacement: true`, `ipam.mode: kubernetes`, base values."
+  cilium/talos:
+    enable_when: platform is Talos
+    description: "Replaces full privileged mode with explicit Linux capabilities (CHOWN, NET_ADMIN, etc.) and disables cgroup auto-mount (Talos already mounts cgroups at boot)."
+  cilium/gateway:
+    enable_when: "`gateway.driver: cilium`"
+    description: "Enables `gatewayAPI` on Cilium and ships a Kyverno ClusterPolicy that injects LBIPAM sharing annotations onto Cilium-owned Gateway services. Fixes a create-then-patch race in cilium-operator that would otherwise prevent IP sharing on first reconcile."
+  cilium/prometheus:
+    enable_when: "`telemetry.metrics.enabled: true`"
+    description: "Enables Prometheus on the operator and agent and creates a ServiceMonitor for each."
+  cilium/hubble:
+    enable_when: always
+    description: "Hubble metrics (dns, drop, port-distribution, tcp, flow, icmp, http), Hubble Relay, Hubble UI, and the cronJob-based TLS rotation method (avoids a bug where `helm` mode re-renders server-secret on every upgrade)."
+  cilium/l2:
+    enable_when: platform is Talos
+    description: "Enables `l2announcements` and `externalIPs` and creates `CiliumLoadBalancerIPPool/default` with the configured IP range plus `CiliumL2AnnouncementPolicy/default` matching `^eth[0-9]+` and `^ens[0-9]+` interfaces. Replaces kube-vip and MetalLB on Talos."
+
+dependencies:
+  policy-resources:
+    required_when: "`policies.enabled: true` or `gateway.driver: cilium`"
+    reason: "Re-rolls Cilium pods after Kyverno's mutation policies are live. When `cilium/gateway` is active, also provides the Kyverno CRDs the LBIPAM sharing ClusterPolicy depends on."
+  telemetry-base:
+    required_when: "`telemetry.metrics.enabled: true` or `telemetry.logs.enabled: true`"
+    reason: "The `cilium/prometheus` ServiceMonitor and the Hubble ServiceMonitor target Prometheus from telemetry."

--- a/kustomize/cni/README.md
+++ b/kustomize/cni/README.md
@@ -1,0 +1,132 @@
+---
+title: CNI add-on
+description: Cilium as the cluster CNI, bootstrapped via Terraform and adopted by Flux.
+---
+
+# CNI
+
+Cilium is the only CNI driver this blueprint installs. Other CNIs
+(flannel on docker-desktop, AKS's managed CNI) bypass this add-on
+entirely when `cluster.cni.driver` is not `cilium`.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  tf[Terraform<br/>cni/cilium]
+  flux[Flux helm-controller]
+
+  subgraph systemcni[system-cni]
+    helmrel[HelmRelease cilium]
+  end
+
+  subgraph kubesystem[kube-system]
+    agent[DaemonSet cilium-agent]
+    operator[Deployment cilium-operator]
+    hubble[Hubble Relay + UI]
+  end
+
+  tf -.bootstrap.-> helmrel
+  flux ==adopt==> helmrel
+  helmrel --> agent
+  helmrel --> operator
+  helmrel --> hubble
+```
+
+The pattern is **bootstrap-then-adopt**: Terraform installs Cilium first
+via the Talos API (because Flux needs pod networking to reconcile), then
+Flux adopts the running HelmRelease so day-2 changes flow through GitOps.
+The HelmRelease CR lives in `system-cni`; the Cilium workloads deploy
+into `kube-system` per upstream convention.
+
+## Recipes
+
+### Talos default
+
+```yaml
+- name: cni
+  path: cni
+  dependsOn: [policy-resources, telemetry-base]
+  components: [cilium, cilium/talos, cilium/prometheus, cilium/hubble, cilium/l2]
+  substitutions:
+    k8s_service_host: 10.5.0.10
+    loadbalancer_start_ip: 10.5.1.10
+    loadbalancer_end_ip: 10.5.1.30
+    cluster_name: local
+    operator_replicas: "2"
+  timeout: 15m
+```
+
+### Talos with Cilium as the gateway driver
+
+Adds `cilium/gateway`. The `gateway-base` dependency is contributed by
+`option-gateway` so the Gateway API CRDs exist before cilium-operator
+starts.
+
+```yaml
+components: [cilium, cilium/talos, cilium/gateway, cilium/prometheus, cilium/hubble, cilium/l2]
+dependsOn:  [policy-resources, telemetry-base, gateway-base]
+```
+
+### EKS
+
+No Talos-specific patches and no L2 announcer (AWS LB Controller handles
+LB). `k8s_service_host` is parsed from the cluster Terraform output.
+
+```yaml
+components: [cilium, cilium/prometheus, cilium/hubble]
+substitutions:
+  k8s_service_host: <from terraform_output('cluster', 'cluster_endpoint')>
+```
+
+## Operations
+
+- **Cilium pods crash-loop with `Operation not permitted` on Talos** — the `cilium/talos` component is missing or its capabilities patch didn't apply.
+- **`cilium-operator` doesn't create a Gateway controller** — the Gateway API CRDs were not present at start. Restart `cilium-operator` after the CRDs are installed.
+- **Cilium gateway Service has no LB IP** — verify the `cilium-gateway-lbipam-sharing` ClusterPolicy is `Ready` and the `cilium-lbipam-config` ConfigMap in `system-gateway` exists.
+- **`HelmRelease/cilium` reports `no matches for kind CiliumLoadBalancerIPPool`** — the Cilium chart installs these CRDs; reconciling Flux too early can race the install. Re-reconcile.
+- **`windsor apply` flaps Cilium replica counts** — Terraform `operator_replicas` and the Flux substitution disagree. Both must derive from `topology`.
+
+## Security
+
+- `system-cni` has no PSA labels; Cilium workloads live in `kube-system` with host networking and restricted Linux capabilities (full set on non-Talos; explicit set on Talos via `cilium/talos`).
+- `kubeProxyReplacement: true` means Cilium replaces kube-proxy entirely; removing this add-on does not restore kube-proxy.
+- Hubble TLS certificates rotate via an in-cluster CronJob (cert-manager is not required for Hubble).
+
+<!-- BEGIN_KUSTOMIZE_DOCS -->
+
+## Substitutions
+
+| Name | Required when | Effect |
+|---|---|---|
+| `k8s_service_host` | always | API server hostname Cilium reaches before its eBPF service rules are active. On Talos resolves to a fixed offset from the cluster CIDR; on EKS parsed from the cluster Terraform output. User-facing knob is `cluster.endpoint`. |
+| `cluster_name` | always | Cilium cluster identity stamped onto Hubble flows, metrics, and (if enabled) ClusterMesh routing. Sourced from the Windsor context name (top-level `id` in `values.yaml`). |
+| `operator_replicas` | always | 1 on single-node clusters (avoids pending pods + Lease churn), 2 otherwise. Set from `topology`. |
+| `loadbalancer_start_ip` | `cilium/l2` is enabled (Talos) | Start of the LBIPAM IP pool. Stamped onto `CiliumLoadBalancerIPPool/default`. |
+| `loadbalancer_end_ip` | `cilium/l2` is enabled (Talos) | End of the LBIPAM IP pool. |
+
+## Components
+
+| Component | Enable when | Effect |
+|---|---|---|
+| `cilium` | always | Helm release of Cilium in `system-cni`, targeting `kube-system`. `kubeProxyReplacement: true`, `ipam.mode: kubernetes`, base values. |
+| `cilium/talos` | platform is Talos | Replaces full privileged mode with explicit Linux capabilities (CHOWN, NET_ADMIN, etc.) and disables cgroup auto-mount (Talos already mounts cgroups at boot). |
+| `cilium/gateway` | `gateway.driver: cilium` | Enables `gatewayAPI` on Cilium and ships a Kyverno ClusterPolicy that injects LBIPAM sharing annotations onto Cilium-owned Gateway services. Fixes a create-then-patch race in cilium-operator that would otherwise prevent IP sharing on first reconcile. |
+| `cilium/prometheus` | `telemetry.metrics.enabled: true` | Enables Prometheus on the operator and agent and creates a ServiceMonitor for each. |
+| `cilium/hubble` | always | Hubble metrics (dns, drop, port-distribution, tcp, flow, icmp, http), Hubble Relay, Hubble UI, and the cronJob-based TLS rotation method (avoids a bug where `helm` mode re-renders server-secret on every upgrade). |
+| `cilium/l2` | platform is Talos | Enables `l2announcements` and `externalIPs` and creates `CiliumLoadBalancerIPPool/default` with the configured IP range plus `CiliumL2AnnouncementPolicy/default` matching `^eth[0-9]+` and `^ens[0-9]+` interfaces. Replaces kube-vip and MetalLB on Talos. |
+
+## Dependencies
+
+| Add-on | Required when | Reason |
+|---|---|---|
+| `policy-resources` | `policies.enabled: true` or `gateway.driver: cilium` | Re-rolls Cilium pods after Kyverno's mutation policies are live. When `cilium/gateway` is active, also provides the Kyverno CRDs the LBIPAM sharing ClusterPolicy depends on. |
+| `telemetry-base` | `telemetry.metrics.enabled: true` or `telemetry.logs.enabled: true` | The `cilium/prometheus` ServiceMonitor and the Hubble ServiceMonitor target Prometheus from telemetry. |
+
+<!-- END_KUSTOMIZE_DOCS -->
+
+## See also
+
+- [contexts/_template/facets/option-cni.yaml](../../contexts/_template/facets/option-cni.yaml) — canonical wiring.
+- [terraform/cni/cilium/](../../terraform/cni/cilium/) — Terraform bootstrap module.
+- Related add-ons: [policy](../policy/), [telemetry](../telemetry/), [gateway](../gateway/), [csi](../csi/), [lb](../lb/).

--- a/scripts/kustomize-docs.sh
+++ b/scripts/kustomize-docs.sh
@@ -123,6 +123,12 @@ process_dir() {
   echo "ok: $readme" >&2
 }
 
+process_all() {
+  for d in kustomize/*/; do
+    process_dir "$d"
+  done
+}
+
 usage() {
   cat >&2 <<'USAGE'
 usage:
@@ -147,12 +153,10 @@ main() {
       usage
       ;;
     --all)
-      for d in kustomize/*/; do
-        process_dir "$d"
-      done
+      process_all
       ;;
     --check)
-      "$0" --all
+      process_all
       if ! git diff --exit-code -- 'kustomize/*/README.md'; then
         echo "error: kustomize-docs produced drift. Run 'task docs:kustomize' and commit the result." >&2
         exit 1

--- a/scripts/kustomize-docs.sh
+++ b/scripts/kustomize-docs.sh
@@ -134,6 +134,14 @@ USAGE
 }
 
 main() {
+  # The kustomize/*/ glob below is relative to PWD. Without this guard, a
+  # subdirectory invocation would expand to nothing and --check would exit 0
+  # while real drift sits untested.
+  [[ -d kustomize ]] || {
+    echo "error: run kustomize-docs.sh from the repo root" >&2
+    exit 1
+  }
+
   case "${1:-}" in
     "")
       usage

--- a/scripts/kustomize-docs.sh
+++ b/scripts/kustomize-docs.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+#
+# kustomize-docs.sh - Materialize the BEGIN_KUSTOMIZE_DOCS / END_KUSTOMIZE_DOCS
+# region of kustomize/<add-on>/README.md from kustomize/<add-on>/.docs.yaml.
+#
+# Usage:
+#   scripts/kustomize-docs.sh kustomize/<add-on>     # one add-on
+#   scripts/kustomize-docs.sh --all                  # every add-on with .docs.yaml
+#   scripts/kustomize-docs.sh --check                # CI: fail on drift
+#
+# Requires: yq v4 (mikefarah). Available via aqua.
+
+set -euo pipefail
+
+BEGIN_MARKER='<!-- BEGIN_KUSTOMIZE_DOCS -->'
+END_MARKER='<!-- END_KUSTOMIZE_DOCS -->'
+
+# Render Substitutions / Components / Dependencies tables to stdout.
+render_tables() {
+  local docs="$1"
+
+  # yq expressions are intentionally single-quoted: their `.field` syntax
+  # must reach yq verbatim, not be expanded by the shell.
+  if yq -e '.substitutions' "$docs" >/dev/null 2>&1; then
+    printf '## Substitutions\n\n'
+    printf '| Name | Required when | Effect |\n'
+    printf '|---|---|---|\n'
+    # shellcheck disable=SC2016
+    yq -r '
+      .substitutions | to_entries[] |
+      "| `" + .key + "` | " +
+      (.value.required_when // "always") + " | " +
+      (.value.description // "") + " |"
+    ' "$docs"
+    printf '\n'
+  fi
+
+  if yq -e '.components' "$docs" >/dev/null 2>&1; then
+    printf '## Components\n\n'
+    printf '| Component | Enable when | Effect |\n'
+    printf '|---|---|---|\n'
+    # shellcheck disable=SC2016
+    yq -r '
+      .components | to_entries[] |
+      "| `" + .key + "` | " +
+      (.value.enable_when // "always") + " | " +
+      (.value.description // "") + " |"
+    ' "$docs"
+    printf '\n'
+  fi
+
+  if yq -e '.dependencies' "$docs" >/dev/null 2>&1; then
+    printf '## Dependencies\n\n'
+    printf '| Add-on | Required when | Reason |\n'
+    printf '|---|---|---|\n'
+    # shellcheck disable=SC2016
+    yq -r '
+      .dependencies | to_entries[] |
+      "| `" + .key + "` | " +
+      (.value.required_when // "always") + " | " +
+      (.value.reason // "") + " |"
+    ' "$docs"
+    printf '\n'
+  fi
+}
+
+# Replace the marker region in $readme with the contents of $rendered_file.
+# Passing multi-line content via -v doesn't work in awk; use getline from a
+# temp file instead.
+inject() {
+  local readme="$1"
+  local rendered_file="$2"
+  local tmp
+  tmp="$(mktemp)"
+
+  awk -v begin="$BEGIN_MARKER" -v end="$END_MARKER" -v rf="$rendered_file" '
+    $0 == begin {
+      print
+      print ""
+      while ((getline line < rf) > 0) print line
+      close(rf)
+      skip = 1
+      next
+    }
+    $0 == end {
+      print
+      skip = 0
+      next
+    }
+    !skip { print }
+  ' "$readme" > "$tmp"
+
+  mv "$tmp" "$readme"
+}
+
+process_dir() {
+  local dir="${1%/}"
+  local readme="$dir/README.md"
+  local docs="$dir/.docs.yaml"
+
+  if [ ! -f "$docs" ]; then
+    echo "skip: $dir (no .docs.yaml)" >&2
+    return 0
+  fi
+  if [ ! -f "$readme" ]; then
+    echo "error: $dir missing README.md" >&2
+    return 1
+  fi
+  if ! grep -qF "$BEGIN_MARKER" "$readme"; then
+    echo "error: $readme missing $BEGIN_MARKER" >&2
+    return 1
+  fi
+  if ! grep -qF "$END_MARKER" "$readme"; then
+    echo "error: $readme missing $END_MARKER" >&2
+    return 1
+  fi
+
+  local rendered_file
+  rendered_file="$(mktemp)"
+  render_tables "$docs" > "$rendered_file"
+  inject "$readme" "$rendered_file"
+  rm -f "$rendered_file"
+  echo "ok: $readme" >&2
+}
+
+usage() {
+  cat >&2 <<'USAGE'
+usage:
+  kustomize-docs.sh kustomize/<add-on>     # one add-on
+  kustomize-docs.sh --all                  # every add-on with .docs.yaml
+  kustomize-docs.sh --check                # CI: fail on drift
+USAGE
+  exit 2
+}
+
+main() {
+  case "${1:-}" in
+    "")
+      usage
+      ;;
+    --all)
+      for d in kustomize/*/; do
+        process_dir "$d"
+      done
+      ;;
+    --check)
+      "$0" --all
+      if ! git diff --exit-code -- 'kustomize/*/README.md'; then
+        echo "error: kustomize-docs produced drift. Run 'task docs:kustomize' and commit the result." >&2
+        exit 1
+      fi
+      ;;
+    -h|--help)
+      usage
+      ;;
+    *)
+      process_dir "$1"
+      ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> This PR introduces documentation infrastructure (a new CNI add-on README and a shell-based doc generator) with no changes to deployed Kubernetes resources, so the blast radius is limited to CI and developer tooling.
>
> **Overview**
>
> Introduces `kustomize/cni/README.md` as the pilot operator guide for the Cilium CNI add-on, paired with a machine-readable `kustomize/cni/.docs.yaml` descriptor that drives a new `scripts/kustomize-docs.sh` generator. The generator materializes Substitutions, Components, and Dependencies tables between fenced markers in each README, and a new CI step (`task docs:kustomize:check`) enforces that the rendered tables stay in sync with the descriptor.
>
> The tooling follows a generate-then-diff pattern: `--check` runs `--all` in place and fails if `git diff` detects any change. Three issues worth addressing before this pattern scales to more add-ons: the script has no working-directory guard (a silent false-pass risk when run outside the repo root), the `--check` mode re-invokes itself via `$0` which can misbehave in wrapper contexts, and the `yq` binary is installed from GitHub Releases without checksum verification.
>
> Reviewed by Claude for commit `8d8dddf`.
<!-- /claude-code-review:summary -->
