### PR TITLE
chore(docs): Enhance documentation with umbrella indices and required frontmatter descriptions for modules

### DIFF
--- a/.claude/skills/docs-author/SKILL.md
+++ b/.claude/skills/docs-author/SKILL.md
@@ -31,7 +31,7 @@ Exact glob roots are finalized with the website `docs:vendor` script; treat the 
 
 ## Frontmatter (Markdown)
 
-- `title` (required), `description` (recommended).
+- `title` (required), `description` (**required for per-module READMEs** — the umbrella generator pulls from it; missing descriptions fail CI).
 - Optional: `sidebar_order` for ingest nav.
 
 ## Voice
@@ -39,10 +39,16 @@ Exact glob roots are finalized with the website `docs:vendor` script; treat the 
 - **Reference only:** imperative, tables for inputs/vars, no marketing copy.
 - Link generic blueprint concepts to `https://www.windsorcli.dev/docs/blueprints/...` (schema, sharing, facets).
 
+## Umbrella indices (`kustomize/README.md`, `terraform/README.md`)
+
+Both umbrella READMEs carry a `<!-- BEGIN_INDEX -->` / `<!-- END_INDEX -->` region populated by `scripts/umbrella-index.sh <root>`. The generator is bundled into the existing per-layer doc tasks: `task docs:kustomize` runs the kustomize index after the add-on tables, `task docs:terraform` runs the terraform index after terraform-docs. CI catches drift via `task docs:kustomize:check` and `task docs:terraform:check` — there is no standalone umbrella task. The generator walks each per-module README (kustomize 1-level-deep; terraform any depth, skipping `.terraform/`), pulls the frontmatter `description:`, and emits a `| path | purpose |` table; missing `description:` fields fail the build.
+
+The umbrellas exist purely as **reference indices** for the site's Infrastructure / Cluster narrative pages to link to. Don't put system overviews, decision matrices, or architecture diagrams in them — that content belongs on the site.
+
 ## Terraform reference
 
