### PR TITLE
chore(docs): Update README files for various modules with detailed descriptions

### DIFF
--- a/kustomize/README.md
+++ b/kustomize/README.md
@@ -1,19 +1,18 @@
 ---
-title: Kustomize add-ons
-description: Index of the cluster add-ons that Flux reconciles via Kustomization CRs.
+title: Kustomize add-on reference
+description: Reference index for the Kustomize add-ons in this blueprint.
 ---
 
 # kustomize/
 
-Each subdirectory here is a cluster add-on that Flux reconciles via a
-Kustomization CR composed from a Windsor facet. The on-cluster
-operator-facing slice (Helm releases, ClusterPolicies, etc.) lives
-here; the IaC slice (cloud accounts, networks, clusters) lives under
-[`terraform/`](../terraform/).
+Reference index for the Kustomize add-ons in this blueprint. The
+**Cluster** narrative on the docs site explains what this layer does,
+which add-ons are required vs. opt-in, and how the schema fields drive
+composition. Links from there land here.
 
 ## Add-ons
 
-| Add-on | Purpose |
+| Path | Purpose |
 |---|---|
 | [cni](cni/) | Container networking. Cilium with optional Gateway API, L2 announcer, Hubble. |
 | [csi](csi/) | Persistent storage drivers and StorageClasses. AWS EBS, Azure Disk, OpenEBS, Longhorn. |
@@ -21,39 +20,9 @@ here; the IaC slice (cloud accounts, networks, clusters) lives under
 | [demo](demo/) | Sample applications (Postgres cluster, static site, Istio bookinfo) for blueprint validation. |
 | [dns](dns/) | external-dns for hostname publication; coredns + etcd for in-cluster private DNS. |
 | [gateway](gateway/) | Gateway API implementation (Envoy Gateway or Cilium) and the cluster's external Gateway. |
-| [gitops](gitops/) | system-gitops namespace + Flux webhook receiver scaffolding (operator-wired via Terraform, not via kustomize facets). |
-| [ingress](ingress/) | Reserved for legacy `Ingress`-style routing (currently unused — operators route via the gateway add-on). |
 | [lb](lb/) | LoadBalancer Service provider: aws-lb-controller, MetalLB, or kube-vip. |
 | [object-store](object-store/) | MinIO Operator for in-cluster S3-compatible object storage. |
 | [observability](observability/) | Grafana dashboards and log store (stdout, Quickwit, or Elasticsearch + Kibana). |
 | [pki](pki/) | cert-manager, trust-manager, and the cluster's ClusterIssuers. |
 | [policy](policy/) | Kyverno admission controller and the baseline ClusterPolicies. |
 | [telemetry](telemetry/) | kube-prometheus-stack and FluentBit for cluster-level metrics and log collection. |
-
-## Conventions
-
-Every add-on README follows a fixed structure: a short intro, an
-Architecture Mermaid diagram, Recipes showing the canonical facet
-entries, and a region between `<!-- BEGIN_KUSTOMIZE_DOCS -->` /
-`<!-- END_KUSTOMIZE_DOCS -->` containing auto-generated Substitutions /
-Components / Dependencies tables. The tables are materialized from
-each add-on's `.docs.yaml` descriptor by [scripts/kustomize-docs.sh](../scripts/kustomize-docs.sh)
-(`task docs:kustomize`). CI fails the build on drift (`task
-docs:kustomize:check`).
-
-**Single- vs multi-facet add-ons.** Several add-ons split across two
-Kustomization paths so Flux can install CRDs (`<addon>-base`) before
-the cluster-resource CRs that depend on them (`<addon>-resources`).
-This pattern is used by `gateway`, `lb`, `pki`, `policy`, and
-`telemetry`. Their `.docs.yaml` declares a `facets:` array and tags
-each component with the facet it belongs to; the generator renders
-one Components sub-table per facet.
-
-For the underlying timeout / interval guidance on the Kustomization /
-HelmRelease CRs, see [GUIDELINES.md](GUIDELINES.md).
-
-## Related
-
-- [terraform/](../terraform/) — cloud-account, network, and cluster modules that bootstrap the platform this add-on tree runs on.
-- [contexts/_template/facets/](../contexts/_template/facets/) — facet definitions that compose these add-ons into deployable bundles.
-- Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/

