### PR TITLE
chore(docs): update mermaid diagram in object-store README for clarity

### DIFF
--- a/kustomize/object-store/README.md
+++ b/kustomize/object-store/README.md
@@ -28,7 +28,7 @@ flowchart LR
     tenant_svc[Service<br/>S3 API]
   end
 
-  csi[(csi default StorageClass<br/>`single`)]
+  csi[(csi default StorageClass<br/>single)]
   consumers[Workloads<br/>quickwit / etc.]
 
   flux ==> operator_hr


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> Isolated documentation-only change with no impact on configuration, code, or deployed resources.
>
> **Overview**
>
> Removes backticks from a node label in the Mermaid flowchart inside `kustomize/object-store/README.md`. The word `single` (the default StorageClass name) was wrapped in backtick characters, which are not valid as inline code spans inside Mermaid HTML-style node labels and could cause the diagram to fail rendering or display the literal backtick characters depending on the Mermaid version. Dropping them yields clean, portable plain text.
>
> No behavioral change — only diagram rendering is affected.
>
> Reviewed by Claude for commit `23c5c84`.

<!-- /claude-code-review:summary -->