-- Generate from modules in this repo with `task docs` (terraform-docs injected between `<!-- BEGIN_TF_DOCS -->` / `<!-- END_TF_DOCS -->` markers in each module's `README.md`). Commit the regenerated `terraform/<module-path>/README.md` (`cluster/talos`, `gitops/flux`, etc.). The site ingest pipeline mirrors these into `docs/reference/terraform/<module-path>/` per the path mapping above; contributors don't write into `docs/reference/` directly.
-- Inputs, outputs, and gotchas belong here; high-level “what is Terraform in Windsor” stays on the site under `/docs/components/terraform`.
+- Generate from modules in this repo with `task docs:terraform` (terraform-docs injected between `<!-- BEGIN_TF_DOCS -->` / `<!-- END_TF_DOCS -->` markers in each module's `README.md`). Commit the regenerated `terraform/<module-path>/README.md` (`cluster/talos`, `gitops/flux`, etc.). CI runs `task docs:terraform:check` to fail on drift. The site ingest pipeline mirrors these into `docs/reference/terraform/<module-path>/` per the path mapping above; contributors don't write into `docs/reference/` directly.
+- Inputs, outputs, and gotchas belong here; high-level "what is Terraform in Windsor" stays on the site under `/docs/components/terraform`.
 
 ## Kustomize add-on README (per `kustomize/<add-on>/`)
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -82,7 +82,7 @@ tasks:
       - cmd: terraform fmt -recursive
 
   docs:terraform:
-    desc: Generate the Inputs/Outputs/Resources tables inside every terraform/<module>/README.md via terraform-docs
+    desc: Generate the Inputs/Outputs/Resources tables inside every terraform/<module>/README.md via terraform-docs, plus the terraform/README.md umbrella index
     silent: true
     cmds:
       - cmd: |
@@ -93,6 +93,7 @@ tasks:
             echo "Generating docs for $dir"
             docker run --rm -v "$(pwd):/src" -w "/src/$dir" quay.io/terraform-docs/terraform-docs:0.20.0 markdown table --output-file README.md --output-mode inject .
           done
+      - scripts/umbrella-index.sh terraform
 
   docs:terraform:check:
     desc: Fail if docs:terraform would produce drift (CI use)
@@ -108,14 +109,16 @@ tasks:
           fi
 
   docs:kustomize:
-    desc: Generate the Substitutions/Components/Dependencies tables inside every kustomize/<add-on>/README.md from its .docs.yaml descriptor
+    desc: Generate the Substitutions/Components/Dependencies tables inside every kustomize/<add-on>/README.md from its .docs.yaml descriptor, plus the kustomize/README.md umbrella index
     cmds:
       - scripts/kustomize-docs.sh --all
+      - scripts/umbrella-index.sh kustomize
 
   docs:kustomize:check:
     desc: Fail if docs:kustomize would produce drift (CI use)
     cmds:
       - scripts/kustomize-docs.sh --check
+      - scripts/umbrella-index.sh --check kustomize
 
   docs:reference:
     desc: Materialize kustomize and terraform READMEs into docs/reference/ for windsorcli.github.io ingest

--- a/kustomize/README.md
+++ b/kustomize/README.md
@@ -12,17 +12,20 @@ composition. Links from there land here.
 
 ## Add-ons
 
+<!-- BEGIN_INDEX -->
+
 | Path | Purpose |
 |---|---|
-| [cni](cni/) | Container networking. Cilium with optional Gateway API, L2 announcer, Hubble. |
-| [csi](csi/) | Persistent storage drivers and StorageClasses. AWS EBS, Azure Disk, OpenEBS, Longhorn. |
+| [cni](cni/) | Cilium as the cluster CNI, bootstrapped via Terraform and adopted by Flux. |
+| [csi](csi/) | Persistent storage drivers and StorageClasses. AWS EBS, Azure Disk, OpenEBS host-path, and Longhorn distributed. |
 | [database](database/) | CloudNativePG operator for in-cluster PostgreSQL. |
-| [demo](demo/) | Sample applications (Postgres cluster, static site, Istio bookinfo) for blueprint validation. |
-| [dns](dns/) | external-dns for hostname publication; coredns + etcd for in-cluster private DNS. |
+| [demo](demo/) | Sample applications (PostgreSQL cluster, static website, Istio bookinfo) for blueprint validation. |
+| [dns](dns/) | external-dns for hostname publication and (opt-in) coredns for in-cluster private DNS. |
 | [gateway](gateway/) | Gateway API implementation (Envoy Gateway or Cilium) and the cluster's external Gateway. |
-| [lb](lb/) | LoadBalancer Service provider: aws-lb-controller, MetalLB, or kube-vip. |
+| [lb](lb/) | LoadBalancer Service implementation (AWS LB Controller, MetalLB, or kube-vip) for non-managed clusters. |
 | [object-store](object-store/) | MinIO Operator for in-cluster S3-compatible object storage. |
-| [observability](observability/) | Grafana dashboards and log store (stdout, Quickwit, or Elasticsearch + Kibana). |
-| [pki](pki/) | cert-manager, trust-manager, and the cluster's ClusterIssuers. |
-| [policy](policy/) | Kyverno admission controller and the baseline ClusterPolicies. |
+| [observability](observability/) | Grafana dashboards and the cluster's log store (stdout, Quickwit, or Elasticsearch + Kibana). |
+| [pki](pki/) | cert-manager, trust-manager, and the cluster's ClusterIssuers (selfsigned, private CA, ACME). |
+| [policy](policy/) | Kyverno admission controller and the cluster's baseline ClusterPolicies. |
 | [telemetry](telemetry/) | kube-prometheus-stack and FluentBit for cluster-level metrics and log collection. |
+<!-- END_INDEX -->

--- a/scripts/umbrella-index.sh
+++ b/scripts/umbrella-index.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+#
+# umbrella-index.sh - Materialize the BEGIN_INDEX / END_INDEX region of
+# kustomize/README.md and terraform/README.md from per-module README
+# frontmatter.
+#
+# Usage:
+#   scripts/umbrella-index.sh                # regen both umbrellas
+#   scripts/umbrella-index.sh --check        # CI: fail on drift
+#
+# Every per-module README (kustomize/*/README.md and terraform/**/README.md,
+# excluding the umbrellas themselves and .terraform/) must have a frontmatter
+# block with `description:` set. Missing descriptions fail the script.
+
+set -euo pipefail
+
+BEGIN_MARKER='<!-- BEGIN_INDEX -->'
+END_MARKER='<!-- END_INDEX -->'
+
+# Extract the description: field from $1's frontmatter, print to stdout.
+# Empty string if no frontmatter or no description field.
+extract_description() {
+  local readme="$1"
+  awk '
+    NR == 1 && $0 == "---" { in_fm = 1; next }
+    in_fm && $0 == "---" { exit }
+    in_fm && /^description:/ {
+      sub(/^description: */, "")
+      gsub(/^"|"$/, "")
+      print
+      exit
+    }
+  ' "$readme"
+}
+
+# List per-module README paths under $1, excluding the umbrella itself.
+# Kustomize add-ons are 1-level-deep (kustomize/<addon>/README.md); nested
+# READMEs there are component-level notes, not add-ons. Terraform modules
+# can be legitimately nested (cluster/talos/config, etc.), so allow any
+# depth — but skip vendored provider READMEs under .terraform/.
+list_modules() {
+  local root="$1"
+  if [ "$root" = "kustomize" ]; then
+    find "$root" -maxdepth 2 -name README.md -type f \
+      -not -path "$root/README.md" \
+      | sort
+  else
+    find "$root" -name README.md -type f \
+      -not -path "*/.terraform/*" \
+      -not -path "$root/README.md" \
+      | sort
+  fi
+}
+
+# Build the index table for $1 (root subtree) into stdout.
+build_table() {
+  local root="$1"
+  local errors=0
+  # `readme` is the loop variable; declared local to keep it from leaking
+  # into the caller (process_one also uses a `readme` variable).
+  local readme rel desc
+
+  printf '| Path | Purpose |\n'
+  printf '|---|---|\n'
+
+  while IFS= read -r readme; do
+    rel="${readme#"$root"/}"
+    rel="${rel%/README.md}"
+
+    desc="$(extract_description "$readme")"
+    if [ -z "$desc" ]; then
+      echo "error: $readme has no frontmatter description:" >&2
+      errors=1
+      continue
+    fi
+
+    printf '| [%s](%s/) | %s |\n' "$rel" "$rel" "$desc"
+  done < <(list_modules "$root")
+
+  return $errors
+}
+
+# Replace the marker region in $readme with the content of $content_file.
+inject() {
+  local readme="$1"
+  local content_file="$2"
+  local tmp
+  tmp="$(mktemp)"
+
+  awk -v begin="$BEGIN_MARKER" -v end="$END_MARKER" -v cf="$content_file" '
+    $0 == begin {
+      print
+      print ""
+      while ((getline line < cf) > 0) print line
+      close(cf)
+      skip = 1
+      next
+    }
+    $0 == end {
+      print
+      skip = 0
+      next
+    }
+    !skip { print }
+  ' "$readme" > "$tmp"
+
+  mv "$tmp" "$readme"
+}
+
+process_one() {
+  local root="$1"
+  local readme="$root/README.md"
+
+  if [ ! -f "$readme" ]; then
+    echo "error: $readme missing" >&2
+    return 1
+  fi
+  if ! grep -qF "$BEGIN_MARKER" "$readme"; then
+    echo "error: $readme missing $BEGIN_MARKER" >&2
+    return 1
+  fi
+  if ! grep -qF "$END_MARKER" "$readme"; then
+    echo "error: $readme missing $END_MARKER" >&2
+    return 1
+  fi
+
+  local table
+  table="$(mktemp)"
+  if ! build_table "$root" > "$table"; then
+    rm -f "$table"
+    return 1
+  fi
+  inject "$readme" "$table"
+  rm -f "$table"
+  echo "ok: $readme" >&2
+}
+
+usage() {
+  cat >&2 <<'USAGE'
+usage:
+  umbrella-index.sh <root>            # regen <root>/README.md (root = kustomize|terraform)
+  umbrella-index.sh --check <root>    # CI: fail on drift in <root>/README.md
+USAGE
+  exit 2
+}
+
+main() {
+  local check=0 root=""
+  case "${1:-}" in
+    --check) check=1; root="${2:-}" ;;
+    -h|--help) usage ;;
+    "") usage ;;
+    *) root="$1" ;;
+  esac
+
+  [[ "$root" == "kustomize" || "$root" == "terraform" ]] || {
+    echo "error: root must be 'kustomize' or 'terraform' (got '$root')" >&2
+    usage
+  }
+
+  # Index roots are repo-relative; without this guard, --check would
+  # silently pass when run from anywhere else.
+  [[ -d "$root" ]] || {
+    echo "error: run umbrella-index.sh from the repo root" >&2
+    exit 1
+  }
+
+  process_one "$root"
+
+  if [ "$check" -eq 1 ]; then
+    if ! git diff --exit-code -- "$root/README.md"; then
+      echo "error: $root/README.md has drift. Run 'task docs:$root' and commit the result." >&2
+      exit 1
+    fi
+  fi
+}
+
+main "$@"

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -12,21 +12,27 @@ layer. Links from there land here.
 
 ## Modules
 
