### PR TITLE
chore(docs): enhance SKILL.md with multi-facet add-on guidelines and examples

### DIFF
--- a/.claude/skills/docs-author/SKILL.md
+++ b/.claude/skills/docs-author/SKILL.md
@@ -83,7 +83,31 @@ dependencies:
     reason: "<single line>"
 ```
 
-Reference: [kustomize/cni/](../../../kustomize/cni/) is the pilot — copy its `README.md` + `.docs.yaml` pair as a template when authoring a new add-on. Align with `.claude/skills/kustomize-author/SKILL.md` for the underlying Kustomize layout.
+Reference: [kustomize/cni/](../../../kustomize/cni/) is the single-facet pilot — copy its `README.md` + `.docs.yaml` pair as a template when authoring a new add-on. Align with `.claude/skills/kustomize-author/SKILL.md` for the underlying Kustomize layout.
+
+### Multi-facet add-ons (`base+resources` split)
+
+Some add-ons split into two Kustomization paths so Flux reconciles CRDs / Helm releases (`<addon>/base`) before the resource CRs that depend on them (`<addon>/resources`). Facets are named `<addon>-base` and `<addon>-resources`; the latter `dependsOn` the former. Active examples: `policy`, `pki`, `telemetry`, `gateway`, `lb`.
+
+`.docs.yaml` adds a top-level `facets:` list and tags each component with its `facet:`:
+
+```yaml
+facets:
+  - <addon>-base
+  - <addon>-resources
+
+components:
+  <name>:
+    facet: <addon>-base
+    enable_when: <string>
+    description: "<single line>"
+```
+
+`scripts/kustomize-docs.sh` renders one `## Components — <facet>` sub-table per facet in declared order. The safety check fails closed on components missing `facet:` or referencing a facet not in the list.
+
+Collision rule: when the same literal name is wired in both facets (e.g. `prometheus` lives in `telemetry-base` as the Helm release and in `telemetry-resources` as ServiceMonitors), use path-prefixed keys in `.docs.yaml` — `base/prometheus`, `resources/prometheus`. Operators still write the bare name in their facets; the path resolves from the facet's `path:`. Call this out in the README intro whenever prefixes appear.
+
+Reference: [kustomize/policy/](../../../kustomize/policy/) is the simplest multi-facet pilot; [kustomize/telemetry/](../../../kustomize/telemetry/) shows the collision-prefix case.
 
 ## Compatibility
 


### PR DESCRIPTION
## Summary

- Codifies the multi-facet `facets:` schema (landed in #1904) in `docs-author/SKILL.md`: naming idiom (`<addon>-base` / `<addon>-resources`), per-component `facet:` field, safety check, and the path-prefix collision rule for cases like `base/prometheus` vs `resources/prometheus`.
- Names `kustomize/policy/` (simplest multi-facet pilot) and `kustomize/telemetry/` (collision-prefix exemplar). Re-labels `kustomize/cni/` as the single-facet pilot for symmetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)