--- a/kustomize/csi/README.md
+++ b/kustomize/csi/README.md
@@ -9,11 +9,14 @@ The cluster's persistent-volume layer. Four drivers ship in this add-on,
 one selected per cluster:
 
 - `aws-ebs` for EKS, `azure-disk` for AKS — StorageClass-only wrappers
-  around the cloud's preinstalled CSI driver.
+  around the cloud's preinstalled CSI driver. Volumes are AZ- / zone-pinned
+  to the node that first mounts them.
 - `openebs` for local single-node clusters — Helm release plus a hostpath
-  provisioner that allocates from a directory on each node.
-- `longhorn` for HA or schedulable-controlplane clusters — Helm release
-  of a distributed replicated block-storage system.
+  provisioner that allocates from a directory on each node. No replication;
+  volumes are tied to the node they were created on.
+- `longhorn` for HA or schedulable-controlplane clusters — Helm release of
+  a distributed block-storage system that replicates each volume across
+  multiple nodes.
 
 The default StorageClass is always named `single` regardless of driver,
 so workloads asking for the default disk get a per-cluster-appropriate

--- a/kustomize/gateway/README.md
+++ b/kustomize/gateway/README.md
@@ -9,11 +9,14 @@ The cluster's external traffic entrypoint via the Kubernetes Gateway API.
 Two driver options:
 
 - **Envoy Gateway** (default) — a dedicated control-plane and data-plane
-  Envoy stack installed by Helm. Supports per-app `HTTPRouteFilter` for
-  rich response shaping (used here for the catch-all 404).
-- **Cilium** — uses Cilium's built-in Gateway API implementation. No
-  separate Helm release; the `cilium/gateway` component on the `cni`
-  add-on enables `gatewayAPI` on the existing Cilium operator. This
+  Envoy stack installed by Helm. Heavier than Cilium's built-in path, but
+  unlocks advanced L7 (`HTTPRouteFilter`, ext_authz, rich response
+  shaping). Used here for the catch-all 404, and the right pick when you
+  need those knobs.
+- **Cilium** — uses Cilium's built-in Gateway API implementation. Single
+  dataplane for L3/L4 and L7; LoadBalancer Services share IPs via Cilium
+  LBIPAM. No separate Helm release; the `cilium/gateway` component on the
+  `cni` add-on enables `gatewayAPI` on the existing Cilium operator. This
   add-on only contributes the GatewayClass and the LBIPAM-sharing patch.
 
 The add-on splits across two Kustomization paths so Flux can install the

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,69 @@
+---
+title: Terraform layer
+description: Cloud / host substrate — state backend, network, Kubernetes control plane, GitOps bootstrap.
+---
+
+# terraform/
+
+Each subdirectory here is a Terraform module that brings part of the
+cloud or host substrate into existence: the state backend, the network
+fabric, the Kubernetes control plane, the VM substrate (when Talos is
+the cluster driver), and the GitOps bootstrap that hands reconciliation
+off to Flux. Once Flux is up, the [`kustomize/`](../kustomize/) layer
+takes over for everything that runs on the cluster.
+
+## Bootstrap chain
+
+```mermaid
+flowchart LR
+  backend[backend/&lt;driver&gt;]
+  workstation[workstation/&lt;driver&gt;<br/>local hosts only]
+  network[network/&lt;driver&gt;<br/>EKS / AKS only]
+  compute[compute/&lt;driver&gt;<br/>Talos only]
+  cluster[cluster/&lt;driver&gt;]
+  dns[dns/zone/&lt;driver&gt;]
+  gitops[gitops/flux]
+  kustomize[kustomize/ layer]
+
+  backend -- remote state --> network & compute & cluster & dns & gitops
+  workstation -- network + registry --> compute
+  network -- VPC + subnet IDs --> cluster
+  compute -- VM endpoints --> cluster
+  cluster -- kubeconfig --> gitops
+  cluster -- kubeconfig --> dns
+  gitops -- Flux running --> kustomize
+```
+
+The first `windsor bootstrap` runs `backend/<driver>` with local state
+to provision the remote backend. Every later `windsor apply` reads /
+writes through that backend.
+
+## Modules
+
+| Area | Drivers | Purpose |
+|---|---|---|
+| [backend](backend/) | [s3](backend/s3/) · [azurerm](backend/azurerm/) | Remote Terraform state + locking. |
+| [workstation](workstation/) | [docker](workstation/docker/) · [incus](workstation/incus/) | Local-host runtime backing `windsor up` on developer machines. |
+| [network](network/) | [aws-vpc](network/aws-vpc/) · [azure-vnet](network/azure-vnet/) | Cloud-side network fabric (VPC / VNet). EKS and AKS only; Talos clusters skip this layer. |
+| [compute](compute/) | [docker](compute/docker/) · [hyperv](compute/hyperv/) · [incus](compute/incus/) | VM substrate Talos containers/VMs run on. Skipped on EKS / AKS. |
+| [cluster](cluster/) | [aws-eks](cluster/aws-eks/) · [azure-aks](cluster/azure-aks/) · [talos](cluster/talos/) | Kubernetes control plane. |
+| [dns/zone](dns/zone/) | [route53](dns/zone/route53/) · [azure-dns](dns/zone/azure-dns/) | Cloud-side DNS zone external-dns writes into. |
+| [gitops](gitops/) | [flux](gitops/flux/) | Bootstraps Flux so the kustomize/ layer can self-manage. |
+| [cni](cni/) | [cilium](cni/cilium/) | Out-of-band CNI bootstrap for Talos (pods need networking before Flux exists). |
+
+## Conventions
+
+Each module README has a brief hand-written intro followed by an
+auto-generated `<!-- BEGIN_TF_DOCS -->` region (Requirements / Providers
+/ Modules / Resources / Inputs / Outputs). The tables are materialized
+by `terraform-docs` (`task docs:terraform`); CI fails the build on drift
+(`task docs:terraform:check`).
+
+For the underlying terraform style + naming conventions, see
+[`.claude/skills/terraform-style/SKILL.md`](../.claude/skills/terraform-style/SKILL.md).
+
+## Related
+
+- [kustomize/](../kustomize/) — cluster add-ons reconciled by Flux after the bootstrap chain finishes.
+- [contexts/_template/facets/](../contexts/_template/facets/) — facets that compose these modules into deployable bundles.
+- Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,69 +1,32 @@
 ---