+<!-- BEGIN_INDEX -->
+
 | Path | Purpose |
 |---|---|
-| [backend/s3](backend/s3/) | Remote Terraform state on S3 + DynamoDB lock. |
 | [backend/azurerm](backend/azurerm/) | Remote Terraform state on Azure Blob + native lease. |
-| [workstation/docker](workstation/docker/) | Local-host Docker network + registry backing `windsor up`. |
-| [workstation/incus](workstation/incus/) | Local-host Incus bridge + registry. |
-| [network/aws-vpc](network/aws-vpc/) | VPC + public/private subnets + NAT for EKS. |
-| [network/azure-vnet](network/azure-vnet/) | VNet + subnets for AKS. |
+| [backend/s3](backend/s3/) | Remote Terraform state on S3 + DynamoDB lock. |
+| [cluster/aws-eks](cluster/aws-eks/) | Managed Kubernetes control plane on AWS. |
+| [cluster/aws-eks/additions](cluster/aws-eks/additions/) | VPC CNI and EBS CSI driver helpers for EKS. |
+| [cluster/azure-aks](cluster/azure-aks/) | Managed Kubernetes control plane on Azure. |
+| [cluster/talos](cluster/talos/) | Self-hosted Kubernetes control plane via the Talos API. |
+| [cluster/talos/config](cluster/talos/config/) | Per-node Talos machine config + CIDATA seeds. |
+| [cluster/talos/extensions](cluster/talos/extensions/) | Talos image build with system extensions. |
+| [cni/cilium](cni/cilium/) | Out-of-band Cilium bootstrap for Talos clusters. |
 | [compute/docker](compute/docker/) | Talos containers on Docker. |
 | [compute/hyperv](compute/hyperv/) | Talos VMs on Hyper-V (Windows host). |
 | [compute/incus](compute/incus/) | Talos VMs on Incus. |
