### PR TITLE
chore(docs): add scripts for materializing kustomize and terraform READMEs into docs/reference/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,6 @@ contexts/**/.gcp/
 .cursor/
 .vscode/*.local.*
 
-# Local notes / scratch docs (kept out of source control)
-docs/
+# Everything under docs/ is local. docs/reference/ is generated on demand
+# by `task docs:reference` for the website build to consume; never committed.
+docs/*

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -103,3 +103,8 @@ tasks:
     desc: Fail if docs:kustomize would produce drift (CI use)
     cmds:
       - scripts/kustomize-docs.sh --check
+
+  docs:reference:
+    desc: Materialize kustomize and terraform READMEs into docs/reference/ for windsorcli.github.io ingest
+    cmds:
+      - node scripts/sync-reference.mjs

--- a/kustomize/csi/.docs.yaml
+++ b/kustomize/csi/.docs.yaml
@@ -1,0 +1,52 @@
+# Descriptor consumed by scripts/kustomize-docs.sh to populate the
+# BEGIN_KUSTOMIZE_DOCS / END_KUSTOMIZE_DOCS region of README.md.
+# Edit this file (not the README tables) when substitutions, components,
+# or dependencies change.
+
+substitutions:
+  single_storage_type:
+    required_when: "`aws-ebs` or `azure-disk` is enabled"
+    description: "Disk type for the cloud `single` StorageClass. Sourced from `cluster.storage.single_storage_type`. AWS values: `gp3` (default), `gp2`, `io1`. Azure values: `StandardSSD_LRS` (default), `Premium_LRS`, `UltraSSD_LRS`."
+  local_volume_path:
+    required_when: "`openebs/dynamic-localpv` is enabled"
+    description: "Host directory the OpenEBS hostpath provisioner allocates from. Sourced from `cluster.storage.local_base_path` (schema default `/var/mnt/local`). The directory must exist on every node before any PVC is created."
+
+components:
+  aws-ebs:
+    enable_when: "platform is AWS (EKS)"
+    description: "StorageClass `single` (default class) using `ebs.csi.aws.com`, `WaitForFirstConsumer`, `allowVolumeExpansion: true`, `encrypted: true`, `fsType: ext4`, `type: ${single_storage_type}`. The CSI driver itself is preinstalled by EKS; this component ships StorageClass only."
+  azure-disk:
+    enable_when: "platform is Azure (AKS)"
+    description: "StorageClass `single` (default class) using `disk.csi.azure.com`, `WaitForFirstConsumer`, `allowVolumeExpansion: true`, `cachingMode: ReadWrite`, `fsType: ext4`, `skuName: ${single_storage_type}`. The CSI driver itself is preinstalled by AKS."
+  openebs:
+    enable_when: "`cluster.storage.driver: openebs`"
+    description: "Helm release of the `openebs` chart in `system-csi`. `localpv-provisioner` is disabled at this layer and enabled by the variant components below so single-node clusters can disable leader election. zfs-localpv, lvm-localpv, and mayastor sub-charts are disabled."
+  openebs/single-node:
+    enable_when: "openebs driver AND single-node topology"
+    description: "Patches the openebs HelmRelease to set `localpv-provisioner.localpv.enableLeaderElection: false`. Avoids Lease churn on single-node clusters."
+  openebs/dynamic-localpv:
+    enable_when: "openebs driver"
+    description: "Enables the openebs localpv-provisioner and creates two StorageClasses (`local`, and `single` as default class). Both use `openebs.io/local` hostpath, `BasePath: ${local_volume_path}`, `WaitForFirstConsumer`."
+  longhorn:
+    enable_when: "`cluster.storage.driver: longhorn`"
+    description: "Helm release of Longhorn in `system-csi`, plus a StorageClass `single` (default class) using `driver.longhorn.io` with `numberOfReplicas: \"1\"`, `volumeBindingMode: Immediate`, `allowVolumeExpansion: true`."
+  longhorn/single-node:
+    enable_when: "longhorn driver AND (single-node topology OR `cluster.controlplanes.schedulable: true`)"
+    description: "Patches the longhorn HelmRelease to add `defaultSettings.taintToleration: \"node-role.kubernetes.io/control-plane:NoSchedule\"` so Longhorn pods schedule on tainted control planes."
+  longhorn/ha:
+    enable_when: "longhorn driver AND ha topology"
+    description: "Patches the longhorn HelmRelease for HA: `defaultReplicaCount: 3`, hard `replicaSoftAntiAffinity: false`, `longhornUI.replicas: 2`, CSI sidecar replicas at 3. Adds a second StorageClass `replicated` with `numberOfReplicas: \"3\"` for explicit multi-replica volumes."
+  longhorn/prometheus:
+    enable_when: "longhorn driver AND `addons.observability.enabled: true`"
+    description: "ServiceMonitor for `longhorn-manager` metrics on the `manager` port."
+
+dependencies:
+  policy-resources:
+    required_when: "`policies.enabled: true`"
+    reason: "`system-csi` runs at PSA `privileged`; Kyverno's image-digest and admission policies must be live before CSI driver pods are admitted."
+  cni:
+    required_when: "always (added by `option-cni`)"
+    reason: "CSI's `node-driver-registrar` sees transient loopback connectivity drops during eBPF init and crash-loops without this ordering."
+  telemetry-base:
+    required_when: "longhorn driver AND (`telemetry.metrics.enabled: true` OR `telemetry.logs.enabled: true`)"
+    reason: "The `longhorn/prometheus` ServiceMonitor needs Prometheus to be live."

--- a/kustomize/csi/README.md
+++ b/kustomize/csi/README.md
@@ -1,0 +1,146 @@
+---
+title: CSI add-on
+description: Persistent storage drivers and StorageClasses. AWS EBS, Azure Disk, OpenEBS host-path, and Longhorn distributed.
+---
+
+# CSI
+
+The cluster's persistent-volume layer. Four drivers ship in this add-on,
+one selected per cluster:
+
+- `aws-ebs` for EKS, `azure-disk` for AKS — StorageClass-only wrappers
+  around the cloud's preinstalled CSI driver.
+- `openebs` for local single-node clusters — Helm release plus a hostpath
+  provisioner that allocates from a directory on each node.
+- `longhorn` for HA or schedulable-controlplane clusters — Helm release
+  of a distributed replicated block-storage system.
+
+The default StorageClass is always named `single` regardless of driver,
+so workloads asking for the default disk get a per-cluster-appropriate
+provisioner without knowing which one is wired. Longhorn HA clusters
+also expose a `replicated` class for explicit multi-replica volumes.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  flux[Flux helm-controller]
+
+  subgraph systemcsi[system-csi]
+    hr_openebs[HelmRelease openebs]
+    hr_longhorn[HelmRelease longhorn]
+    sc_single[StorageClass 'single']
+    sc_replicated[StorageClass 'replicated']
+
+    subgraph workloads[driver workloads]
+      openebs_pods[openebs-localpv-provisioner]
+      longhorn_pods[longhorn-manager DaemonSet<br/>longhorn-instance-manager<br/>longhorn-csi-plugin]
+    end
+  end
+
+  pvc[PersistentVolumeClaim] --> sc_single
+  pvc --> sc_replicated
+  flux ==> hr_openebs
+  flux ==> hr_longhorn
+  hr_openebs --> openebs_pods
+  hr_longhorn --> longhorn_pods
+  sc_single -.cloud paths.-> aws[(EBS / Azure Disk<br/>preinstalled CSI)]
+  sc_single -.openebs.-> hostpath[(node hostpath<br/>local_volume_path)]
+  sc_single -.longhorn.-> longhorndist[(replicated block<br/>storage)]
+  sc_replicated -.longhorn ha.-> longhorndist
+```
+
+The cloud drivers are pure-Kubernetes layers — only the StorageClass is
+new; the CSI driver pods are managed by the cloud control plane. OpenEBS
+and Longhorn install full helm releases into `system-csi` and bring their
+own workload pods.
+
+## Recipes
+
+### EKS
+
+```yaml
+- name: csi
+  path: csi
+  dependsOn: [policy-resources, cni]
+  components: [aws-ebs]
+  timeout: 5m
+  substitutions:
+    single_storage_type: gp3
+```
+
+### AKS
+
+```yaml
+- name: csi
+  path: csi
+  dependsOn: [policy-resources, cni]
+  components: [azure-disk]
+  timeout: 5m
+  substitutions:
+    single_storage_type: StandardSSD_LRS
+```
+
+### Local single-node with OpenEBS host-path
+
+```yaml
+- name: csi
+  path: csi
+  dependsOn: [policy-resources, cni]
+  components: [openebs, openebs/single-node, openebs/dynamic-localpv]
+  timeout: 20m
+  substitutions:
+    local_volume_path: /var/mnt/local
+```
+
+### HA cluster with Longhorn
+
+```yaml
+- name: csi
+  path: csi
+  dependsOn: [policy-resources, telemetry-base, cni]
+  components: [longhorn, longhorn/ha, longhorn/prometheus]
+  timeout: 20m
+```
+
+<!-- BEGIN_KUSTOMIZE_DOCS -->
+
+## Substitutions
+
+| Name | Required when | Effect |
+|---|---|---|
+| `single_storage_type` | `aws-ebs` or `azure-disk` is enabled | Disk type for the cloud `single` StorageClass. Sourced from `cluster.storage.single_storage_type`. AWS values: `gp3` (default), `gp2`, `io1`. Azure values: `StandardSSD_LRS` (default), `Premium_LRS`, `UltraSSD_LRS`. |
+| `local_volume_path` | `openebs/dynamic-localpv` is enabled | Host directory the OpenEBS hostpath provisioner allocates from. Sourced from `cluster.storage.local_base_path` (schema default `/var/mnt/local`). The directory must exist on every node before any PVC is created. |
+
+## Components
+
+| Component | Enable when | Effect |
+|---|---|---|
+| `aws-ebs` | platform is AWS (EKS) | StorageClass `single` (default class) using `ebs.csi.aws.com`, `WaitForFirstConsumer`, `allowVolumeExpansion: true`, `encrypted: true`, `fsType: ext4`, `type: ${single_storage_type}`. The CSI driver itself is preinstalled by EKS; this component ships StorageClass only. |
+| `azure-disk` | platform is Azure (AKS) | StorageClass `single` (default class) using `disk.csi.azure.com`, `WaitForFirstConsumer`, `allowVolumeExpansion: true`, `cachingMode: ReadWrite`, `fsType: ext4`, `skuName: ${single_storage_type}`. The CSI driver itself is preinstalled by AKS. |
+| `openebs` | `cluster.storage.driver: openebs` | Helm release of the `openebs` chart in `system-csi`. `localpv-provisioner` is disabled at this layer and enabled by the variant components below so single-node clusters can disable leader election. zfs-localpv, lvm-localpv, and mayastor sub-charts are disabled. |
+| `openebs/single-node` | openebs driver AND single-node topology | Patches the openebs HelmRelease to set `localpv-provisioner.localpv.enableLeaderElection: false`. Avoids Lease churn on single-node clusters. |
+| `openebs/dynamic-localpv` | openebs driver | Enables the openebs localpv-provisioner and creates two StorageClasses (`local`, and `single` as default class). Both use `openebs.io/local` hostpath, `BasePath: ${local_volume_path}`, `WaitForFirstConsumer`. |
+| `longhorn` | `cluster.storage.driver: longhorn` | Helm release of Longhorn in `system-csi`, plus a StorageClass `single` (default class) using `driver.longhorn.io` with `numberOfReplicas: "1"`, `volumeBindingMode: Immediate`, `allowVolumeExpansion: true`. |
+| `longhorn/single-node` | longhorn driver AND (single-node topology OR `cluster.controlplanes.schedulable: true`) | Patches the longhorn HelmRelease to add `defaultSettings.taintToleration: "node-role.kubernetes.io/control-plane:NoSchedule"` so Longhorn pods schedule on tainted control planes. |
+| `longhorn/ha` | longhorn driver AND ha topology | Patches the longhorn HelmRelease for HA: `defaultReplicaCount: 3`, hard `replicaSoftAntiAffinity: false`, `longhornUI.replicas: 2`, CSI sidecar replicas at 3. Adds a second StorageClass `replicated` with `numberOfReplicas: "3"` for explicit multi-replica volumes. |
+| `longhorn/prometheus` | longhorn driver AND `addons.observability.enabled: true` | ServiceMonitor for `longhorn-manager` metrics on the `manager` port. |
+
+## Dependencies
+
+| Add-on | Required when | Reason |
+|---|---|---|
+| `policy-resources` | `policies.enabled: true` | `system-csi` runs at PSA `privileged`; Kyverno's image-digest and admission policies must be live before CSI driver pods are admitted. |
+| `cni` | always (added by `option-cni`) | CSI's `node-driver-registrar` sees transient loopback connectivity drops during eBPF init and crash-loops without this ordering. |
+| `telemetry-base` | longhorn driver AND (`telemetry.metrics.enabled: true` OR `telemetry.logs.enabled: true`) | The `longhorn/prometheus` ServiceMonitor needs Prometheus to be live. |
+
+<!-- END_KUSTOMIZE_DOCS -->
+
+## See also
+
+- [contexts/_template/facets/platform-aws.yaml](../../contexts/_template/facets/platform-aws.yaml) — AWS EBS wiring.
+- [contexts/_template/facets/platform-azure.yaml](../../contexts/_template/facets/platform-azure.yaml) — Azure Disk wiring.
+- [contexts/_template/facets/option-storage.yaml](../../contexts/_template/facets/option-storage.yaml) — OpenEBS and Longhorn driver selection.
+- [contexts/_template/facets/option-single-node.yaml](../../contexts/_template/facets/option-single-node.yaml) — single-node OpenEBS overlay.
+- [contexts/_template/facets/option-cni.yaml](../../contexts/_template/facets/option-cni.yaml) — adds the `cni` reverse dependency.
+- Related add-ons: [policy](../policy/), [cni](../cni/), [telemetry](../telemetry/), [observability](../observability/).

--- a/kustomize/observability/.docs.yaml
+++ b/kustomize/observability/.docs.yaml
@@ -68,7 +68,7 @@ components:
     description: "Helm release of the Quickwit chart in `system-observability`. Search-optimized log store backed by object storage (S3 / Azure Blob / GCS via add-on `object-store`)."
   quickwit/pvc:
     enable_when: "`addons.observability.logs_driver == 'quickwit'`"
-    description: "PVC for the quickwit indexer's staging data. Bound by `cni`'s default StorageClass."
+    description: "PVC for the quickwit indexer's staging data. Bound by `csi`'s default StorageClass."
   quickwit/prometheus:
     enable_when: "`addons.observability.logs_driver == 'quickwit'`"
     description: "ServiceMonitor for quickwit metrics."

--- a/kustomize/observability/.docs.yaml
+++ b/kustomize/observability/.docs.yaml
@@ -1,0 +1,100 @@
+# Descriptor consumed by scripts/kustomize-docs.sh to populate the
+# BEGIN_KUSTOMIZE_DOCS / END_KUSTOMIZE_DOCS region of README.md.
+# Edit this file (not the README tables) when substitutions, components,
+# or dependencies change.
+
+substitutions:
+  external_domain:
+    required_when: "`grafana/gateway` or `kibana/gateway` is enabled"
+    description: "Hostname suffix for the Grafana / Kibana HTTPRoute. Resolves to `dns.public_domain` when set, otherwise `dns.private_domain`."
+  timezone:
+    required_when: "`grafana` is enabled"
+    description: "Grafana display timezone. Sourced from the top-level `timezone` config; defaults to `utc` when unset."
+  date_full:
+    required_when: "`grafana` is enabled"
+    description: "Grafana full date format. Derived from `time_format` (`12h` switches to 12-hour clock); falls back to `YYYY-MM-DD HH:mm:ss`."
+  date_interval_second:
+    required_when: "`grafana` is enabled"
+    description: "Grafana second-granularity timestamp format on time series; tracks `time_format`."
+  date_interval_minute:
+    required_when: "`grafana` is enabled"
+    description: "Grafana minute-granularity timestamp format."
+  date_interval_hour:
+    required_when: "`grafana` is enabled"
+    description: "Grafana hour-granularity timestamp format."
+  date_interval_day:
+    required_when: "`grafana` is enabled"
+    description: "Grafana day-granularity timestamp format."
+
+components:
+  grafana:
+    enable_when: "`addons.observability.dashboards == 'grafana'`"
+    description: "Helm release of the Grafana chart in `system-observability`. Provides the Grafana UI, sidecar dashboard loader, and a default Prometheus datasource. Image tag and chart version tracked by Renovate."
+  grafana/prometheus:
+    enable_when: "`addons.observability.dashboards == 'grafana'`"
+    description: "Patches the grafana HelmRelease with the Prometheus datasource URL and adds prometheus-internals dashboards. (Deprecated forwarder for `dashboards/prometheus` plus helm patches; consolidates in v0.8.0.)"
+  grafana/dashboards/*:
+    enable_when: "varies per dashboard"
+    description: "Per-topic dashboard ConfigMaps loaded by the Grafana sidecar. Always-on: `node`, `kubernetes`, `flux`, `cert-manager`, `fluent-bit`, `fluentd`. Conditional: `cloudnativepg` (when CNPG is the database driver), `longhorn` (when csi=longhorn), `cilium` (when cni=cilium), `envoy` (when gateway.driver=envoy), `logs/quickwit` (when logs_driver=quickwit). Each ships as a separate component path."
+  grafana/gateway:
+    enable_when: "`addons.observability.dashboards == 'grafana'` AND `gateway.enabled: true`"
+    description: "HTTPRoute exposing Grafana at `grafana.${external_domain}` through the cluster Gateway. Skipped on clusters without Gateway API."
+  grafana/dev:
+    enable_when: "`dev == true`"
+    description: "Patches the grafana HelmRelease to disable persistence and lower resource requests. Used by dev contexts to keep the footprint small."
+  grafana/quickwit:
+    enable_when: "`addons.observability.dashboards == 'grafana'` AND `logs_driver == 'quickwit'`"
+    description: "Adds the Quickwit datasource to Grafana so logs-explore dashboards can query the quickwit indexer. (Deprecated forwarder for `dashboards/quickwit` plus helm patches.)"
+  fluentd:
+    enable_when: "`telemetry.logs.driver == 'fluentd'`"
+    description: "Helm release of the `fluent-operator` chart sourced from a GitRepository (chart embedded in `system-gitops`). Installs the fluent-operator CR controller and a fluentd DaemonSet. Container runtime pinned to `containerd`."
+  fluentd/filters/otel:
+    enable_when: "`telemetry.logs.driver == 'fluentd'`"
+    description: "Fluentd CRDs that normalize log records into OpenTelemetry severity / body / resource fields before they hit the output."
+  fluentd/filters/log-level/*:
+    enable_when: "`telemetry.logs.driver == 'fluentd'` AND `log_level != 'trace'`"
+    description: "One of `info` / `debug` / `warn` filter variants — drops log records below the configured threshold so downstream stores only see what the operator asked for. `trace` skips this component entirely."
+  fluentd/prometheus:
+    enable_when: "`telemetry.logs.driver == 'fluentd'` AND `telemetry.metrics.enabled: true`"
+    description: "Patches the fluentd DaemonSet to expose Prometheus metrics and adds a ServiceMonitor in `system-observability`."
+  fluentd/outputs/stdout:
+    enable_when: "`addons.observability.logs_driver == 'stdout'`"
+    description: "Routes fluentd records to container stdout. No external store. Dev / smoke-test default."
+  fluentd/outputs/quickwit:
+    enable_when: "`addons.observability.logs_driver == 'quickwit'`"
+    description: "Routes fluentd records to the quickwit ingest API with batching and retry tuned for the quickwit `0.8.x` chart."
+  quickwit:
+    enable_when: "`addons.observability.logs_driver == 'quickwit'`"
+    description: "Helm release of the Quickwit chart in `system-observability`. Search-optimized log store backed by object storage (S3 / Azure Blob / GCS via add-on `object-store`)."
+  quickwit/pvc:
+    enable_when: "`addons.observability.logs_driver == 'quickwit'`"
+    description: "PVC for the quickwit indexer's staging data. Bound by `cni`'s default StorageClass."
+  quickwit/prometheus:
+    enable_when: "`addons.observability.logs_driver == 'quickwit'`"
+    description: "ServiceMonitor for quickwit metrics."
+  elasticsearch:
+    enable_when: "`addons.observability.logs_driver == 'elasticsearch'`"
+    description: "Helm release of the Elastic-published Elasticsearch chart in `system-observability`. Bundles a Certificate (issuer = cluster CA) for TLS between client and the ES cluster."
+  kibana:
+    enable_when: "`addons.observability.logs_driver == 'elasticsearch'`"
+    description: "Helm release of the Kibana chart, wired to the elasticsearch service."
+  kibana/gateway:
+    enable_when: "`addons.observability.logs_driver == 'elasticsearch'` AND `gateway.enabled: true`"
+    description: "HTTPRoute exposing Kibana at `kibana.${external_domain}` through the cluster Gateway."
+
+dependencies:
+  telemetry-base:
+    required_when: "always (grafana, fluentd, and dashboards facets all set it)"
+    reason: "Prometheus must be live so Grafana's datasource and fluentd's ServiceMonitor have a scrape target."
+  telemetry-resources:
+    required_when: "any `logs_driver` is selected"
+    reason: "Provides the shared resources (FluentBit / FluentD operator CRDs, ClusterFlow base) the log-driver outputs attach to."
+  csi:
+    required_when: "`logs_driver == 'quickwit'` OR `logs_driver == 'elasticsearch'`"
+    reason: "Quickwit's staging PVC and Elasticsearch's data PVCs both need a working default StorageClass."
+  gateway-resources:
+    required_when: "`logs_driver == 'elasticsearch'` (always) OR `grafana/gateway` is enabled"
+    reason: "HTTPRoutes need the cluster Gateway to be Programmed first."
+  dns:
+    required_when: "`dns.enabled: true` AND `addons.observability.dashboards == 'grafana'`"
+    reason: "External DNS records for `grafana.${external_domain}` and `kibana.${external_domain}` are managed by the dns add-on; without it, hostnames don't resolve."

--- a/kustomize/observability/README.md
+++ b/kustomize/observability/README.md
@@ -153,7 +153,7 @@ back-end Helm release runs alongside.
 | `fluentd/outputs/stdout` | `addons.observability.logs_driver == 'stdout'` | Routes fluentd records to container stdout. No external store. Dev / smoke-test default. |
 | `fluentd/outputs/quickwit` | `addons.observability.logs_driver == 'quickwit'` | Routes fluentd records to the quickwit ingest API with batching and retry tuned for the quickwit `0.8.x` chart. |
 | `quickwit` | `addons.observability.logs_driver == 'quickwit'` | Helm release of the Quickwit chart in `system-observability`. Search-optimized log store backed by object storage (S3 / Azure Blob / GCS via add-on `object-store`). |
-| `quickwit/pvc` | `addons.observability.logs_driver == 'quickwit'` | PVC for the quickwit indexer's staging data. Bound by `cni`'s default StorageClass. |
+| `quickwit/pvc` | `addons.observability.logs_driver == 'quickwit'` | PVC for the quickwit indexer's staging data. Bound by `csi`'s default StorageClass. |
 | `quickwit/prometheus` | `addons.observability.logs_driver == 'quickwit'` | ServiceMonitor for quickwit metrics. |
 | `elasticsearch` | `addons.observability.logs_driver == 'elasticsearch'` | Helm release of the Elastic-published Elasticsearch chart in `system-observability`. Bundles a Certificate (issuer = cluster CA) for TLS between client and the ES cluster. |
 | `kibana` | `addons.observability.logs_driver == 'elasticsearch'` | Helm release of the Kibana chart, wired to the elasticsearch service. |

--- a/kustomize/observability/README.md
+++ b/kustomize/observability/README.md
@@ -1,0 +1,181 @@
+---
+title: Observability add-on
+description: Grafana dashboards and the cluster's log store (stdout, Quickwit, or Elasticsearch + Kibana).
+---
+
+# Observability
+
+The dashboards-and-logs layer. Two halves that can be enabled independently:
+
+- **Dashboards** — Grafana with a Prometheus datasource and per-add-on
+  dashboards. Set `addons.observability.dashboards: grafana`.
+- **Log store** — fluentd ships records to one of three back-ends:
+  `stdout` (dev), `quickwit` (production default), or `elasticsearch` +
+  `kibana` (when ES is already the team's standard). Set
+  `addons.observability.logs_driver` to choose.
+
+The metric pipeline (Prometheus, fluent-bit) lives in the `telemetry`
+add-on; this add-on assumes telemetry-base is already producing metrics
+and shipping logs to fluentd's input.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  flux[Flux helm-controller]
+
+  subgraph systemobs[system-observability]
+    grafana_hr[HelmRelease grafana]
+    fluentd_hr[HelmRelease fluent-operator]
+    quickwit_hr[HelmRelease quickwit]
+    es_hr[HelmRelease elasticsearch]
+    kibana_hr[HelmRelease kibana]
+
+    grafana_pods[grafana StatefulSet]
+    fluentd_pods[fluentd DaemonSet]
+    quickwit_pods[quickwit indexer + searcher]
+    es_pods[elasticsearch StatefulSet]
+    kibana_pods[kibana Deployment]
+  end
+
+  prom[(Prometheus<br/>telemetry add-on)]
+  objstore[(object-store)]
+  gateway[Cluster Gateway]
+
+  flux ==> grafana_hr & fluentd_hr & quickwit_hr & es_hr & kibana_hr
+  grafana_hr --> grafana_pods
+  fluentd_hr --> fluentd_pods
+  quickwit_hr --> quickwit_pods
+  es_hr --> es_pods
+  kibana_hr --> kibana_pods
+
+  prom -.datasource.-> grafana_pods
+  fluentd_pods -.logs.-> quickwit_pods
+  fluentd_pods -.logs.-> es_pods
+  fluentd_pods -.logs.-> stdout([stdout])
+  quickwit_pods -.indices.-> objstore
+  kibana_pods --> es_pods
+
+  gateway --> grafana_pods
+  gateway --> kibana_pods
+```
+
+Grafana, fluentd, quickwit, elasticsearch, and kibana all live in
+`system-observability`. Fluentd is the universal log shipper; the
+`logs_driver` choice selects which output component is added and which
+back-end Helm release runs alongside.
+
+## Recipes
+
+### Grafana dashboards only (no log store)
+
+```yaml
+- name: observability
+  path: observability
+  dependsOn: [telemetry-base, dns]
+  components:
+    - grafana
+    - grafana/prometheus
+    - grafana/dashboards/node
+    - grafana/dashboards/kubernetes
+    - grafana/dashboards/flux
+    - grafana/dashboards/cert-manager
+    - grafana/dashboards/fluent-bit
+    - grafana/dashboards/fluentd
+  timeout: 15m
+  substitutions:
+    timezone: utc
+    external_domain: example.com
+    date_full: YYYY-MM-DD HH:mm:ss
+    date_interval_second: HH:mm:ss
+    date_interval_minute: HH:mm
+    date_interval_hour: MM/DD HH:mm
+    date_interval_day: MM/DD
+```
+
+### Add Quickwit as the log store
+
+```yaml
+- name: observability
+  path: observability
+  dependsOn: [csi, telemetry-resources]
+  components:
+    - fluentd/outputs/quickwit
+    - quickwit
+    - quickwit/pvc
+    - quickwit/prometheus
+    - grafana/quickwit
+    - grafana/dashboards/logs/quickwit
+```
+
+### Elasticsearch + Kibana log store
+
+```yaml
+- name: observability
+  path: observability
+  dependsOn: [csi, gateway-resources]
+  components:
+    - elasticsearch
+    - kibana
+    - kibana/gateway
+  substitutions:
+    external_domain: example.com
+```
+
+<!-- BEGIN_KUSTOMIZE_DOCS -->
+
+## Substitutions
+
+| Name | Required when | Effect |
+|---|---|---|
+| `external_domain` | `grafana/gateway` or `kibana/gateway` is enabled | Hostname suffix for the Grafana / Kibana HTTPRoute. Resolves to `dns.public_domain` when set, otherwise `dns.private_domain`. |
+| `timezone` | `grafana` is enabled | Grafana display timezone. Sourced from the top-level `timezone` config; defaults to `utc` when unset. |
+| `date_full` | `grafana` is enabled | Grafana full date format. Derived from `time_format` (`12h` switches to 12-hour clock); falls back to `YYYY-MM-DD HH:mm:ss`. |
+| `date_interval_second` | `grafana` is enabled | Grafana second-granularity timestamp format on time series; tracks `time_format`. |
+| `date_interval_minute` | `grafana` is enabled | Grafana minute-granularity timestamp format. |
+| `date_interval_hour` | `grafana` is enabled | Grafana hour-granularity timestamp format. |
+| `date_interval_day` | `grafana` is enabled | Grafana day-granularity timestamp format. |
+
+## Components
+
+| Component | Enable when | Effect |
+|---|---|---|
+| `grafana` | `addons.observability.dashboards == 'grafana'` | Helm release of the Grafana chart in `system-observability`. Provides the Grafana UI, sidecar dashboard loader, and a default Prometheus datasource. Image tag and chart version tracked by Renovate. |
+| `grafana/prometheus` | `addons.observability.dashboards == 'grafana'` | Patches the grafana HelmRelease with the Prometheus datasource URL and adds prometheus-internals dashboards. (Deprecated forwarder for `dashboards/prometheus` plus helm patches; consolidates in v0.8.0.) |
+| `grafana/dashboards/*` | varies per dashboard | Per-topic dashboard ConfigMaps loaded by the Grafana sidecar. Always-on: `node`, `kubernetes`, `flux`, `cert-manager`, `fluent-bit`, `fluentd`. Conditional: `cloudnativepg` (when CNPG is the database driver), `longhorn` (when csi=longhorn), `cilium` (when cni=cilium), `envoy` (when gateway.driver=envoy), `logs/quickwit` (when logs_driver=quickwit). Each ships as a separate component path. |
+| `grafana/gateway` | `addons.observability.dashboards == 'grafana'` AND `gateway.enabled: true` | HTTPRoute exposing Grafana at `grafana.${external_domain}` through the cluster Gateway. Skipped on clusters without Gateway API. |
+| `grafana/dev` | `dev == true` | Patches the grafana HelmRelease to disable persistence and lower resource requests. Used by dev contexts to keep the footprint small. |
+| `grafana/quickwit` | `addons.observability.dashboards == 'grafana'` AND `logs_driver == 'quickwit'` | Adds the Quickwit datasource to Grafana so logs-explore dashboards can query the quickwit indexer. (Deprecated forwarder for `dashboards/quickwit` plus helm patches.) |
+| `fluentd` | `telemetry.logs.driver == 'fluentd'` | Helm release of the `fluent-operator` chart sourced from a GitRepository (chart embedded in `system-gitops`). Installs the fluent-operator CR controller and a fluentd DaemonSet. Container runtime pinned to `containerd`. |
+| `fluentd/filters/otel` | `telemetry.logs.driver == 'fluentd'` | Fluentd CRDs that normalize log records into OpenTelemetry severity / body / resource fields before they hit the output. |
+| `fluentd/filters/log-level/*` | `telemetry.logs.driver == 'fluentd'` AND `log_level != 'trace'` | One of `info` / `debug` / `warn` filter variants — drops log records below the configured threshold so downstream stores only see what the operator asked for. `trace` skips this component entirely. |
+| `fluentd/prometheus` | `telemetry.logs.driver == 'fluentd'` AND `telemetry.metrics.enabled: true` | Patches the fluentd DaemonSet to expose Prometheus metrics and adds a ServiceMonitor in `system-observability`. |
+| `fluentd/outputs/stdout` | `addons.observability.logs_driver == 'stdout'` | Routes fluentd records to container stdout. No external store. Dev / smoke-test default. |
+| `fluentd/outputs/quickwit` | `addons.observability.logs_driver == 'quickwit'` | Routes fluentd records to the quickwit ingest API with batching and retry tuned for the quickwit `0.8.x` chart. |
+| `quickwit` | `addons.observability.logs_driver == 'quickwit'` | Helm release of the Quickwit chart in `system-observability`. Search-optimized log store backed by object storage (S3 / Azure Blob / GCS via add-on `object-store`). |
+| `quickwit/pvc` | `addons.observability.logs_driver == 'quickwit'` | PVC for the quickwit indexer's staging data. Bound by `cni`'s default StorageClass. |
+| `quickwit/prometheus` | `addons.observability.logs_driver == 'quickwit'` | ServiceMonitor for quickwit metrics. |
+| `elasticsearch` | `addons.observability.logs_driver == 'elasticsearch'` | Helm release of the Elastic-published Elasticsearch chart in `system-observability`. Bundles a Certificate (issuer = cluster CA) for TLS between client and the ES cluster. |
+| `kibana` | `addons.observability.logs_driver == 'elasticsearch'` | Helm release of the Kibana chart, wired to the elasticsearch service. |
+| `kibana/gateway` | `addons.observability.logs_driver == 'elasticsearch'` AND `gateway.enabled: true` | HTTPRoute exposing Kibana at `kibana.${external_domain}` through the cluster Gateway. |
+
+## Dependencies
+
+| Add-on | Required when | Reason |
+|---|---|---|
+| `telemetry-base` | always (grafana, fluentd, and dashboards facets all set it) | Prometheus must be live so Grafana's datasource and fluentd's ServiceMonitor have a scrape target. |
+| `telemetry-resources` | any `logs_driver` is selected | Provides the shared resources (FluentBit / FluentD operator CRDs, ClusterFlow base) the log-driver outputs attach to. |
+| `csi` | `logs_driver == 'quickwit'` OR `logs_driver == 'elasticsearch'` | Quickwit's staging PVC and Elasticsearch's data PVCs both need a working default StorageClass. |
+| `gateway-resources` | `logs_driver == 'elasticsearch'` (always) OR `grafana/gateway` is enabled | HTTPRoutes need the cluster Gateway to be Programmed first. |
+| `dns` | `dns.enabled: true` AND `addons.observability.dashboards == 'grafana'` | External DNS records for `grafana.${external_domain}` and `kibana.${external_domain}` are managed by the dns add-on; without it, hostnames don't resolve. |
+
+<!-- END_KUSTOMIZE_DOCS -->
+
+## See also
+
+- [contexts/_template/facets/addon-observability.yaml](../../contexts/_template/facets/addon-observability.yaml) — canonical wiring for dashboards and log stores.
+- [contexts/_template/facets/platform-base.yaml](../../contexts/_template/facets/platform-base.yaml) — fluentd base shipper wiring.
+- [contexts/_template/facets/option-storage.yaml](../../contexts/_template/facets/option-storage.yaml) — Longhorn dashboard injection.
+- [contexts/_template/facets/option-cni.yaml](../../contexts/_template/facets/option-cni.yaml) — Cilium dashboard injection.
+- [contexts/_template/facets/addon-database.yaml](../../contexts/_template/facets/addon-database.yaml) — CloudNativePG dashboard injection.
+- Related add-ons: [telemetry](../telemetry/), [pki](../pki/), [object-store](../object-store/), [csi](../csi/), [gateway](../gateway/), [dns](../dns/).

--- a/scripts/sync-reference.mjs
+++ b/scripts/sync-reference.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+/**
+ * Materialize each kustomize and terraform README.md into docs/reference/
+ * for windsorcli.github.io ingest.
+ *
+ * Run from repo root: node scripts/sync-reference.mjs
+ *
+ * Output layout:
+ *   kustomize/<add-on>/README.md          → docs/reference/kustomize/<add-on>.md
+ *   terraform/<category>/README.md        → docs/reference/terraform/<category>.md
+ *   terraform/<category>/<module>/README  → docs/reference/terraform/<category>/<module>.md
+ *
+ * Also imported by windsorcli.github.io/scripts/vendor-docs.mjs (keep mapping logic in sync).
+ */
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Skip dot-prefixed directories (.terraform/, .git/, .windsor/, etc.)
+function walkReadmes(dir, acc = []) {
+  for (const ent of readdirSync(dir, { withFileTypes: true })) {
+    if (ent.name.startsWith('.')) continue;
+    const p = join(dir, ent.name);
+    if (ent.isDirectory()) walkReadmes(p, acc);
+    else if (ent.name === 'README.md') acc.push(p);
+  }
+  return acc;
+}
+
+function titleFromReadme(srcRoot, readmePath, fallbackPrefix) {
+  const body = readFileSync(readmePath, 'utf8');
+  const m = body.match(/^---\s*[\s\S]*?title:\s*(.+?)\s*$/m);
+  if (m) return m[1].replace(/^["']|["']$/g, '').trim();
+  const h1 = body.replace(/^---[\s\S]*?---\s*/, '').match(/^#\s+(.+)/m);
+  if (h1) return h1[1].trim();
+  const rel = relative(srcRoot, dirname(readmePath));
+  if (!rel || rel === '.') return `${fallbackPrefix} (overview)`;
+  const parts = rel.split(/[/\\]/);
+  return parts[parts.length - 1].replace(/-/g, ' ');
+}
+
+function ensureFrontmatter(srcRoot, srcPath, body, sourceLabel) {
+  if (body.trimStart().startsWith('---')) return body;
+  const title = titleFromReadme(srcRoot, srcPath, sourceLabel);
+  const rel = relative(srcRoot, dirname(srcPath)) || '.';
+  const desc = `Operator notes from ${sourceLabel.toLowerCase()}/${rel} (generated; edit README in ${sourceLabel.toLowerCase()}/).`;
+  return `---\ntitle: ${JSON.stringify(title)}\ndescription: ${JSON.stringify(desc)}\n---\n\n${body}`;
+}
+
+function destPathForReadme(srcRoot, outRoot, readmePath) {
+  const parent = dirname(readmePath);
+  const rel = relative(srcRoot, parent);
+  if (!rel || rel === '.') {
+    return join(outRoot, 'index.md');
+  }
+  const segments = rel.split(/[/\\]/).filter(Boolean);
+  const base = segments.pop();
+  const sub = segments;
+  return join(outRoot, ...sub, `${base}.md`);
+}
+
+export function hasMarkdownUnder(dir) {
+  if (!existsSync(dir)) return false;
+  const stack = [dir];
+  while (stack.length) {
+    const d = stack.pop();
+    for (const ent of readdirSync(d, { withFileTypes: true })) {
+      if (ent.name.startsWith('.')) continue;
+      const p = join(d, ent.name);
+      if (ent.isDirectory()) stack.push(p);
+      else if (ent.name.endsWith('.md')) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Generic materializer used by both kustomize and terraform syncs.
+ * @param {string} srcRoot absolute path to source tree (e.g. .../kustomize, .../terraform)
+ * @param {string} outRoot absolute path to output tree (e.g. .../docs/reference/kustomize)
+ * @param {string} sourceLabel label for synthesized frontmatter ("Kustomize" / "Terraform")
+ * @returns {number} files written
+ */
+function materializeReadmes(srcRoot, outRoot, sourceLabel) {
+  if (!existsSync(srcRoot)) return 0;
+  mkdirSync(outRoot, { recursive: true });
+  const readmes = walkReadmes(srcRoot);
+  let n = 0;
+  for (const readme of readmes) {
+    const raw = readFileSync(readme, 'utf8');
+    const out = destPathForReadme(srcRoot, outRoot, readme);
+    mkdirSync(dirname(out), { recursive: true });
+    writeFileSync(out, ensureFrontmatter(srcRoot, readme, raw, sourceLabel), 'utf8');
+    n += 1;
+  }
+  return n;
+}
+
+export function materializeKustomizeReadmes(kustomizeRoot, outputDir) {
+  return materializeReadmes(kustomizeRoot, outputDir, 'Kustomize');
+}
+
+export function materializeTerraformReadmes(terraformRoot, outputDir) {
+  return materializeReadmes(terraformRoot, outputDir, 'Terraform');
+}
+
+function syncTree(repoRoot, srcName, sourceLabel) {
+  const srcRoot = join(repoRoot, srcName);
+  const outRoot = join(repoRoot, 'docs', 'reference', srcName);
+
+  if (!existsSync(srcRoot)) {
+    console.error(`sync-reference: no ${srcName}/ directory`);
+    return 0;
+  }
+
+  rmSync(outRoot, { recursive: true, force: true });
+  mkdirSync(outRoot, { recursive: true });
+
+  const readmes = walkReadmes(srcRoot);
+  if (readmes.length === 0) {
+    console.warn(`sync-reference: no README.md under ${srcName}/`);
+    return 0;
+  }
+
+  for (const readme of readmes) {
+    const raw = readFileSync(readme, 'utf8');
+    const out = destPathForReadme(srcRoot, outRoot, readme);
+    mkdirSync(dirname(out), { recursive: true });
+    writeFileSync(out, ensureFrontmatter(srcRoot, readme, raw, sourceLabel), 'utf8');
+    console.log(
+      `sync-reference: ${relative(repoRoot, readme)} → ${relative(repoRoot, out)}`,
+    );
+  }
+  console.log(
+    `sync-reference: wrote ${readmes.length} file(s) under docs/reference/${srcName}/`,
+  );
+  return readmes.length;
+}
+
+/** Default: sync both kustomize/ and terraform/ into this repo's docs/reference/ tree. */
+export function syncIntoCoreRepo(coreRepoRoot = join(__dirname, '..')) {
+  const k = syncTree(coreRepoRoot, 'kustomize', 'Kustomize');
+  const t = syncTree(coreRepoRoot, 'terraform', 'Terraform');
+  return k + t;
+}
+
+const entryFile = fileURLToPath(import.meta.url);
+if (process.argv[1] && resolve(process.argv[1]) === entryFile) {
+  syncIntoCoreRepo();
+}


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> This PR touches only documentation and build tooling — no Kubernetes manifests, Helm values, or cluster-facing configuration are modified.
>
> **Overview**
>
> Introduces documentation infrastructure for the CSI and observability add-ons: a README and descriptor YAML for each, plus a new `sync-reference.mjs` script that materializes those READMEs into a `docs/reference/` tree for the windsorcli.github.io website build. The `.gitignore` entry for `docs/` is refined from `docs/` to `docs/*` so the generated output stays local while allowing the directory itself to exist.
>
> The descriptor YAMLs (`.docs.yaml`) act as the single source of truth for component tables and are consumed by the existing `kustomize-docs.sh` generator. One factual error is present: the `quickwit/pvc` description in both the descriptor and the generated README names `cni` as the StorageClass provider — it should be `csi`.
>
> Reviewed by Claude for commit `74df7ea`.

<!-- /claude-code-review:summary -->