-title: Terraform layer
-description: Cloud / host substrate — state backend, network, Kubernetes control plane, GitOps bootstrap.
+title: Terraform module reference
+description: Reference index for the Terraform modules in this blueprint.
 ---
 
 # terraform/
 
-Each subdirectory here is a Terraform module that brings part of the
-cloud or host substrate into existence: the state backend, the network
-fabric, the Kubernetes control plane, the VM substrate (when Talos is
-the cluster driver), and the GitOps bootstrap that hands reconciliation
-off to Flux. Once Flux is up, the [`kustomize/`](../kustomize/) layer
-takes over for everything that runs on the cluster.
-
-## Bootstrap chain
-
-```mermaid
-flowchart LR
-  backend[backend/&lt;driver&gt;]
-  workstation[workstation/&lt;driver&gt;<br/>local hosts only]
-  network[network/&lt;driver&gt;<br/>EKS / AKS only]
-  compute[compute/&lt;driver&gt;<br/>Talos only]
-  cluster[cluster/&lt;driver&gt;]
-  dns[dns/zone/&lt;driver&gt;]
-  gitops[gitops/flux]
-  kustomize[kustomize/ layer]
-
-  backend -- remote state --> network & compute & cluster & dns & gitops
-  workstation -- network + registry --> compute
-  network -- VPC + subnet IDs --> cluster
-  compute -- VM endpoints --> cluster
-  cluster -- kubeconfig --> gitops
-  cluster -- kubeconfig --> dns
-  gitops -- Flux running --> kustomize
-```
-
-The first `windsor bootstrap` runs `backend/<driver>` with local state
-to provision the remote backend. Every later `windsor apply` reads /
-writes through that backend.
+Reference index for the Terraform modules in this blueprint. The
+**Infrastructure** narrative on the docs site explains what this layer
+does, when to pick which driver, and how it relates to the Cluster
+layer. Links from there land here.
 
 ## Modules
 