-| [cluster/aws-eks](cluster/aws-eks/) | Managed Kubernetes on AWS. |
-| [cluster/azure-aks](cluster/azure-aks/) | Managed Kubernetes on Azure. |
-| [cluster/talos](cluster/talos/) | Self-hosted Kubernetes via Talos. |
-| [cni/cilium](cni/cilium/) | Out-of-band Cilium bootstrap for Talos. |
-| [dns/zone/route53](dns/zone/route53/) | Public DNS zone on AWS Route53. |
 | [dns/zone/azure-dns](dns/zone/azure-dns/) | DNS zone on Azure DNS. |
+| [dns/zone/route53](dns/zone/route53/) | Public DNS zone on AWS Route53. |
 | [gitops/flux](gitops/flux/) | Flux installation; hands reconciliation to the kustomize/ layer. |
+| [network/aws-vpc](network/aws-vpc/) | VPC + public/private subnets + NAT for EKS. |
+| [network/azure-vnet](network/azure-vnet/) | VNet + subnets for AKS. |
+| [workstation/docker](workstation/docker/) | Local-host Docker network + registry. |
+| [workstation/incus](workstation/incus/) | Local-host Incus bridge + registry. |
+<!-- END_INDEX -->

--- a/terraform/backend/azurerm/README.md
+++ b/terraform/backend/azurerm/README.md
@@ -1,3 +1,8 @@
+---
+title: backend/azurerm
+description: Remote Terraform state on Azure Blob + native lease.
+---
+
 # backend/azurerm
 
 Remote Terraform state for Azure contexts. The bootstrap pass runs this