-| Area | Drivers | Purpose |
-|---|---|---|
-| [backend](backend/) | [s3](backend/s3/) · [azurerm](backend/azurerm/) | Remote Terraform state + locking. |
-| [workstation](workstation/) | [docker](workstation/docker/) · [incus](workstation/incus/) | Local-host runtime backing `windsor up` on developer machines. |
-| [network](network/) | [aws-vpc](network/aws-vpc/) · [azure-vnet](network/azure-vnet/) | Cloud-side network fabric (VPC / VNet). EKS and AKS only; Talos clusters skip this layer. |
-| [compute](compute/) | [docker](compute/docker/) · [hyperv](compute/hyperv/) · [incus](compute/incus/) | VM substrate Talos containers/VMs run on. Skipped on EKS / AKS. |
-| [cluster](cluster/) | [aws-eks](cluster/aws-eks/) · [azure-aks](cluster/azure-aks/) · [talos](cluster/talos/) | Kubernetes control plane. |
-| [dns/zone](dns/zone/) | [route53](dns/zone/route53/) · [azure-dns](dns/zone/azure-dns/) | Cloud-side DNS zone external-dns writes into. |
-| [gitops](gitops/) | [flux](gitops/flux/) | Bootstraps Flux so the kustomize/ layer can self-manage. |
-| [cni](cni/) | [cilium](cni/cilium/) | Out-of-band CNI bootstrap for Talos (pods need networking before Flux exists). |
-
-## Conventions
-
-Each module README has a brief hand-written intro followed by an
-auto-generated `<!-- BEGIN_TF_DOCS -->` region (Requirements / Providers
-/ Modules / Resources / Inputs / Outputs). The tables are materialized
-by `terraform-docs` (`task docs:terraform`); CI fails the build on drift
-(`task docs:terraform:check`).
-
-For the underlying terraform style + naming conventions, see
-[`.claude/skills/terraform-style/SKILL.md`](../.claude/skills/terraform-style/SKILL.md).
-
-## Related
-
-- [kustomize/](../kustomize/) — cluster add-ons reconciled by Flux after the bootstrap chain finishes.
-- [contexts/_template/facets/](../contexts/_template/facets/) — facets that compose these modules into deployable bundles.
-- Blueprint schema and facet syntax — https://www.windsorcli.dev/docs/blueprints/
+| Path | Purpose |
+|---|---|
+| [backend/s3](backend/s3/) | Remote Terraform state on S3 + DynamoDB lock. |
+| [backend/azurerm](backend/azurerm/) | Remote Terraform state on Azure Blob + native lease. |
+| [workstation/docker](workstation/docker/) | Local-host Docker network + registry backing `windsor up`. |
+| [workstation/incus](workstation/incus/) | Local-host Incus bridge + registry. |
+| [network/aws-vpc](network/aws-vpc/) | VPC + public/private subnets + NAT for EKS. |
+| [network/azure-vnet](network/azure-vnet/) | VNet + subnets for AKS. |
+| [compute/docker](compute/docker/) | Talos containers on Docker. |
+| [compute/hyperv](compute/hyperv/) | Talos VMs on Hyper-V (Windows host). |
+| [compute/incus](compute/incus/) | Talos VMs on Incus. |
+| [cluster/aws-eks](cluster/aws-eks/) | Managed Kubernetes on AWS. |
+| [cluster/azure-aks](cluster/azure-aks/) | Managed Kubernetes on Azure. |
+| [cluster/talos](cluster/talos/) | Self-hosted Kubernetes via Talos. |
+| [cni/cilium](cni/cilium/) | Out-of-band Cilium bootstrap for Talos. |
+| [dns/zone/route53](dns/zone/route53/) | Public DNS zone on AWS Route53. |
+| [dns/zone/azure-dns](dns/zone/azure-dns/) | DNS zone on Azure DNS. |
+| [gitops/flux](gitops/flux/) | Flux installation; hands reconciliation to the kustomize/ layer. |