--- a/terraform/backend/s3/README.md
+++ b/terraform/backend/s3/README.md
@@ -1,3 +1,8 @@
+---
+title: backend/s3
+description: Remote Terraform state on S3 + DynamoDB lock.
+---
+
 # backend/s3
 
 Remote Terraform state for AWS contexts. The bootstrap pass runs this

--- a/terraform/cluster/aws-eks/README.md
+++ b/terraform/cluster/aws-eks/README.md
@@ -1,3 +1,8 @@
+---
+title: cluster/aws-eks
+description: Managed Kubernetes control plane on AWS.
+---
+
 # cluster/aws-eks
 
 Managed Kubernetes control plane on AWS. The module consumes the VPC and

--- a/terraform/cluster/aws-eks/additions/README.md
+++ b/terraform/cluster/aws-eks/additions/README.md
@@ -1,3 +1,10 @@
+---
+title: cluster/aws-eks/additions
+description: VPC CNI and EBS CSI driver helpers for EKS.
+---
+
+# cluster/aws-eks/additions
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/terraform/cluster/azure-aks/README.md
+++ b/terraform/cluster/azure-aks/README.md
@@ -1,3 +1,8 @@
+---
+title: cluster/azure-aks
+description: Managed Kubernetes control plane on Azure.
+---
+
 # cluster/azure-aks
 
 Managed Kubernetes control plane on Azure. The module creates the AKS

--- a/terraform/cluster/talos/README.md
+++ b/terraform/cluster/talos/README.md
@@ -1,3 +1,8 @@
+---
+title: cluster/talos
+description: Self-hosted Kubernetes control plane via the Talos API.
+---
+
 # cluster/talos
 
 Self-hosted Kubernetes control plane via the Talos API. Provisioning is

--- a/terraform/cluster/talos/config/README.md
+++ b/terraform/cluster/talos/config/README.md
@@ -1,3 +1,10 @@
+---
+title: cluster/talos/config
+description: Per-node Talos machine config + CIDATA seeds.
+---
+
+# cluster/talos/config
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/terraform/cluster/talos/extensions/README.md
+++ b/terraform/cluster/talos/extensions/README.md
@@ -1,3 +1,10 @@
+---
+title: cluster/talos/extensions
+description: Talos image build with system extensions.
+---
+
+# cluster/talos/extensions
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/terraform/cni/cilium/README.md
+++ b/terraform/cni/cilium/README.md
@@ -1,3 +1,10 @@
+---
+title: cni/cilium
+description: Out-of-band Cilium bootstrap for Talos clusters.
+---
+
+# cni/cilium
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/terraform/compute/docker/README.md
+++ b/terraform/compute/docker/README.md
@@ -1,3 +1,8 @@
+---
+title: compute/docker
+description: Talos containers on Docker.
+---
+
 # compute/docker
 
 VM substrate for Talos clusters when the host runtime is Docker. Default