--- a/terraform/backend/azurerm/README.md
+++ b/terraform/backend/azurerm/README.md
@@ -1,3 +1,10 @@
+# backend/azurerm
+
+Remote Terraform state for Azure contexts. The bootstrap pass runs this
+module with a local backend, provisioning a Storage Account and Blob
+container; subsequent applies use Azure's native blob lease for state
+locking — no separate lock table.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/terraform/backend/s3/README.md
+++ b/terraform/backend/s3/README.md
@@ -1,3 +1,11 @@
+# backend/s3
+
+Remote Terraform state for AWS contexts. The bootstrap pass runs this
+module with a local backend, provisioning an S3 bucket (with versioning
+and server-side encryption) and a DynamoDB table for state locking.
+Every subsequent `windsor apply` reads/writes through the bucket and
+acquires the lock.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/terraform/cluster/aws-eks/README.md
+++ b/terraform/cluster/aws-eks/README.md
@@ -1,3 +1,12 @@
+# cluster/aws-eks
+
+Managed Kubernetes control plane on AWS. The module consumes the VPC and
+private subnet IDs from the `network/aws-vpc` outputs, provisions the
+EKS cluster + a managed node group, and creates an OIDC provider so
+in-cluster ServiceAccounts can assume IAM roles via IRSA. The `additions/`
+submodule wires the VPC CNI and EBS CSI driver helpers that EKS expects
+out-of-band.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/terraform/cluster/azure-aks/README.md
+++ b/terraform/cluster/azure-aks/README.md
@@ -1,6 +1,10 @@
-# Azure AKS Module
+# cluster/azure-aks
 
-This module creates an Azure Kubernetes Service (AKS) cluster with configurable node pools, networking, and security settings.
+Managed Kubernetes control plane on Azure. The module creates the AKS
+cluster with workload identity enabled (so in-cluster ServiceAccounts
+can federate to Entra apps without static credentials), key-vault-backed
+disk encryption, and the supporting role assignments. Consumes private
+subnet IDs from the `network/azure-vnet` outputs.
 
 ## Prerequisites
 

--- a/terraform/cluster/talos/README.md
+++ b/terraform/cluster/talos/README.md
@@ -1,11 +1,14 @@
 # cluster/talos
 
-Self-hosted Kubernetes control plane via the Talos API. Terraform talks
-to the Talos machine API directly: nodes come up unprovisioned from the
-`compute/<driver>` layer, then `talosctl bootstrap` brings the control
-plane online and writes a kubeconfig back. The `config/` submodule
-stamps per-node CIDATA seeds; `extensions/` builds the Talos image with
-the required system extensions baked in.
+Self-hosted Kubernetes control plane via the Talos API. Provisioning is
+fully Terraform-driven through the Talos provider — no operator-side
+`talosctl` calls. Nodes come up unprovisioned from `compute/<driver>`,
+then `talos_machine_configuration_apply` pushes machine configs,
+`talos_machine_bootstrap` initiates etcd election on the first control
+plane, and `talos_cluster_kubeconfig` retrieves the kubeconfig once the
+cluster is healthy. The `config/` submodule stamps per-node CIDATA
+seeds; `extensions/` builds the Talos image with the required system
+extensions baked in.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/terraform/cluster/talos/README.md
+++ b/terraform/cluster/talos/README.md
@@ -1,3 +1,12 @@
+# cluster/talos
+
+Self-hosted Kubernetes control plane via the Talos API. Terraform talks
+to the Talos machine API directly: nodes come up unprovisioned from the
+`compute/<driver>` layer, then `talosctl bootstrap` brings the control
+plane online and writes a kubeconfig back. The `config/` submodule
+stamps per-node CIDATA seeds; `extensions/` builds the Talos image with
+the required system extensions baked in.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/terraform/compute/docker/README.md
+++ b/terraform/compute/docker/README.md
@@ -1,3 +1,11 @@
+# compute/docker
+
+VM substrate for Talos clusters when the host runtime is Docker. Default
+on macOS / Linux developer machines; works against Docker Desktop or
+Colima — anything exposing a local Docker socket. Provisions Talos
+control-plane and worker containers that the `cluster/talos` module then
+brings up via the Talos API.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/terraform/compute/hyperv/README.md
+++ b/terraform/compute/hyperv/README.md
@@ -1,3 +1,10 @@
+# compute/hyperv
+
+VM substrate for Talos clusters on Windows hosts. Provisions Talos
+control-plane and worker VMs on the Hyper-V hypervisor (ships with
+Windows Pro / Enterprise / Server) — full-VM isolation, not containers.
+Pairs with the `cluster/talos` module.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/terraform/compute/incus/README.md
+++ b/terraform/compute/incus/README.md
@@ -1,3 +1,11 @@
+# compute/incus
+
+VM substrate for Talos clusters on Incus (LXD's fork). Provisions Talos
+VMs as full-VM instances on the local Incus daemon — pick this over
+`compute/docker` when you need full-VM isolation or kernel features
+Docker-on-Mac can't expose (e.g. nested KVM, real iSCSI). Pairs with the
+`cluster/talos` module.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/terraform/gitops/flux/README.md
+++ b/terraform/gitops/flux/README.md
@@ -1,3 +1,11 @@
+# gitops/flux
+
+Installs Flux into a freshly-provisioned cluster so the Kustomize layer
+under `core/kustomize/` can take over reconciliation. The module ships
+Flux's CRDs and controllers plus a root `GitRepository` + `Kustomization`
+pointed at the context's GitOps repo. After bootstrap this layer is
+mostly inert — Flux self-manages from the repo going forward.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/terraform/network/aws-vpc/README.md
+++ b/terraform/network/aws-vpc/README.md
@@ -1,3 +1,11 @@
+# network/aws-vpc
+
+The cloud-side network fabric for EKS clusters: a VPC with public and
+private subnets, route tables, an Internet Gateway, and per-AZ NAT
+Gateways for private-subnet egress. `azs` / `public_subnets` /
+`private_subnets` are positional — entries at index `i` across the three
+lists describe the same AZ. Outputs feed the `cluster/aws-eks` module.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/terraform/network/azure-vnet/README.md
+++ b/terraform/network/azure-vnet/README.md
@@ -1,3 +1,10 @@
+# network/azure-vnet
+
+The cloud-side network fabric for AKS clusters: a VNet with private
+subnets carved from `cidr_block`. Size the subnets with enough headroom
+for pod IPs when AKS uses Azure CNI (each Pod consumes one VNet IP).
+Outputs feed the `cluster/azure-aks` module.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/terraform/workstation/docker/README.md
+++ b/terraform/workstation/docker/README.md
@@ -1,3 +1,10 @@
+# workstation/docker
+
+Local-host runtime backing `windsor up` on developer machines. Stands up
+the Docker network, optional local OCI registry, and volumes the cluster
+needs before `compute/docker` brings up Talos containers on top. Works
+with Docker Desktop or Colima.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/terraform/workstation/incus/README.md
+++ b/terraform/workstation/incus/README.md
@@ -1,3 +1,9 @@
+# workstation/incus
+
+Local-host runtime backing `windsor up` when `compute.driver` is
+`incus`. Provisions the LXC bridge and an optional local registry that
+`compute/incus` then attaches the Talos VMs to.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> Pure documentation additions across 15 README files; no executable code is touched.
>
> **Overview**
>
> The PR adds narrative header sections to every Terraform module README that previously opened directly into `<!-- BEGIN_TF_DOCS -->` auto-generated content. Each header gives a one-paragraph plain-English description of what the module does and how it fits into the wider provisioning flow — who calls it, what it depends on, and what it produces. Two Kustomize READMEs (`csi`, `gateway`) receive additional inline clarifications on driver behavior.
>
> The one behavioral claim worth verifying is in `cluster/talos`: the text says `talosctl bootstrap` "writes a kubeconfig back," but bootstrap only initializes etcd — kubeconfig retrieval is a separate step (flagged inline). Everything else reads as accurate.
>
> Reviewed by Claude for commit `58b7573`.
<!-- /claude-code-review:summary -->