--- a/terraform/compute/hyperv/README.md
+++ b/terraform/compute/hyperv/README.md
@@ -1,3 +1,8 @@
+---
+title: compute/hyperv
+description: Talos VMs on Hyper-V (Windows host).
+---
+
 # compute/hyperv
 
 VM substrate for Talos clusters on Windows hosts. Provisions Talos

--- a/terraform/compute/incus/README.md
+++ b/terraform/compute/incus/README.md
@@ -1,3 +1,8 @@
+---
+title: compute/incus
+description: Talos VMs on Incus.
+---
+
 # compute/incus
 
 VM substrate for Talos clusters on Incus (LXD's fork). Provisions Talos

--- a/terraform/dns/zone/azure-dns/README.md
+++ b/terraform/dns/zone/azure-dns/README.md
@@ -1,3 +1,10 @@
+---
+title: dns/zone/azure-dns
+description: DNS zone on Azure DNS.
+---
+
+# dns/zone/azure-dns
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/terraform/dns/zone/route53/README.md
+++ b/terraform/dns/zone/route53/README.md
@@ -1,3 +1,8 @@
+---
+title: dns/zone/route53
+description: Public DNS zone on AWS Route53.
+---
+
 # dns/zone/route53
 
 Creates a public Route53 hosted zone for a domain. Kept independent of any

--- a/terraform/gitops/flux/README.md
+++ b/terraform/gitops/flux/README.md
@@ -1,3 +1,8 @@
+---
+title: gitops/flux
+description: Flux installation; hands reconciliation to the kustomize/ layer.
+---
+
 # gitops/flux
 
 Installs Flux into a freshly-provisioned cluster so the Kustomize layer

--- a/terraform/network/aws-vpc/README.md
+++ b/terraform/network/aws-vpc/README.md
@@ -1,3 +1,8 @@
+---
+title: network/aws-vpc
+description: VPC + public/private subnets + NAT for EKS.
+---
+
 # network/aws-vpc
 
 The cloud-side network fabric for EKS clusters: a VPC with public and

--- a/terraform/network/azure-vnet/README.md
+++ b/terraform/network/azure-vnet/README.md
@@ -1,3 +1,8 @@
+---
+title: network/azure-vnet
+description: VNet + subnets for AKS.
+---
+
 # network/azure-vnet
 
 The cloud-side network fabric for AKS clusters: a VNet with private

--- a/terraform/workstation/docker/README.md
+++ b/terraform/workstation/docker/README.md
@@ -1,3 +1,8 @@
+---
+title: workstation/docker
+description: Local-host Docker network + registry.
+---
+
 # workstation/docker
 
 Local-host runtime backing `windsor up` on developer machines. Stands up

--- a/terraform/workstation/incus/README.md
+++ b/terraform/workstation/incus/README.md
@@ -1,3 +1,8 @@
+---
+title: workstation/incus
+description: Local-host Incus bridge + registry.
+---
+
 # workstation/incus
 
 Local-host runtime backing `windsor up` when `compute.driver` is


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> A documentation-only change: no application code, configuration, or runtime behavior is affected.
>
> **Overview**
>
> Introduces `scripts/umbrella-index.sh`, a generator that reads per-module `description:` frontmatter and materializes `| Path | Purpose |` index tables in `kustomize/README.md` and `terraform/README.md` between `<!-- BEGIN_INDEX -->` / `<!-- END_INDEX -->` markers. The generator is wired into the existing `task docs:kustomize` and `task docs:terraform` task chains, and CI drift checks are added in each check counterpart. Sixteen Terraform module READMEs receive YAML frontmatter blocks to supply the required descriptions.
>
> The two CI check strategies differ by design: `docs:kustomize:check` calls each sub-script in its own `--check` mode, while `docs:terraform:check` regenerates the full terraform tree and scans `git status` across `terraform/`; both correctly surface umbrella drift. One minor edge case: the description extractor strips double-quoted YAML strings but not single-quoted ones — all current modules use bare strings, so this has no effect today.
>
> Reviewed by Claude for commit `d01316b`.

<!-- /claude-code-review:summary -->
