### PR TITLE
chore(docs): Add terraform component readmes

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -26,6 +26,7 @@ layer. Links from there land here.
 | [cluster/talos](cluster/talos/) | Self-hosted Kubernetes control plane via the Talos API. |
 | [cluster/talos/config](cluster/talos/config/) | Per-node Talos machine config + CIDATA seeds. |
 | [cluster/talos/extensions](cluster/talos/extensions/) | Talos image build with system extensions. |
+| [cni](cni/) | Out-of-band Cilium bootstrap for Talos clusters before Flux. |
 | [cni/cilium](cni/cilium/) | Out-of-band Cilium bootstrap for Talos clusters. |
 | [compute](compute/) | Local Talos compute substrate across Docker, Hyper-V, and Incus. |
 | [compute/docker](compute/docker/) | Talos containers on Docker. |

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -26,6 +26,7 @@ layer. Links from there land here.
 | [cluster/talos/config](cluster/talos/config/) | Per-node Talos machine config + CIDATA seeds. |
 | [cluster/talos/extensions](cluster/talos/extensions/) | Talos image build with system extensions. |
 | [cni/cilium](cni/cilium/) | Out-of-band Cilium bootstrap for Talos clusters. |
+| [compute](compute/) | Local Talos compute substrate across Docker, Hyper-V, and Incus. |
 | [compute/docker](compute/docker/) | Talos containers on Docker. |
 | [compute/hyperv](compute/hyperv/) | Talos VMs on Hyper-V (Windows host). |
 | [compute/incus](compute/incus/) | Talos VMs on Incus. |

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -35,6 +35,7 @@ layer. Links from there land here.
 | [dns](dns/) | Public DNS zones for ACME certificates and external-dns. |
 | [dns/zone/azure-dns](dns/zone/azure-dns/) | DNS zone on Azure DNS. |
 | [dns/zone/route53](dns/zone/route53/) | Public DNS zone on AWS Route53. |
+| [gitops](gitops/) | Flux installation that hands reconciliation to the kustomize/ layer. |
 | [gitops/flux](gitops/flux/) | Flux installation; hands reconciliation to the kustomize/ layer. |
 | [network](network/) | Cloud network fabric for managed Kubernetes clusters. |
 | [network/aws-vpc](network/aws-vpc/) | VPC + public/private subnets + NAT for EKS. |

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -30,6 +30,7 @@ layer. Links from there land here.
 | [compute/docker](compute/docker/) | Talos containers on Docker. |
 | [compute/hyperv](compute/hyperv/) | Talos VMs on Hyper-V (Windows host). |
 | [compute/incus](compute/incus/) | Talos VMs on Incus. |
+| [dns](dns/) | Public DNS zones for ACME certificates and external-dns. |
 | [dns/zone/azure-dns](dns/zone/azure-dns/) | DNS zone on Azure DNS. |
 | [dns/zone/route53](dns/zone/route53/) | Public DNS zone on AWS Route53. |
 | [gitops/flux](gitops/flux/) | Flux installation; hands reconciliation to the kustomize/ layer. |

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -16,6 +16,7 @@ layer. Links from there land here.
 
 | Path | Purpose |
 |---|---|
+| [backend](backend/) | Remote Terraform state for cloud contexts (S3, AzureRM). |
 | [backend/azurerm](backend/azurerm/) | Remote Terraform state on Azure Blob + native lease. |
 | [backend/s3](backend/s3/) | Remote Terraform state on S3 + DynamoDB lock. |
 | [cluster](cluster/) | Kubernetes control plane provisioning across Talos, EKS, and AKS. |

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -33,6 +33,7 @@ layer. Links from there land here.
 | [dns/zone/azure-dns](dns/zone/azure-dns/) | DNS zone on Azure DNS. |
 | [dns/zone/route53](dns/zone/route53/) | Public DNS zone on AWS Route53. |
 | [gitops/flux](gitops/flux/) | Flux installation; hands reconciliation to the kustomize/ layer. |
+| [network](network/) | Cloud network fabric for managed Kubernetes clusters. |
 | [network/aws-vpc](network/aws-vpc/) | VPC + public/private subnets + NAT for EKS. |
 | [network/azure-vnet](network/azure-vnet/) | VNet + subnets for AKS. |
 | [workstation/docker](workstation/docker/) | Local-host Docker network + registry. |

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -18,6 +18,7 @@ layer. Links from there land here.
 |---|---|
 | [backend/azurerm](backend/azurerm/) | Remote Terraform state on Azure Blob + native lease. |
 | [backend/s3](backend/s3/) | Remote Terraform state on S3 + DynamoDB lock. |
+| [cluster](cluster/) | Kubernetes control plane provisioning across Talos, EKS, and AKS. |
 | [cluster/aws-eks](cluster/aws-eks/) | Managed Kubernetes control plane on AWS. |
 | [cluster/aws-eks/additions](cluster/aws-eks/additions/) | VPC CNI and EBS CSI driver helpers for EKS. |
 | [cluster/azure-aks](cluster/azure-aks/) | Managed Kubernetes control plane on Azure. |

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -35,7 +35,7 @@ layer. Links from there land here.
 | [dns](dns/) | Public DNS zones for ACME certificates and external-dns. |
 | [dns/zone/azure-dns](dns/zone/azure-dns/) | DNS zone on Azure DNS. |
 | [dns/zone/route53](dns/zone/route53/) | Public DNS zone on AWS Route53. |
-| [gitops](gitops/) | Flux installation that hands reconciliation to the kustomize/ layer. |
+| [gitops](gitops/) | Flux installation that hands reconciliation to the kustomize layer. |
 | [gitops/flux](gitops/flux/) | Flux installation; hands reconciliation to the kustomize/ layer. |
 | [network](network/) | Cloud network fabric for managed Kubernetes clusters. |
 | [network/aws-vpc](network/aws-vpc/) | VPC + public/private subnets + NAT for EKS. |

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -38,6 +38,7 @@ layer. Links from there land here.
 | [network](network/) | Cloud network fabric for managed Kubernetes clusters. |
 | [network/aws-vpc](network/aws-vpc/) | VPC + public/private subnets + NAT for EKS. |
 | [network/azure-vnet](network/azure-vnet/) | VNet + subnets for AKS. |
+| [workstation](workstation/) | Local-host networking, registry, and DNS for developer clusters. |
 | [workstation/docker](workstation/docker/) | Local-host Docker network + registry. |
 | [workstation/incus](workstation/incus/) | Local-host Incus bridge + registry. |
 <!-- END_INDEX -->

--- a/terraform/backend/README.md
+++ b/terraform/backend/README.md
@@ -5,14 +5,16 @@ description: Remote Terraform state for cloud contexts (S3, AzureRM).
 
 # Backend
 
-Two drivers provision remote Terraform state infrastructure: `s3` (AWS S3
-bucket + DynamoDB lock) and `azurerm` (Azure Storage Account + Blob with
-native lease). Selection is by `terraform.backend.type`. The `local`,
-`kubernetes`, and `none` backend types do not run a Terraform module —
-they are consumed directly by Terraform without provisioning anything.
+The backend category has two drivers. `s3` provisions an AWS S3
+bucket along with a DynamoDB table for state locking. `azurerm`
+provisions an Azure Storage Account and a Blob container, using
+Azure's native blob lease for locking. The driver is selected by
+`terraform.backend.type`. The `local`, `kubernetes`, and `none`
+backend types don't run a Terraform module; they're consumed directly
+by Terraform without provisioning anything.
 
-The backend stack runs first in every cloud context; downstream stacks
-(`network`, `cluster`, `dns-zone`) all depend on it.
+The backend stack runs first in every cloud context. The downstream
+stacks (`network`, `cluster`, `dns-zone`) all depend on it.
 
 ## Architecture
 
@@ -40,10 +42,10 @@ flowchart LR
   blob --> state
 ```
 
-The bootstrap pass runs each backend module with a **local** state file,
-provisioning the bucket / Storage Account. Subsequent `windsor apply`
-calls then read and write state through the remote backend and hold the
-lock for the duration of the run.
+The bootstrap pass runs each backend module with a local state file,
+which provisions the bucket or Storage Account. Subsequent
+`windsor apply` calls then read and write state through the remote
+backend and hold the lock for the duration of the run.
 
 ## Recipes
 
@@ -56,10 +58,11 @@ terraform:
     type: s3
 ```
 
-Provisions an S3 bucket with versioning and server-side encryption, plus
-a DynamoDB table for state locking. The bucket name and table name
-derive from the context `id` (top-level), keeping state for different
-contexts in distinct paths within the same account.
+The module provisions an S3 bucket with versioning and server-side
+encryption, along with a DynamoDB table for state locking. The bucket
+name and table name derive from the context `id` (top-level), which
+keeps state for different contexts in distinct paths within the same
+account.
 
 ### Azure / AzureRM
 
@@ -70,8 +73,9 @@ terraform:
     type: azurerm
 ```
 
-Provisions a Storage Account and Blob container. Locking uses Azure's
-native blob lease so there is no separate lock table to manage.
+The module provisions a Storage Account and Blob container. Locking
+uses Azure's native blob lease, so there's no separate lock table to
+manage.
 
 ### Local (no backend module)
 
@@ -82,41 +86,49 @@ terraform:
     type: local
 ```
 
-No backend module runs. Terraform state lives next to each stack in the
-context's local state directory. Appropriate for single-operator dev
-clusters and CI runs that don't need to share state across machines.
+No backend module runs. Terraform state lives next to each stack in
+the context's local state directory. This is the right choice for
+single-operator dev clusters and CI runs that don't need to share
+state across machines.
 
 ## Operations
 
-- **Bootstrap chicken-and-egg** — the bucket has to exist before
-  Terraform can use it for state. The s3 / azurerm modules solve this
-  by running with a local backend on the first apply, then handing the
-  state location over to the remote backend for subsequent runs.
-- **State lock held by a dead run** — a crashed `windsor apply` leaves
-  the lock in place. On AWS, delete the row from the DynamoDB lock
-  table; on Azure, release the lease on the state blob. Audit the
-  state first; the lock exists for a reason.
-- **Backend type changed mid-context** — switching `terraform.backend.type`
-  on a context that already has remote state requires manual migration
-  (`terraform init -migrate-state`). Windsor does not auto-migrate.
-- **`type: none` chosen accidentally** — disables backend configuration
-  entirely. Terraform writes state to the default in-memory location,
-  which means no persistence across runs. Reserved for ephemeral test
-  contexts.
+The bootstrap is a chicken-and-egg situation: the bucket has to exist
+before Terraform can use it for state. The `s3` and `azurerm` modules
+solve this by running with a local backend on the first apply, then
+handing the state location over to the remote backend for subsequent
+runs.
+
+A state lock held by a dead run won't release on its own. A crashed
+`windsor apply` leaves the lock in place. On AWS, delete the row from
+the DynamoDB lock table; on Azure, release the lease on the state
+blob. Audit the state first, because the lock exists for a reason.
+
+Switching `terraform.backend.type` on a context that already has
+remote state requires manual migration via
+`terraform init -migrate-state`. Windsor doesn't auto-migrate.
+
+`type: none` disables backend configuration entirely. Terraform then
+writes state to the default in-memory location, which means no
+persistence across runs. This is reserved for ephemeral test
+contexts.
 
 ## Security
 
-- The s3 module enables versioning and SSE on the bucket. Versioning
-  also doubles as a poor-man's audit trail for state writes.
-- The azurerm module uses blob leases for locking; the lease ID is
-  scoped to the Storage Account credential and not visible from outside.
-- Neither module makes the state object public. Bucket ACLs (S3) and
-  Storage Account network rules (Azure) follow account defaults and
-  should be tightened to private subnets / service endpoints in
-  production.
+The `s3` module enables versioning and SSE on the bucket. Versioning
+also doubles as a poor-man's audit trail for state writes.
+
+The `azurerm` module uses blob leases for locking. The lease ID is
+scoped to the Storage Account credential and isn't visible from
+outside.
+
+Neither module makes the state object public. Bucket ACLs on S3 and
+Storage Account network rules on Azure follow account defaults, and
+should be tightened to private subnets or service endpoints in
+production.
 
 ## See also
 
-- [s3/](s3/), [azurerm/](azurerm/) — per-driver Terraform reference.
-- [Terraform backend docs](https://developer.hashicorp.com/terraform/language/backend) — upstream backend reference.
-- [../cluster/](../cluster/), [../network/](../network/) — downstream stacks that read state from the backend.
+- [s3/](s3/) and [azurerm/](azurerm/) for the per-driver Terraform reference.
+- [Terraform backend docs](https://developer.hashicorp.com/terraform/language/backend) for the upstream backend reference.
+- [../cluster/](../cluster/) and [../network/](../network/) for the downstream stacks that read state from the backend.

--- a/terraform/backend/README.md
+++ b/terraform/backend/README.md
@@ -1,0 +1,122 @@
+---
+title: Backend
+description: Remote Terraform state for cloud contexts (S3, AzureRM).
+---
+
+# Backend
+
+Two drivers provision remote Terraform state infrastructure: `s3` (AWS S3
+bucket + DynamoDB lock) and `azurerm` (Azure Storage Account + Blob with
+native lease). Selection is by `terraform.backend.type`. The `local`,
+`kubernetes`, and `none` backend types do not run a Terraform module —
+they are consumed directly by Terraform without provisioning anything.
+
+The backend stack runs first in every cloud context; downstream stacks
+(`network`, `cluster`, `dns-zone`) all depend on it.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  schema[schema.yaml<br/>terraform.backend.type]
+
+  subgraph s3path[S3]
+    tfS3[terraform/backend/s3]
+    bucket[S3 bucket<br/>+ DynamoDB lock]
+  end
+
+  subgraph azpath[AzureRM]
+    tfAz[terraform/backend/azurerm]
+    blob[Storage Account<br/>+ Blob container]
+  end
+
+  state[Remote state<br/>for all stacks]
+
+  schema -->|s3| tfS3
+  schema -->|azurerm| tfAz
+  tfS3 --> bucket
+  tfAz --> blob
+  bucket --> state
+  blob --> state
+```
+
+The bootstrap pass runs each backend module with a **local** state file,
+provisioning the bucket / Storage Account. Subsequent `windsor apply`
+calls then read and write state through the remote backend and hold the
+lock for the duration of the run.
+
+## Recipes
+
+### AWS / S3
+
+```yaml
+platform: aws
+terraform:
+  backend:
+    type: s3
+```
+
+Provisions an S3 bucket with versioning and server-side encryption, plus
+a DynamoDB table for state locking. The bucket name and table name
+derive from the context `id` (top-level), keeping state for different
+contexts in distinct paths within the same account.
+
+### Azure / AzureRM
+
+```yaml
+platform: azure
+terraform:
+  backend:
+    type: azurerm
+```
+
+Provisions a Storage Account and Blob container. Locking uses Azure's
+native blob lease so there is no separate lock table to manage.
+
+### Local (no backend module)
+
+```yaml
+# Any platform; common for dev contexts.
+terraform:
+  backend:
+    type: local
+```
+
+No backend module runs. Terraform state lives next to each stack in the
+context's local state directory. Appropriate for single-operator dev
+clusters and CI runs that don't need to share state across machines.
+
+## Operations
+
+- **Bootstrap chicken-and-egg** — the bucket has to exist before
+  Terraform can use it for state. The s3 / azurerm modules solve this
+  by running with a local backend on the first apply, then handing the
+  state location over to the remote backend for subsequent runs.
+- **State lock held by a dead run** — a crashed `windsor apply` leaves
+  the lock in place. On AWS, delete the row from the DynamoDB lock
+  table; on Azure, release the lease on the state blob. Audit the
+  state first; the lock exists for a reason.
+- **Backend type changed mid-context** — switching `terraform.backend.type`
+  on a context that already has remote state requires manual migration
+  (`terraform init -migrate-state`). Windsor does not auto-migrate.
+- **`type: none` chosen accidentally** — disables backend configuration
+  entirely. Terraform writes state to the default in-memory location,
+  which means no persistence across runs. Reserved for ephemeral test
+  contexts.
+
+## Security
+
+- The s3 module enables versioning and SSE on the bucket. Versioning
+  also doubles as a poor-man's audit trail for state writes.
+- The azurerm module uses blob leases for locking; the lease ID is
+  scoped to the Storage Account credential and not visible from outside.
+- Neither module makes the state object public. Bucket ACLs (S3) and
+  Storage Account network rules (Azure) follow account defaults and
+  should be tightened to private subnets / service endpoints in
+  production.
+
+## See also
+
+- [s3/](s3/), [azurerm/](azurerm/) — per-driver Terraform reference.
+- [Terraform backend docs](https://developer.hashicorp.com/terraform/language/backend) — upstream backend reference.
+- [../cluster/](../cluster/), [../network/](../network/) — downstream stacks that read state from the backend.

--- a/terraform/backend/README.md
+++ b/terraform/backend/README.md
@@ -30,9 +30,7 @@ flowchart LR
   apply[windsor apply]
 
   subgraph aws[AWS account]
-    subgraph bucket[S3 bucket<br/>versioned + KMS-encrypted + public access blocked]
-      state[(state.tfstate)]
-    end
+    state[(state.tfstate<br/>in versioned S3 bucket<br/>public access blocked)]
     lock[DynamoDB table<br/>terraform-state-lock]
     kms[KMS key<br/>state encryption]
   end
@@ -64,14 +62,14 @@ flowchart LR
 
   subgraph azure[Azure resource group]
     sa[Storage account]
-    subgraph container[Blob container]
-      state[(state.tfstate<br/>+ blob lease)]
-    end
+    container[Blob container]
+    state[(state.tfstate<br/>+ blob lease)]
   end
 
   apply -.acquire lease.-> state
   apply -.read / write.-> state
-  container -.lives in.-> sa
+  state -.in.-> container
+  container -.in.-> sa
 ```
 
 ```yaml

--- a/terraform/backend/README.md
+++ b/terraform/backend/README.md
@@ -114,10 +114,11 @@ Switching `terraform.backend.type` on a context that already has
 remote state requires manual migration via
 `terraform init -migrate-state`. Windsor doesn't auto-migrate.
 
-`type: none` disables backend configuration entirely. Terraform then
-writes state to the default in-memory location, which means no
-persistence across runs. This is reserved for ephemeral test
-contexts.
+`type: none` suppresses backend block emission. Terraform then falls
+back to its built-in local backend and writes `terraform.tfstate` to
+the working directory. State is on disk but not centralized or
+locked, which is fine for ephemeral test contexts and inappropriate
+for anything shared across machines.
 
 ## Security
 

--- a/terraform/backend/README.md
+++ b/terraform/backend/README.md
@@ -16,32 +16,6 @@ by Terraform without provisioning anything.
 The backend stack runs first in every cloud context. The downstream
 stacks (`network`, `cluster`, `dns-zone`) all depend on it.
 
-## Architecture
-
-```mermaid
-flowchart LR
-  values[values.yaml<br/>terraform.backend.type]
-
-  subgraph s3path[S3]
-    tfS3[terraform/backend/s3]
-    bucket[S3 bucket<br/>+ DynamoDB lock]
-  end
-
-  subgraph azpath[AzureRM]
-    tfAz[terraform/backend/azurerm]
-    blob[Storage Account<br/>+ Blob container]
-  end
-
-  state[Remote state<br/>for all stacks]
-
-  values -->|s3| tfS3
-  values -->|azurerm| tfAz
-  tfS3 --> bucket
-  tfAz --> blob
-  bucket --> state
-  blob --> state
-```
-
 The bootstrap pass runs each backend module with a local state file,
 which provisions the bucket or Storage Account. Subsequent
 `windsor apply` calls then read and write state through the remote
@@ -51,6 +25,23 @@ backend and hold the lock for the duration of the run.
 
 ### AWS / S3
 
+```mermaid
+flowchart LR
+  apply[windsor apply]
+
+  subgraph aws[AWS account]
+    subgraph bucket[S3 bucket<br/>versioned + KMS-encrypted + public access blocked]
+      state[(state.tfstate)]
+    end
+    lock[DynamoDB table<br/>terraform-state-lock]
+    kms[KMS key<br/>state encryption]
+  end
+
+  apply -.acquire lock.-> lock
+  apply -.read / write.-> state
+  state -.encrypted by.-> kms
+```
+
 ```yaml
 platform: aws
 terraform:
@@ -58,13 +49,30 @@ terraform:
     type: s3
 ```
 
-The module provisions an S3 bucket with versioning and server-side
-encryption, along with a DynamoDB table for state locking. The bucket
-name and table name derive from the context `id` (top-level), which
-keeps state for different contexts in distinct paths within the same
-account.
+The module provisions an S3 bucket with versioning, server-side
+encryption via a managed KMS key, lifecycle rules, and a public
+access block. Locking goes through a DynamoDB table named for the
+context. The bucket name and table name both derive from the context
+`id` (top-level), which keeps state for different contexts in
+distinct paths within the same account.
 
 ### Azure / AzureRM
+
+```mermaid
+flowchart LR
+  apply[windsor apply]
+
+  subgraph azure[Azure resource group]
+    sa[Storage account]
+    subgraph container[Blob container]
+      state[(state.tfstate<br/>+ blob lease)]
+    end
+  end
+
+  apply -.acquire lease.-> state
+  apply -.read / write.-> state
+  container -.lives in.-> sa
+```
 
 ```yaml
 platform: azure
@@ -73,9 +81,9 @@ terraform:
     type: azurerm
 ```
 
-The module provisions a Storage Account and Blob container. Locking
-uses Azure's native blob lease, so there's no separate lock table to
-manage.
+The module provisions a Storage Account and a Blob container. Locking
+uses the native blob lease on the state object itself, so there's no
+separate lock table to manage.
 
 ### Local (no backend module)
 
@@ -115,16 +123,17 @@ contexts.
 
 ## Security
 
-The `s3` module enables versioning and SSE on the bucket. Versioning
-also doubles as a poor-man's audit trail for state writes.
+The `s3` module enables versioning, server-side KMS encryption, and a
+public access block on the bucket. Versioning doubles as a poor-man's
+audit trail for state writes.
 
 The `azurerm` module uses blob leases for locking. The lease ID is
 scoped to the Storage Account credential and isn't visible from
 outside.
 
-Neither module makes the state object public. Bucket ACLs on S3 and
-Storage Account network rules on Azure follow account defaults, and
-should be tightened to private subnets or service endpoints in
+Neither module makes the state object public. Bucket policies on S3
+and Storage Account network rules on Azure follow account defaults
+and should be tightened to private subnets or service endpoints in
 production.
 
 ## See also

--- a/terraform/backend/README.md
+++ b/terraform/backend/README.md
@@ -20,7 +20,7 @@ stacks (`network`, `cluster`, `dns-zone`) all depend on it.
 
 ```mermaid
 flowchart LR
-  schema[schema.yaml<br/>terraform.backend.type]
+  values[values.yaml<br/>terraform.backend.type]
 
   subgraph s3path[S3]
     tfS3[terraform/backend/s3]
@@ -34,8 +34,8 @@ flowchart LR
 
   state[Remote state<br/>for all stacks]
 
-  schema -->|s3| tfS3
-  schema -->|azurerm| tfAz
+  values -->|s3| tfS3
+  values -->|azurerm| tfAz
   tfS3 --> bucket
   tfAz --> blob
   bucket --> state

--- a/terraform/cluster/README.md
+++ b/terraform/cluster/README.md
@@ -64,11 +64,7 @@ before Flux starts.
 flowchart LR
   subgraph aws[AWS account]
     eks[EKS control plane<br/>managed]
-
-    subgraph priv[VPC private subnets]
-      ng[Node group<br/>EC2 workers]
-    end
-
+    ng[Node group<br/>EC2 workers in VPC private subnets]
     iam[IAM Role<br/>cert-manager DNS-01]
     pi[Pod Identity association]
   end
@@ -106,11 +102,7 @@ survive across cluster destroys.
 flowchart LR
   subgraph azure[Azure resource group]
     aks[AKS control plane<br/>managed]
-
-    subgraph subnet[VNet subnet]
-      np[Node pool<br/>VMs + in-box Cilium]
-    end
-
+    np[Node pool<br/>VMs in VNet subnet, in-box Cilium]
     uami[User-Assigned MI<br/>cert-manager + external-dns]
     fed[Federated credential<br/>via OIDC issuer]
     kv[Key Vault<br/>disk encryption set]

--- a/terraform/cluster/README.md
+++ b/terraform/cluster/README.md
@@ -12,42 +12,29 @@ Azure cluster. The selector is `cluster.driver`, which defaults from
 `platform` (aws picks eks, azure picks aks, anything else picks talos).
 Setting `cluster.driver` explicitly overrides the platform default.
 
-## Architecture
-
-```mermaid
-flowchart LR
-  values[values.yaml<br/>cluster.driver]
-
-  subgraph talospath[Talos]
-    tfTalos[terraform/cluster/talos]
-    talosCp[Talos control plane<br/>+ kubeconfig]
-  end
-
-  subgraph ekspath[EKS]
-    tfEks[terraform/cluster/aws-eks]
-    eksCluster[EKS cluster<br/>+ managed node groups<br/>+ kubeconfig]
-  end
-
-  subgraph akspath[AKS]
-    tfAks[terraform/cluster/azure-aks]
-    aksCluster[AKS cluster<br/>+ node pools<br/>+ kubeconfig]
-  end
-
-  values -->|talos| tfTalos
-  values -->|eks| tfEks
-  values -->|aks| tfAks
-  tfTalos --> talosCp
-  tfEks --> eksCluster
-  tfAks --> aksCluster
-```
-
-Every driver ends up writing a working kubeconfig. The kustomize layer
-then adopts the cluster and brings up CNI, CSI, gateway, PKI, and DNS,
-after which Flux drives reconciliation from the repo.
+Every driver writes out a working kubeconfig. The kustomize layer then
+adopts the cluster and brings up CNI, CSI, gateway, PKI, and DNS, and
+Flux drives reconciliation from the repo afterwards.
 
 ## Recipes
 
 ### Talos (self-hosted)
+
+```mermaid
+flowchart LR
+  cfg[Machine config<br/>+ Talos secrets]
+
+  subgraph cluster[Kubernetes cluster]
+    cp[controlplane-N<br/>etcd + apiserver]
+    w[worker-N<br/>kubelet]
+  end
+
+  kc[kubeconfig.yaml]
+
+  cfg -.applies to.-> cp
+  cfg -.applies to.-> w
+  cp --> kc
+```
 
 ```yaml
 platform: metal     # or hyperv, incus, docker
@@ -73,6 +60,27 @@ before Flux starts.
 
 ### EKS (managed AWS)
 
+```mermaid
+flowchart LR
+  subgraph aws[AWS account]
+    eks[EKS control plane<br/>managed]
+
+    subgraph priv[VPC private subnets]
+      ng[Node group<br/>EC2 workers]
+    end
+
+    iam[IAM Role<br/>cert-manager DNS-01]
+    pi[Pod Identity association]
+  end
+
+  kc[kubeconfig.yaml]
+
+  eks --> ng
+  eks --> kc
+  pi -.binds.-> iam
+  pi -.serves.-> ng
+```
+
 ```yaml
 platform: aws
 cluster:
@@ -86,11 +94,36 @@ cluster:
 
 EKS pulls networking from `terraform/network/aws-vpc` and provisions
 managed node groups from `cluster.pools`. `cluster.workers` is ignored
-on elastic providers, so use `pools` instead. The
-`cluster/aws-eks/additions` module installs IAM entries that survive
-across cluster destroys.
+on elastic providers, so use `pools` instead. The IAM role and Pod
+Identity association are created when `dns.public_domain` is set; the
+role is scoped to the Route53 zone provisioned by `dns/zone/route53`.
+The `cluster/aws-eks/additions` module installs IAM entries that
+survive across cluster destroys.
 
 ### AKS (managed Azure)
+
+```mermaid
+flowchart LR
+  subgraph azure[Azure resource group]
+    aks[AKS control plane<br/>managed]
+
+    subgraph subnet[VNet subnet]
+      np[Node pool<br/>VMs + in-box Cilium]
+    end
+
+    uami[User-Assigned MI<br/>cert-manager + external-dns]
+    fed[Federated credential<br/>via OIDC issuer]
+    kv[Key Vault<br/>disk encryption set]
+  end
+
+  kc[kubeconfig.yaml]
+
+  aks --> np
+  aks --> kc
+  fed -.binds.-> uami
+  fed -.serves.-> np
+  np -.encrypts disks via.-> kv
+```
 
 ```yaml
 platform: azure
@@ -103,9 +136,12 @@ cluster:
 ```
 
 AKS pulls networking from `terraform/network/azure-vnet`. Cilium is
-the in-box CNI here, so `cluster.cni` isn't exercised. When
-`dns.public_domain` is set, Workload Identity gets wired for
-cert-manager and external-dns.
+the in-box CNI here, so `cluster.cni` isn't exercised. Workload
+Identity (User-Assigned Managed Identity plus a federated credential
+through the AKS OIDC issuer) is wired for cert-manager and
+external-dns when `dns.public_domain` is set. Node-pool disks are
+encrypted by a Disk Encryption Set keyed from a per-cluster Key
+Vault.
 
 ## Operations
 

--- a/terraform/cluster/README.md
+++ b/terraform/cluster/README.md
@@ -1,0 +1,146 @@
+---
+title: Cluster
+description: Kubernetes control plane provisioning across Talos, EKS, and AKS.
+---
+
+# Cluster
+
+Three drivers create the Kubernetes control plane: `talos` (self-hosted,
+default on bare metal and local providers), `eks` (managed AWS), and `aks`
+(managed Azure). `cluster.driver` selects which one runs; it defaults from
+`platform` (aws → eks, azure → aks, otherwise → talos) and an explicit
+value wins.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  schema[schema.yaml<br/>cluster.driver]
+
+  subgraph talospath[Talos]
+    tfTalos[terraform/cluster/talos]
+    tfConfig[terraform/cluster/talos/config]
+    tfExt[terraform/cluster/talos/extensions]
+  end
+
+  subgraph ekspath[EKS]
+    tfEks[terraform/cluster/aws-eks]
+    tfAdd[terraform/cluster/aws-eks/additions]
+  end
+
+  subgraph akspath[AKS]
+    tfAks[terraform/cluster/azure-aks]
+  end
+
+  kubeconfig[kubeconfig.yaml]
+
+  schema -->|talos| tfTalos
+  schema -->|eks| tfEks
+  schema -->|aks| tfAks
+  tfTalos --> tfConfig
+  tfTalos --> tfExt
+  tfEks --> tfAdd
+  tfTalos --> kubeconfig
+  tfEks --> kubeconfig
+  tfAks --> kubeconfig
+```
+
+Every driver produces a working kubeconfig. From there the `kustomize/`
+layer adopts the cluster (CNI, CSI, gateway, PKI, DNS) and Flux takes over
+reconciliation.
+
+## Recipes
+
+### Talos (self-hosted)
+
+```yaml
+platform: metal     # or hyperv, incus, docker
+topology: single-node
+cluster:
+  driver: talos
+  endpoint: https://10.5.0.1:6443
+  controlplanes:
+    count: 1
+    schedulable: true
+  workers:
+    count: 0
+  cni:
+    driver: cilium    # default is flannel
+```
+
+The Talos API installs Kubernetes onto already-running compute. The matching
+`compute/` driver (`docker`, `hyperv`, `incus`) must stand up nodes first;
+`cluster/talos` then bootstraps the control plane and writes the
+kubeconfig. Setting `cluster.cni.driver: cilium` runs the Cilium bootstrap
+module before Flux starts.
+
+### EKS (managed AWS)
+
+```yaml
+platform: aws
+cluster:
+  driver: eks
+  pools:
+    workers:
+      class: general
+      count: 2
+      lifecycle: on-demand
+```
+
+EKS draws networking from `terraform/network/aws-vpc` and provisions managed
+node groups from `cluster.pools`. `cluster.workers` is ignored on elastic
+providers. The `cluster/aws-eks/additions` module installs IAM entries that
+persist across cluster destroys.
+
+### AKS (managed Azure)
+
+```yaml
+platform: azure
+cluster:
+  driver: aks
+  pools:
+    workers:
+      class: general
+      count: 2
+```
+
+AKS draws networking from `terraform/network/azure-vnet`. Cilium ships as
+the in-box CNI so `cluster.cni` is not exercised. Workload Identity is
+wired for cert-manager and external-dns when `dns.public_domain` is set.
+
+## Operations
+
+- **`cluster.driver` and `platform` disagree** — `platform: metal` with
+  `cluster.driver: eks` (or any mismatched pair) silently binds the wrong
+  cloud and fails at apply. Schema validation catches the documented pairs;
+  novel pairs surface at `terraform apply` time.
+- **Kubeconfig fetch hangs on Talos** — `cluster.endpoint` must match a
+  reachable address and the control plane VM/container must be up. Check
+  `compute/` outputs first.
+- **EKS or AKS workers don't appear** — `cluster.workers` is ignored on
+  elastic providers. Define `cluster.pools` instead.
+- **`cluster.storage.driver` set on a managed cluster** — the field is
+  Talos-only. Managed clusters use the cloud's default CSI (EBS on EKS,
+  Azure Disk on AKS).
+- **Pool pinned to a single instance type** — capacity shortages take the
+  pool down. Provide multiple types in `instance_types` and let the
+  provider pick.
+
+## Security
+
+- Managed clusters use cloud-native identity for in-cluster integrations:
+  IRSA on EKS, Workload Identity on AKS. Service-account tokens never
+  leave the cluster boundary.
+- Talos enforces signed machine config; rotation is handled inside
+  `cluster/talos/config`.
+- `cluster.controlplanes.schedulable: true` lifts the NoSchedule taint
+  from the control plane. Acceptable for single-node clusters; reconsider
+  for multi-tenant production.
+
+## See also
+
+- [talos/](talos/), [aws-eks/](aws-eks/), [azure-aks/](azure-aks/) — per-driver Terraform reference.
+- [../network/](../network/) — VPC/VNet that backs the cluster on AWS/Azure.
+- [../compute/](../compute/) — Talos compute providers.
+- [../cni/](../cni/) — Cilium bootstrap module (Talos).
+- [../../kustomize/cni/](../../kustomize/cni/), [../../kustomize/csi/](../../kustomize/csi/), [../../kustomize/pki/](../../kustomize/pki/) — kustomize add-ons that adopt the cluster.

--- a/terraform/cluster/README.md
+++ b/terraform/cluster/README.md
@@ -20,30 +20,25 @@ flowchart LR
 
   subgraph talospath[Talos]
     tfTalos[terraform/cluster/talos]
-    tfConfig[terraform/cluster/talos/config]
-    tfExt[terraform/cluster/talos/extensions]
+    talosCp[Talos control plane<br/>+ kubeconfig]
   end
 
   subgraph ekspath[EKS]
     tfEks[terraform/cluster/aws-eks]
-    tfAdd[terraform/cluster/aws-eks/additions]
+    eksCluster[EKS cluster<br/>+ managed node groups<br/>+ kubeconfig]
   end
 
   subgraph akspath[AKS]
     tfAks[terraform/cluster/azure-aks]
+    aksCluster[AKS cluster<br/>+ node pools<br/>+ kubeconfig]
   end
-
-  kubeconfig[kubeconfig.yaml]
 
   values -->|talos| tfTalos
   values -->|eks| tfEks
   values -->|aks| tfAks
-  tfTalos --> tfConfig
-  tfTalos --> tfExt
-  tfEks --> tfAdd
-  tfTalos --> kubeconfig
-  tfEks --> kubeconfig
-  tfAks --> kubeconfig
+  tfTalos --> talosCp
+  tfEks --> eksCluster
+  tfAks --> aksCluster
 ```
 
 Every driver ends up writing a working kubeconfig. The kustomize layer

--- a/terraform/cluster/README.md
+++ b/terraform/cluster/README.md
@@ -5,11 +5,12 @@ description: Kubernetes control plane provisioning across Talos, EKS, and AKS.
 
 # Cluster
 
-Three drivers create the Kubernetes control plane: `talos` (self-hosted,
-default on bare metal and local providers), `eks` (managed AWS), and `aks`
-(managed Azure). `cluster.driver` selects which one runs; it defaults from
-`platform` (aws → eks, azure → aks, otherwise → talos) and an explicit
-value wins.
+The cluster category has three drivers. `talos` provisions a self-hosted
+control plane and is the default on bare metal and local providers.
+`eks` provisions a managed AWS cluster, and `aks` provisions a managed
+Azure cluster. The selector is `cluster.driver`, which defaults from
+`platform` (aws picks eks, azure picks aks, anything else picks talos).
+Setting `cluster.driver` explicitly overrides the platform default.
 
 ## Architecture
 
@@ -45,9 +46,9 @@ flowchart LR
   tfAks --> kubeconfig
 ```
 
-Every driver produces a working kubeconfig. From there the `kustomize/`
-layer adopts the cluster (CNI, CSI, gateway, PKI, DNS) and Flux takes over
-reconciliation.
+Every driver ends up writing a working kubeconfig. The kustomize layer
+then adopts the cluster and brings up CNI, CSI, gateway, PKI, and DNS,
+after which Flux drives reconciliation from the repo.
 
 ## Recipes
 
@@ -68,11 +69,12 @@ cluster:
     driver: cilium    # default is flannel
 ```
 
-The Talos API installs Kubernetes onto already-running compute. The matching
-`compute/` driver (`docker`, `hyperv`, `incus`) must stand up nodes first;
-`cluster/talos` then bootstraps the control plane and writes the
-kubeconfig. Setting `cluster.cni.driver: cilium` runs the Cilium bootstrap
-module before Flux starts.
+The Talos API installs Kubernetes onto compute that's already up, so
+the matching compute driver (`docker`, `hyperv`, or `incus`) needs to
+provision nodes first. The `cluster/talos` module then reaches those
+nodes through the Talos API and writes the kubeconfig. Setting
+`cluster.cni.driver` to `cilium` runs the Cilium bootstrap module
+before Flux starts.
 
 ### EKS (managed AWS)
 
@@ -87,10 +89,11 @@ cluster:
       lifecycle: on-demand
 ```
 
-EKS draws networking from `terraform/network/aws-vpc` and provisions managed
-node groups from `cluster.pools`. `cluster.workers` is ignored on elastic
-providers. The `cluster/aws-eks/additions` module installs IAM entries that
-persist across cluster destroys.
+EKS pulls networking from `terraform/network/aws-vpc` and provisions
+managed node groups from `cluster.pools`. `cluster.workers` is ignored
+on elastic providers, so use `pools` instead. The
+`cluster/aws-eks/additions` module installs IAM entries that survive
+across cluster destroys.
 
 ### AKS (managed Azure)
 
@@ -104,43 +107,51 @@ cluster:
       count: 2
 ```
 
-AKS draws networking from `terraform/network/azure-vnet`. Cilium ships as
-the in-box CNI so `cluster.cni` is not exercised. Workload Identity is
-wired for cert-manager and external-dns when `dns.public_domain` is set.
+AKS pulls networking from `terraform/network/azure-vnet`. Cilium is
+the in-box CNI here, so `cluster.cni` isn't exercised. When
+`dns.public_domain` is set, Workload Identity gets wired for
+cert-manager and external-dns.
 
 ## Operations
 
-- **`cluster.driver` and `platform` disagree** — `platform: metal` with
-  `cluster.driver: eks` (or any mismatched pair) silently binds the wrong
-  cloud and fails at apply. Schema validation catches the documented pairs;
-  novel pairs surface at `terraform apply` time.
-- **Kubeconfig fetch hangs on Talos** — `cluster.endpoint` must match a
-  reachable address and the control plane VM/container must be up. Check
-  `compute/` outputs first.
-- **EKS or AKS workers don't appear** — `cluster.workers` is ignored on
-  elastic providers. Define `cluster.pools` instead.
-- **`cluster.storage.driver` set on a managed cluster** — the field is
-  Talos-only. Managed clusters use the cloud's default CSI (EBS on EKS,
-  Azure Disk on AKS).
-- **Pool pinned to a single instance type** — capacity shortages take the
-  pool down. Provide multiple types in `instance_types` and let the
-  provider pick.
+If `cluster.driver` and `platform` disagree (for example
+`platform: metal` with `cluster.driver: eks`), Terraform binds to the
+wrong cloud and fails at apply time. The schema validates the
+documented coherent pairs, but novel combinations slip through and
+only surface during the apply.
+
+When Talos hangs at kubeconfig fetch, the endpoint isn't reachable.
+`cluster.endpoint` has to match a real address, and the control plane
+VM or container has to be up. Check the compute step's outputs first.
+
+On elastic providers (EKS, AKS), `cluster.workers` is ignored. Define
+`cluster.pools` instead.
+
+`cluster.storage.driver` is Talos-only. Managed clusters use the
+cloud's default CSI (EBS on EKS, Azure Disk on AKS) and ignore
+whatever's set here.
+
+Pinning a pool to a single instance type is fragile. Capacity
+shortages will take the pool down. Provide a list of acceptable types
+and let the provider pick.
 
 ## Security
 
-- Managed clusters use cloud-native identity for in-cluster integrations:
-  IRSA on EKS, Workload Identity on AKS. Service-account tokens never
-  leave the cluster boundary.
-- Talos enforces signed machine config; rotation is handled inside
-  `cluster/talos/config`.
-- `cluster.controlplanes.schedulable: true` lifts the NoSchedule taint
-  from the control plane. Acceptable for single-node clusters; reconsider
-  for multi-tenant production.
+Managed clusters use cloud-native identity for in-cluster integrations
+(IRSA on EKS, Workload Identity on AKS). Service-account tokens don't
+leave the cluster boundary in either case.
+
+Talos enforces signed machine config, and rotation is handled inside
+`cluster/talos/config`.
+
+`cluster.controlplanes.schedulable: true` removes the NoSchedule taint
+from the control plane. That's fine for single-node clusters but
+worth reconsidering for anything multi-tenant.
 
 ## See also
 
-- [talos/](talos/), [aws-eks/](aws-eks/), [azure-aks/](azure-aks/) — per-driver Terraform reference.
-- [../network/](../network/) — VPC/VNet that backs the cluster on AWS/Azure.
-- [../compute/](../compute/) — Talos compute providers.
-- [../cni/](../cni/) — Cilium bootstrap module (Talos).
-- [../../kustomize/cni/](../../kustomize/cni/), [../../kustomize/csi/](../../kustomize/csi/), [../../kustomize/pki/](../../kustomize/pki/) — kustomize add-ons that adopt the cluster.
+- [talos/](talos/), [aws-eks/](aws-eks/), [azure-aks/](azure-aks/) for the per-driver Terraform reference.
+- [../network/](../network/) for the VPC and VNet modules that back the cluster on AWS and Azure.
+- [../compute/](../compute/) for Talos compute providers.
+- [../cni/](../cni/) for the Cilium bootstrap module on Talos.
+- [../../kustomize/cni/](../../kustomize/cni/), [../../kustomize/csi/](../../kustomize/csi/), and [../../kustomize/pki/](../../kustomize/pki/) for the kustomize add-ons that adopt the cluster.

--- a/terraform/cluster/README.md
+++ b/terraform/cluster/README.md
@@ -16,7 +16,7 @@ Setting `cluster.driver` explicitly overrides the platform default.
 
 ```mermaid
 flowchart LR
-  schema[schema.yaml<br/>cluster.driver]
+  values[values.yaml<br/>cluster.driver]
 
   subgraph talospath[Talos]
     tfTalos[terraform/cluster/talos]
@@ -35,9 +35,9 @@ flowchart LR
 
   kubeconfig[kubeconfig.yaml]
 
-  schema -->|talos| tfTalos
-  schema -->|eks| tfEks
-  schema -->|aks| tfAks
+  values -->|talos| tfTalos
+  values -->|eks| tfEks
+  values -->|aks| tfAks
   tfTalos --> tfConfig
   tfTalos --> tfExt
   tfEks --> tfAdd

--- a/terraform/cni/README.md
+++ b/terraform/cni/README.md
@@ -24,14 +24,12 @@ flowchart LR
   tf[terraform/cni/cilium]
   api[Talos API]
 
-  subgraph cluster[Kubernetes cluster]
-    subgraph syscni[system-cni namespace]
-      hr[HelmRelease cilium]
-    end
-    subgraph kubesys[kube-system namespace]
-      agent[DaemonSet cilium-agent]
-      op[Deployment cilium-operator]
-    end
+  subgraph syscni[system-cni namespace]
+    hr[HelmRelease cilium]
+  end
+  subgraph kubesys[kube-system namespace]
+    agent[DaemonSet cilium-agent]
+    op[Deployment cilium-operator]
   end
 
   flux[Flux helm-controller]

--- a/terraform/cni/README.md
+++ b/terraform/cni/README.md
@@ -5,16 +5,17 @@ description: Out-of-band Cilium bootstrap for Talos clusters before Flux.
 
 # CNI
 
-One driver: `cilium`. Runs only when `cluster.driver: talos` and
-`cluster.cni.driver: cilium`. Managed clusters bring their own CNI
-(VPC CNI on EKS, in-box Cilium on AKS), so this category does not run
-for them. Talos with the default `flannel` driver also skips it.
+The cni category has one driver, `cilium`, which only runs when
+`cluster.driver: talos` and `cluster.cni.driver: cilium`. Managed
+clusters bring their own CNI (VPC CNI on EKS, in-box Cilium on AKS),
+so this category doesn't run for them. Talos with the default
+`flannel` driver also skips it.
 
-The module exists because Talos starts with `kubeProxyReplacement: true`
-and no built-in CNI when Cilium is chosen — Flux can't reconcile until
-Pods can network. This module installs Cilium directly via Helm against
-the Talos API, then `kustomize/cni/` adopts the running release so day-2
-changes flow through GitOps.
+The module exists because Talos starts with `kubeProxyReplacement:
+true` and no built-in CNI when Cilium is chosen, and Flux can't
+reconcile until Pods can network. So this module installs Cilium
+directly via Helm against the Talos API, and `kustomize/cni/` then
+adopts the running release so day-2 changes flow through GitOps.
 
 ## Architecture
 
@@ -48,27 +49,28 @@ cluster:
     driver: cilium
 ```
 
-No `cilium` block exists at the schema level; the only knob is the
-driver selector. Tunables (operator replica count, Hubble settings,
-LBIPAM ranges) flow through the `kustomize/cni/` substitutions, not
-through this module.
+There's no `cilium` block at the schema level; the only knob is the
+driver selector. The tunables (operator replica count, Hubble
+settings, LBIPAM ranges) flow through the `kustomize/cni/`
+substitutions rather than through this module.
 
 ## Operations
 
-- **Module runs but Cilium pods crash on Talos** — the `cilium/talos`
-  kustomize component (capabilities patch) hasn't been applied. The
-  terraform module only installs the base release; Talos-specific
-  patches live in `kustomize/cni/cilium/talos/`.
-- **`windsor apply` flaps Cilium replica counts** — the Terraform-
-  installed release and the Flux-adopted HelmRelease compute
-  `operator_replicas` from different sources. Both must derive from
-  `topology`.
-- **Skipping cilium on Talos** — leaving `cluster.cni.driver` unset (or
-  `flannel`) bypasses this module entirely. Flannel is the Talos
-  built-in and needs no bootstrap.
+If the module runs but Cilium pods crash on Talos, the `cilium/talos`
+kustomize component (the capabilities patch) hasn't been applied yet.
+The terraform module only installs the base release; Talos-specific
+patches live in `kustomize/cni/cilium/talos/`.
+
+If `windsor apply` flaps Cilium replica counts, the
+Terraform-installed release and the Flux-adopted HelmRelease are
+computing `operator_replicas` from different sources. Both have to
+derive from `topology`.
+
+Leaving `cluster.cni.driver` unset (or `flannel`) skips this module
+entirely. Flannel is the Talos built-in and needs no bootstrap.
 
 ## See also
 
-- [cilium/](cilium/) — per-module Terraform reference.
-- [../../kustomize/cni/](../../kustomize/cni/) — the adopting HelmRelease and full operational guide for Cilium (substitutions, components, dependencies).
-- [../cluster/](../cluster/) — the cluster module that produces the kubeconfig this bootstrap uses.
+- [cilium/](cilium/) for the per-module Terraform reference.
+- [../../kustomize/cni/](../../kustomize/cni/) for the adopting HelmRelease and the full operational guide for Cilium (substitutions, components, dependencies).
+- [../cluster/](../cluster/) for the cluster module that produces the kubeconfig this bootstrap uses.

--- a/terraform/cni/README.md
+++ b/terraform/cni/README.md
@@ -21,7 +21,7 @@ adopts the running release so day-2 changes flow through GitOps.
 
 ```mermaid
 flowchart LR
-  schema[schema.yaml<br/>cluster.cni.driver: cilium]
+  values[values.yaml<br/>cluster.cni.driver: cilium]
 
   tfCni[terraform/cni/cilium]
   helm[Helm release<br/>cilium]
@@ -29,7 +29,7 @@ flowchart LR
   flux[Flux helm-controller]
   kCni[kustomize/cni/<br/>HelmRelease cilium]
 
-  schema --> tfCni
+  values --> tfCni
   tfCni -.installs.-> helm
   flux ==adopts==> helm
   kCni --> flux

--- a/terraform/cni/README.md
+++ b/terraform/cni/README.md
@@ -1,0 +1,74 @@
+---
+title: CNI
+description: Out-of-band Cilium bootstrap for Talos clusters before Flux.
+---
+
+# CNI
+
+One driver: `cilium`. Runs only when `cluster.driver: talos` and
+`cluster.cni.driver: cilium`. Managed clusters bring their own CNI
+(VPC CNI on EKS, in-box Cilium on AKS), so this category does not run
+for them. Talos with the default `flannel` driver also skips it.
+
+The module exists because Talos starts with `kubeProxyReplacement: true`
+and no built-in CNI when Cilium is chosen — Flux can't reconcile until
+Pods can network. This module installs Cilium directly via Helm against
+the Talos API, then `kustomize/cni/` adopts the running release so day-2
+changes flow through GitOps.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  schema[schema.yaml<br/>cluster.cni.driver: cilium]
+
+  tfCni[terraform/cni/cilium]
+  helm[Helm release<br/>cilium]
+
+  flux[Flux helm-controller]
+  kCni[kustomize/cni/<br/>HelmRelease cilium]
+
+  schema --> tfCni
+  tfCni -.installs.-> helm
+  flux ==adopts==> helm
+  kCni --> flux
+```
+
+After bootstrap, the HelmRelease in `kustomize/cni/` matches the
+running Helm release and Flux takes over reconciliation. Values
+upgrades from then on flow through GitOps.
+
+## Recipe
+
+```yaml
+platform: metal     # or hyperv, incus, docker
+cluster:
+  driver: talos
+  cni:
+    driver: cilium
+```
+
+No `cilium` block exists at the schema level; the only knob is the
+driver selector. Tunables (operator replica count, Hubble settings,
+LBIPAM ranges) flow through the `kustomize/cni/` substitutions, not
+through this module.
+
+## Operations
+
+- **Module runs but Cilium pods crash on Talos** — the `cilium/talos`
+  kustomize component (capabilities patch) hasn't been applied. The
+  terraform module only installs the base release; Talos-specific
+  patches live in `kustomize/cni/cilium/talos/`.
+- **`windsor apply` flaps Cilium replica counts** — the Terraform-
+  installed release and the Flux-adopted HelmRelease compute
+  `operator_replicas` from different sources. Both must derive from
+  `topology`.
+- **Skipping cilium on Talos** — leaving `cluster.cni.driver` unset (or
+  `flannel`) bypasses this module entirely. Flannel is the Talos
+  built-in and needs no bootstrap.
+
+## See also
+
+- [cilium/](cilium/) — per-module Terraform reference.
+- [../../kustomize/cni/](../../kustomize/cni/) — the adopting HelmRelease and full operational guide for Cilium (substitutions, components, dependencies).
+- [../cluster/](../cluster/) — the cluster module that produces the kubeconfig this bootstrap uses.

--- a/terraform/cni/README.md
+++ b/terraform/cni/README.md
@@ -17,29 +17,33 @@ reconcile until Pods can network. So this module installs Cilium
 directly via Helm against the Talos API, and `kustomize/cni/` then
 adopts the running release so day-2 changes flow through GitOps.
 
-## Architecture
+## Recipe
 
 ```mermaid
 flowchart LR
-  values[values.yaml<br/>cluster.cni.driver: cilium]
+  tf[terraform/cni/cilium]
+  api[Talos API]
 
-  tfCni[terraform/cni/cilium]
-  helm[Helm release<br/>cilium]
+  subgraph cluster[Kubernetes cluster]
+    subgraph syscni[system-cni namespace]
+      hr[HelmRelease cilium]
+    end
+    subgraph kubesys[kube-system namespace]
+      agent[DaemonSet cilium-agent]
+      op[Deployment cilium-operator]
+    end
+  end
 
   flux[Flux helm-controller]
-  kCni[kustomize/cni/<br/>HelmRelease cilium]
+  kCni[kustomize/cni/]
 
-  values --> tfCni
-  tfCni -.installs.-> helm
-  flux ==adopts==> helm
+  tf -.installs via.-> api
+  api --> hr
+  hr --> agent
+  hr --> op
+  flux ==adopts==> hr
   kCni --> flux
 ```
-
-After bootstrap, the HelmRelease in `kustomize/cni/` matches the
-running Helm release and Flux takes over reconciliation. Values
-upgrades from then on flow through GitOps.
-
-## Recipe
 
 ```yaml
 platform: metal     # or hyperv, incus, docker
@@ -53,6 +57,11 @@ There's no `cilium` block at the schema level; the only knob is the
 driver selector. The tunables (operator replica count, Hubble
 settings, LBIPAM ranges) flow through the `kustomize/cni/`
 substitutions rather than through this module.
+
+The bootstrap-then-adopt handoff is the architectural point.
+Terraform installs Cilium via the Talos API before Flux can run.
+After Flux comes up, it adopts the HelmRelease that already exists
+and takes ownership of subsequent upgrades.
 
 ## Operations
 

--- a/terraform/cni/README.md
+++ b/terraform/cni/README.md
@@ -22,23 +22,20 @@ adopts the running release so day-2 changes flow through GitOps.
 ```mermaid
 flowchart LR
   tf[terraform/cni/cilium]
-  api[Talos API]
 
   subgraph syscni[system-cni namespace]
     hr[HelmRelease cilium]
   end
+
   subgraph kubesys[kube-system namespace]
-    agent[DaemonSet cilium-agent]
-    op[Deployment cilium-operator]
+    cilium[Cilium pods<br/>agent + operator]
   end
 
   flux[Flux helm-controller]
   kCni[kustomize/cni/]
 
-  tf -.installs via.-> api
-  api --> hr
-  hr --> agent
-  hr --> op
+  tf -.installs via Talos API.-> hr
+  hr --> cilium
   flux ==adopts==> hr
   kCni --> flux
 ```

--- a/terraform/compute/README.md
+++ b/terraform/compute/README.md
@@ -1,0 +1,152 @@
+---
+title: Compute
+description: Local Talos compute substrate across Docker, Hyper-V, and Incus.
+---
+
+# Compute
+
+Three drivers provision Talos nodes on local hardware: `docker` (containers,
+default on macOS and Linux dev machines), `hyperv` (Windows VMs), and `incus`
+(Linux VMs). Selection is by `platform`. Managed-cloud platforms (`aws`,
+`azure`) and `metal` do not use a compute module — EKS/AKS provision their
+own nodes, and `metal` expects nodes that already exist.
+
+Compute always runs before the `cluster/talos` module, which then reaches the
+provisioned nodes through the Talos API.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  schema[schema.yaml<br/>platform]
+
+  subgraph dockerpath[Docker]
+    tfDocker[terraform/compute/docker]
+    dockerNodes[Talos containers]
+  end
+
+  subgraph hyperv[Hyper-V]
+    tfHyperv[terraform/compute/hyperv]
+    hvNodes[Talos VMs]
+  end
+
+  subgraph incus[Incus]
+    tfIncus[terraform/compute/incus]
+    incNodes[Talos VMs]
+  end
+
+  cluster[terraform/cluster/talos]
+
+  schema -->|docker| tfDocker
+  schema -->|hyperv| tfHyperv
+  schema -->|incus| tfIncus
+  tfDocker --> dockerNodes
+  tfHyperv --> hvNodes
+  tfIncus --> incNodes
+  dockerNodes --> cluster
+  hvNodes --> cluster
+  incNodes --> cluster
+```
+
+Node sizing (count, CPU, memory, disks) comes from `cluster.controlplanes`
+and `cluster.workers` and is shared across all three drivers.
+
+## Recipes
+
+### Docker (macOS / Linux dev)
+
+```yaml
+platform: docker
+workstation:
+  runtime: docker-desktop    # or colima, docker
+cluster:
+  driver: talos
+  controlplanes:
+    count: 1
+    schedulable: true
+  workers:
+    count: 0
+topology: single-node
+```
+
+Provisions Talos containers against the local Docker socket.
+`workstation.runtime: docker-desktop` is the macOS path and forces flannel
+CNI (Cilium has no working transport over the desktop loopback). `colima` is
+the lighter macOS alternative; plain `docker` is the Linux engine path.
+
+### Hyper-V (Windows host)
+
+```yaml
+platform: hyperv
+cluster:
+  driver: talos
+  endpoint: https://192.168.3.77:6443
+  controlplanes:
+    count: 1
+    cpu: 4
+    memory: 8
+  workers:
+    count: 1
+    root_disk_size: 30
+```
+
+Provisions Talos VMs on a Windows host running Hyper-V (Pro, Enterprise, or
+Server). The host is reached over SSH using the credentials in the context's
+`environment:` block. `cluster.endpoint` is the bench address that hairpins
+through Hyper-V NAT back to the control plane.
+
+### Incus (Linux host)
+
+```yaml
+platform: incus
+workstation:
+  arch: amd64
+cluster:
+  driver: talos
+  controlplanes:
+    count: 1
+  workers:
+    count: 1
+```
+
+Provisions Talos VMs on a local Incus daemon (KVM-backed). Useful when you
+need real VM isolation, nested KVM, or kernel features that Docker-on-Mac
+can't expose. `workstation.arch` selects the Talos image architecture.
+
+## Operations
+
+- **`cluster/talos` hangs waiting for nodes** — compute didn't run or its
+  outputs aren't visible. Check the terraform plan for the compute step
+  first; cluster fans out from `terraform_output("compute", ...)`.
+- **Docker Desktop ignores `cluster.cni.driver: cilium`** — Cilium has no
+  transport over the desktop loopback, so the workstation facet forces
+  flannel regardless. Use Colima or Incus if Cilium is required locally.
+- **Hyper-V provider can't reach the host** — the SSH host key must already
+  be in the operator's `~/.ssh/known_hosts`. The provider refuses unknown
+  hosts and the error surfaces during `terraform plan`.
+- **Disk sizing too small for Longhorn** — `cluster.workers.root_disk_size`
+  defaults to the provider minimum. Block storage needs a dedicated disk
+  via `cluster.workers.disks`; the root disk is for the OS only.
+- **Single-node cluster pods stay Pending** — `cluster.controlplanes.count:
+  1` with `cluster.workers.count: 0` only schedules when
+  `controlplanes.schedulable: true`. The single-node topology preset sets
+  this automatically.
+
+## Security
+
+- The Docker driver uses the host Docker socket and runs Talos containers
+  privileged. This is root-equivalent on the host; not intended for shared
+  developer machines.
+- The Hyper-V driver requires Administrator credentials to the Windows
+  host. Credentials live in the context's `environment:` block and should
+  be sourced from a secrets manager via `windsor exec`.
+- Incus VMs run as full KVM instances with host-isolated kernels. Talos
+  machine secrets are generated per cluster and never leave the operator's
+  workstation in plain text.
+
+## See also
+
+- [docker/](docker/), [hyperv/](hyperv/), [incus/](incus/) — per-driver Terraform reference.
+- [../cluster/](../cluster/) — Talos control plane that adopts the compute nodes.
+- [../workstation/](../workstation/) — host-side networking (registry, DNS) for local clusters.
+- [../network/](../network/) — cloud networking (skipped on local compute).

--- a/terraform/compute/README.md
+++ b/terraform/compute/README.md
@@ -38,17 +38,12 @@ flowchart LR
     incNodes[Talos VMs]
   end
 
-  cluster[terraform/cluster/talos]
-
   values -->|docker| tfDocker
   values -->|hyperv| tfHyperv
   values -->|incus| tfIncus
   tfDocker --> dockerNodes
   tfHyperv --> hvNodes
   tfIncus --> incNodes
-  dockerNodes --> cluster
-  hvNodes --> cluster
-  incNodes --> cluster
 ```
 
 Node sizing (count, CPU, memory, disks) comes from

--- a/terraform/compute/README.md
+++ b/terraform/compute/README.md
@@ -5,14 +5,17 @@ description: Local Talos compute substrate across Docker, Hyper-V, and Incus.
 
 # Compute
 
-Three drivers provision Talos nodes on local hardware: `docker` (containers,
-default on macOS and Linux dev machines), `hyperv` (Windows VMs), and `incus`
-(Linux VMs). Selection is by `platform`. Managed-cloud platforms (`aws`,
-`azure`) and `metal` do not use a compute module — EKS/AKS provision their
-own nodes, and `metal` expects nodes that already exist.
+The compute category has three drivers that provision Talos nodes on
+local hardware. `docker` runs nodes as containers and is the default
+on macOS and Linux dev machines. `hyperv` runs them as VMs on a
+Windows host. `incus` runs them as VMs on Linux. The driver is
+selected by `platform`. Managed-cloud platforms (`aws`, `azure`) and
+bare-metal (`metal`) don't use a compute module: EKS and AKS
+provision their own nodes, and `metal` expects nodes that already
+exist.
 
-Compute always runs before the `cluster/talos` module, which then reaches the
-provisioned nodes through the Talos API.
+Compute always runs before the `cluster/talos` module, which then
+reaches the provisioned nodes through the Talos API.
 
 ## Architecture
 
@@ -48,12 +51,13 @@ flowchart LR
   incNodes --> cluster
 ```
 
-Node sizing (count, CPU, memory, disks) comes from `cluster.controlplanes`
-and `cluster.workers` and is shared across all three drivers.
+Node sizing (count, CPU, memory, disks) comes from
+`cluster.controlplanes` and `cluster.workers` and is the same across
+all three drivers.
 
 ## Recipes
 
-### Docker (macOS / Linux dev)
+### Docker (macOS or Linux dev)
 
 ```yaml
 platform: docker
@@ -69,10 +73,11 @@ cluster:
 topology: single-node
 ```
 
-Provisions Talos containers against the local Docker socket.
-`workstation.runtime: docker-desktop` is the macOS path and forces flannel
-CNI (Cilium has no working transport over the desktop loopback). `colima` is
-the lighter macOS alternative; plain `docker` is the Linux engine path.
+The module provisions Talos containers against the local Docker
+socket. `workstation.runtime: docker-desktop` is the macOS path and
+forces flannel CNI, because Cilium has no working transport over the
+desktop loopback. `colima` is the lighter macOS alternative, and
+plain `docker` is the Linux engine path.
 
 ### Hyper-V (Windows host)
 
@@ -90,10 +95,11 @@ cluster:
     root_disk_size: 30
 ```
 
-Provisions Talos VMs on a Windows host running Hyper-V (Pro, Enterprise, or
-Server). The host is reached over SSH using the credentials in the context's
-`environment:` block. `cluster.endpoint` is the bench address that hairpins
-through Hyper-V NAT back to the control plane.
+The module provisions Talos VMs on a Windows host running Hyper-V
+(Pro, Enterprise, or Server). It reaches the host over SSH using the
+credentials in the context's `environment:` block. `cluster.endpoint`
+is the bench address that hairpins through the Hyper-V NAT back to
+the control plane.
 
 ### Incus (Linux host)
 
@@ -109,44 +115,55 @@ cluster:
     count: 1
 ```
 
-Provisions Talos VMs on a local Incus daemon (KVM-backed). Useful when you
-need real VM isolation, nested KVM, or kernel features that Docker-on-Mac
-can't expose. `workstation.arch` selects the Talos image architecture.
+The module provisions Talos VMs on a local Incus daemon (KVM-backed).
+This is the right choice when you need real VM isolation, nested KVM,
+or kernel features that Docker on macOS can't expose.
+`workstation.arch` selects the Talos image architecture.
 
 ## Operations
 
-- **`cluster/talos` hangs waiting for nodes** — compute didn't run or its
-  outputs aren't visible. Check the terraform plan for the compute step
-  first; cluster fans out from `terraform_output("compute", ...)`.
-- **Docker Desktop ignores `cluster.cni.driver: cilium`** — Cilium has no
-  transport over the desktop loopback, so the workstation facet forces
-  flannel regardless. Use Colima or Incus if Cilium is required locally.
-- **Hyper-V provider can't reach the host** — the SSH host key must already
-  be in the operator's `~/.ssh/known_hosts`. The provider refuses unknown
-  hosts and the error surfaces during `terraform plan`.
-- **Disk sizing too small for Longhorn** — `cluster.workers.root_disk_size`
-  defaults to the provider minimum. Block storage needs a dedicated disk
-  via `cluster.workers.disks`; the root disk is for the OS only.
-- **Single-node cluster pods stay Pending** — `cluster.controlplanes.count:
-  1` with `cluster.workers.count: 0` only schedules when
-  `controlplanes.schedulable: true`. The single-node topology preset sets
-  this automatically.
+When `cluster/talos` hangs waiting for nodes, compute either didn't
+run or its outputs aren't visible to the cluster step. The cluster
+fans out from `terraform_output("compute", ...)`, so check the
+terraform plan for the compute step first.
+
+Docker Desktop ignores `cluster.cni.driver: cilium`. Cilium has no
+transport over the desktop loopback, so the workstation facet forces
+flannel regardless. Use Colima or Incus if Cilium is required
+locally.
+
+When the Hyper-V provider can't reach the host, the usual cause is
+that the SSH host key isn't in the operator's `~/.ssh/known_hosts`.
+The provider refuses unknown hosts, and the failure surfaces during
+`terraform plan`.
+
+If you intend to use Longhorn, the default `root_disk_size` is too
+small. Longhorn needs a dedicated disk via `cluster.workers.disks`;
+the root disk is for the OS only.
+
+A single-node cluster with `controlplanes.count: 1` and
+`workers.count: 0` only schedules pods when
+`controlplanes.schedulable: true`. The `topology: single-node` preset
+sets this automatically.
 
 ## Security
 
-- The Docker driver uses the host Docker socket and runs Talos containers
-  privileged. This is root-equivalent on the host; not intended for shared
-  developer machines.
-- The Hyper-V driver requires Administrator credentials to the Windows
-  host. Credentials live in the context's `environment:` block and should
-  be sourced from a secrets manager via `windsor exec`.
-- Incus VMs run as full KVM instances with host-isolated kernels. Talos
-  machine secrets are generated per cluster and never leave the operator's
-  workstation in plain text.
+The Docker driver uses the host Docker socket and runs Talos
+containers privileged. That's root-equivalent on the host and isn't
+intended for shared developer machines.
+
+The Hyper-V driver needs Administrator credentials to the Windows
+host. The credentials live in the context's `environment:` block and
+should come from a secrets manager via `windsor exec`, not from a
+plaintext file.
+
+Incus VMs run as full KVM instances with host-isolated kernels. Talos
+machine secrets are generated per cluster and never leave the
+operator's workstation in cleartext.
 
 ## See also
 
-- [docker/](docker/), [hyperv/](hyperv/), [incus/](incus/) — per-driver Terraform reference.
-- [../cluster/](../cluster/) — Talos control plane that adopts the compute nodes.
-- [../workstation/](../workstation/) — host-side networking (registry, DNS) for local clusters.
-- [../network/](../network/) — cloud networking (skipped on local compute).
+- [docker/](docker/), [hyperv/](hyperv/), and [incus/](incus/) for the per-driver Terraform reference.
+- [../cluster/](../cluster/) for the Talos control plane that adopts the compute nodes.
+- [../workstation/](../workstation/) for the host-side networking (registry, DNS) that local clusters depend on.
+- [../network/](../network/) for the cloud networking modules, which are skipped on local compute.

--- a/terraform/compute/README.md
+++ b/terraform/compute/README.md
@@ -63,11 +63,9 @@ plain `docker` is the Linux engine path.
 flowchart LR
   prov[terraform-provider-hyperv<br/>SSH + PowerShell]
 
-  subgraph hv[Hyper-V on Windows host]
-    subgraph natsw[NAT switch<br/>network.cidr_block]
-      cp[talos-controlplane-1<br/>VM]
-      w[talos-worker-1<br/>VM]
-    end
+  subgraph hv[Hyper-V on Windows host, NAT switch network.cidr_block]
+    cp[talos-controlplane-1<br/>VM]
+    w[talos-worker-1<br/>VM]
     netnat[NetNat<br/>host:6443 → cp:6443]
   end
 
@@ -102,11 +100,9 @@ can reach the apiserver from outside the host.
 flowchart LR
   prov[terraform-provider-incus]
 
-  subgraph host[Linux host]
-    subgraph bridge[LXC bridge<br/>workstation-managed]
-      cp[talos-controlplane-1<br/>KVM VM]
-      w[talos-worker-1<br/>KVM VM]
-    end
+  subgraph host[Linux host, LXC bridge workstation-managed]
+    cp[talos-controlplane-1<br/>KVM VM]
+    w[talos-worker-1<br/>KVM VM]
   end
 
   prov --> host

--- a/terraform/compute/README.md
+++ b/terraform/compute/README.md
@@ -25,9 +25,9 @@ reaches the provisioned nodes through the Talos API. Node sizing
 
 ```mermaid
 flowchart LR
-  socket[Docker socket<br/>docker-desktop / colima / linux]
+  socket[Docker socket]
 
-  subgraph bridge[Docker bridge<br/>workstation-managed]
+  subgraph bridge[Docker bridge]
     cp[talos-controlplane-1<br/>container]
     w[talos-worker-1<br/>container]
   end
@@ -61,15 +61,17 @@ plain `docker` is the Linux engine path.
 
 ```mermaid
 flowchart LR
-  prov[terraform-provider-hyperv<br/>SSH + PowerShell]
+  prov[terraform-provider-hyperv]
 
-  subgraph hv[Hyper-V on Windows host, NAT switch network.cidr_block]
+  subgraph hv[Hyper-V NAT switch]
     cp[talos-controlplane-1<br/>VM]
     w[talos-worker-1<br/>VM]
     netnat[NetNat<br/>host:6443 → cp:6443]
   end
 
-  prov --> hv
+  prov --> cp
+  prov --> w
+  prov --> netnat
   netnat -.forwards.-> cp
 ```
 
@@ -100,12 +102,13 @@ can reach the apiserver from outside the host.
 flowchart LR
   prov[terraform-provider-incus]
 
-  subgraph host[Linux host, LXC bridge workstation-managed]
+  subgraph bridge[LXC bridge]
     cp[talos-controlplane-1<br/>KVM VM]
     w[talos-worker-1<br/>KVM VM]
   end
 
-  prov --> host
+  prov --> cp
+  prov --> w
 ```
 
 ```yaml

--- a/terraform/compute/README.md
+++ b/terraform/compute/README.md
@@ -21,7 +21,7 @@ reaches the provisioned nodes through the Talos API.
 
 ```mermaid
 flowchart LR
-  schema[schema.yaml<br/>platform]
+  values[values.yaml<br/>platform]
 
   subgraph dockerpath[Docker]
     tfDocker[terraform/compute/docker]
@@ -40,9 +40,9 @@ flowchart LR
 
   cluster[terraform/cluster/talos]
 
-  schema -->|docker| tfDocker
-  schema -->|hyperv| tfHyperv
-  schema -->|incus| tfIncus
+  values -->|docker| tfDocker
+  values -->|hyperv| tfHyperv
+  values -->|incus| tfIncus
   tfDocker --> dockerNodes
   tfHyperv --> hvNodes
   tfIncus --> incNodes

--- a/terraform/compute/README.md
+++ b/terraform/compute/README.md
@@ -15,44 +15,26 @@ provision their own nodes, and `metal` expects nodes that already
 exist.
 
 Compute always runs before the `cluster/talos` module, which then
-reaches the provisioned nodes through the Talos API.
-
-## Architecture
-
-```mermaid
-flowchart LR
-  values[values.yaml<br/>platform]
-
-  subgraph dockerpath[Docker]
-    tfDocker[terraform/compute/docker]
-    dockerNodes[Talos containers]
-  end
-
-  subgraph hyperv[Hyper-V]
-    tfHyperv[terraform/compute/hyperv]
-    hvNodes[Talos VMs]
-  end
-
-  subgraph incus[Incus]
-    tfIncus[terraform/compute/incus]
-    incNodes[Talos VMs]
-  end
-
-  values -->|docker| tfDocker
-  values -->|hyperv| tfHyperv
-  values -->|incus| tfIncus
-  tfDocker --> dockerNodes
-  tfHyperv --> hvNodes
-  tfIncus --> incNodes
-```
-
-Node sizing (count, CPU, memory, disks) comes from
-`cluster.controlplanes` and `cluster.workers` and is the same across
-all three drivers.
+reaches the provisioned nodes through the Talos API. Node sizing
+(count, CPU, memory, disks) comes from `cluster.controlplanes` and
+`cluster.workers` and is the same across all three drivers.
 
 ## Recipes
 
 ### Docker (macOS or Linux dev)
+
+```mermaid
+flowchart LR
+  socket[Docker socket<br/>docker-desktop / colima / linux]
+
+  subgraph bridge[Docker bridge<br/>workstation-managed]
+    cp[talos-controlplane-1<br/>container]
+    w[talos-worker-1<br/>container]
+  end
+
+  socket --> cp
+  socket --> w
+```
 
 ```yaml
 platform: docker
@@ -69,12 +51,29 @@ topology: single-node
 ```
 
 The module provisions Talos containers against the local Docker
-socket. `workstation.runtime: docker-desktop` is the macOS path and
+socket. They attach to the bridge network that the workstation step
+created. `workstation.runtime: docker-desktop` is the macOS path and
 forces flannel CNI, because Cilium has no working transport over the
 desktop loopback. `colima` is the lighter macOS alternative, and
 plain `docker` is the Linux engine path.
 
 ### Hyper-V (Windows host)
+
+```mermaid
+flowchart LR
+  prov[terraform-provider-hyperv<br/>SSH + PowerShell]
+
+  subgraph hv[Hyper-V on Windows host]
+    subgraph natsw[NAT switch<br/>network.cidr_block]
+      cp[talos-controlplane-1<br/>VM]
+      w[talos-worker-1<br/>VM]
+    end
+    netnat[NetNat<br/>host:6443 → cp:6443]
+  end
+
+  prov --> hv
+  netnat -.forwards.-> cp
+```
 
 ```yaml
 platform: hyperv
@@ -92,11 +91,26 @@ cluster:
 
 The module provisions Talos VMs on a Windows host running Hyper-V
 (Pro, Enterprise, or Server). It reaches the host over SSH using the
-credentials in the context's `environment:` block. `cluster.endpoint`
-is the bench address that hairpins through the Hyper-V NAT back to
-the control plane.
+credentials in the context's `environment:` block. The VMs live on a
+NAT switch (private to the host) and a Windows NetNat rule forwards
+the host's port 6443 to the control plane VM, so `cluster.endpoint`
+can reach the apiserver from outside the host.
 
 ### Incus (Linux host)
+
+```mermaid
+flowchart LR
+  prov[terraform-provider-incus]
+
+  subgraph host[Linux host]
+    subgraph bridge[LXC bridge<br/>workstation-managed]
+      cp[talos-controlplane-1<br/>KVM VM]
+      w[talos-worker-1<br/>KVM VM]
+    end
+  end
+
+  prov --> host
+```
 
 ```yaml
 platform: incus

--- a/terraform/dns/README.md
+++ b/terraform/dns/README.md
@@ -1,0 +1,131 @@
+---
+title: DNS
+description: Public DNS zones for ACME certificates and external-dns.
+---
+
+# DNS
+
+Two drivers under `dns/zone/` provision public DNS zones: `route53` (AWS)
+and `azure-dns` (Azure). Selection follows `platform`, and the zone
+module only runs when `dns.public_domain` is set. With no public domain,
+the cluster falls back to self-signed certificates and no external zone
+is created.
+
+Zones are provisioned in their own Terraform stack so they have an
+independent lifecycle — tearing down the cluster does not drag the zone
+(and its NS delegation effort) with it.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  schema[schema.yaml<br/>dns.public_domain]
+
+  subgraph awspath[AWS]
+    tfR53[terraform/dns/zone/route53]
+    r53[Route53 hosted zone]
+  end
+
+  subgraph azurepath[Azure]
+    tfAz[terraform/dns/zone/azure-dns]
+    azz[Azure DNS zone]
+  end
+
+  certmgr[cert-manager<br/>ACME ClusterIssuer]
+  extdns[external-dns]
+
+  schema -->|aws| tfR53
+  schema -->|azure| tfAz
+  tfR53 --> r53
+  tfAz --> azz
+  r53 --> certmgr
+  r53 --> extdns
+  azz --> certmgr
+  azz --> extdns
+```
+
+The cluster module wires identity into both consumers: IAM Role + Pod
+Identity (EKS), Workload Identity (AKS). cert-manager solves DNS-01
+ACME challenges to issue real Let's Encrypt certificates; external-dns
+keeps record sets in sync with Ingress and HTTPRoute objects.
+
+## Recipes
+
+### AWS Route53
+
+```yaml
+platform: aws
+dns:
+  public_domain: example.windsorcli.dev
+```
+
+Provisions a Route53 public hosted zone in the active account. The
+cluster module then provisions a scoped IAM role for cert-manager
+(record-write actions limited to this zone's ID via
+`cert_manager_hosted_zone_ids`) and the Pod Identity association.
+
+Post-apply: delegate the parent domain at your registrar to the four
+name servers in the module output (`name_servers`). Until delegation
+propagates, ACME challenges will fail and external-dns will warn but
+not block.
+
+### Azure DNS
+
+```yaml
+platform: azure
+dns:
+  public_domain: example.windsorcli.dev
+```
+
+Provisions an Azure DNS public zone in the resource group. Workload
+Identity is configured on the AKS cluster for cert-manager and
+external-dns to write records into this zone.
+
+### Self-signed (no public domain)
+
+```yaml
+platform: aws    # or any platform
+# dns.public_domain unset
+```
+
+No DNS zone module runs. The cluster uses a self-signed ClusterIssuer
+for gateway TLS — the "just-works" mode for dev clusters and local
+deployments. Browsers will warn on the cert but everything else works.
+
+## Operations
+
+- **ACME challenges fail with NXDOMAIN** — NS delegation at the
+  registrar hasn't propagated. Check `dig NS example.windsorcli.dev`
+  against the public root resolvers; until it returns the zone's name
+  servers, cert-manager can't write the DNS-01 record where ACME
+  expects to read it.
+- **external-dns logs `AccessDenied` (AWS)** — the cluster's
+  cert-manager IAM role is scoped to one zone ID. If the zone was
+  re-created out-of-band (different ID), the role's resource ARN no
+  longer matches. Re-apply the cluster module to refresh the binding.
+- **Zone destroyed but records remain** — Route53 zones with active
+  records refuse to delete. `terraform destroy` on the dns-zone stack
+  will fail until external-dns has cleaned up record sets. Drain the
+  cluster first, then destroy the zone.
+- **`dns.private_domain` set without a zone module** — `private_domain`
+  is consumed by the network module's VPC-scoped private Route53 zone
+  (AWS) and by in-cluster CoreDNS; no separate `dns/zone/private/*`
+  module exists.
+
+## Security
+
+- IAM (EKS) and Workload Identity (AKS) bindings scope write access to
+  the single zone provisioned by this module. Compromised cert-manager
+  or external-dns cannot write into unrelated zones in the same
+  account.
+- The zone module exports name servers but no credentials. Delegation
+  is an out-of-band operation done by the operator at their registrar.
+- Self-signed mode generates a root CA inside the cluster; trust it
+  manually on developer machines rather than disabling TLS verification.
+
+## See also
+
+- [zone/route53/](zone/route53/), [zone/azure-dns/](zone/azure-dns/) — per-driver Terraform reference.
+- [../cluster/](../cluster/) — provisions the identity binding (IAM Pod Identity, Workload Identity).
+- [../../kustomize/pki/](../../kustomize/pki/) — cert-manager and ClusterIssuers.
+- [../../kustomize/dns/](../../kustomize/dns/) — external-dns reconciler.

--- a/terraform/dns/README.md
+++ b/terraform/dns/README.md
@@ -28,16 +28,13 @@ binding for both consumers on the matching cloud.
 ```mermaid
 flowchart LR
   registrar[Domain registrar<br/>NS delegation]
+  cm[cert-manager]
+  ed[external-dns]
 
   subgraph aws[AWS account]
-    zone[Route53 hosted zone<br/>example.windsorcli.dev]
-    iam[IAM Role<br/>cert-manager DNS-01<br/>scoped to zone ID]
+    zone[Route53 hosted zone]
+    iam[IAM Role<br/>scoped to zone ID]
     pi[Pod Identity association]
-  end
-
-  subgraph cluster[Cluster]
-    cm[cert-manager]
-    ed[external-dns]
   end
 
   registrar -.delegates.-> zone
@@ -69,16 +66,13 @@ but doesn't block.
 ```mermaid
 flowchart LR
   registrar[Domain registrar<br/>NS delegation]
+  cm[cert-manager]
+  ed[external-dns]
 
   subgraph azure[Azure resource group]
-    zone[Azure DNS zone<br/>example.windsorcli.dev]
-    uami[User-Assigned MI<br/>cert-manager + external-dns]
+    zone[Azure DNS zone]
+    uami[User-Assigned MI]
     fed[Federated credential<br/>via OIDC issuer]
-  end
-
-  subgraph cluster[AKS cluster]
-    cm[cert-manager]
-    ed[external-dns]
   end
 
   registrar -.delegates.-> zone

--- a/terraform/dns/README.md
+++ b/terraform/dns/README.md
@@ -5,15 +5,16 @@ description: Public DNS zones for ACME certificates and external-dns.
 
 # DNS
 
-Two drivers under `dns/zone/` provision public DNS zones: `route53` (AWS)
-and `azure-dns` (Azure). Selection follows `platform`, and the zone
-module only runs when `dns.public_domain` is set. With no public domain,
-the cluster falls back to self-signed certificates and no external zone
-is created.
+The dns category has two drivers under `dns/zone/`. `route53`
+provisions a public Route53 hosted zone on AWS, and `azure-dns`
+provisions a public DNS zone on Azure. The driver is selected by
+`platform`, and the zone module only runs when `dns.public_domain` is
+set. With no public domain, the cluster falls back to self-signed
+certificates and no external zone is created.
 
 Zones are provisioned in their own Terraform stack so they have an
-independent lifecycle — tearing down the cluster does not drag the zone
-(and its NS delegation effort) with it.
+independent lifecycle. Tearing down the cluster doesn't drag the zone
+(and its NS delegation effort) along with it.
 
 ## Architecture
 
@@ -44,10 +45,11 @@ flowchart LR
   azz --> extdns
 ```
 
-The cluster module wires identity into both consumers: IAM Role + Pod
-Identity (EKS), Workload Identity (AKS). cert-manager solves DNS-01
-ACME challenges to issue real Let's Encrypt certificates; external-dns
-keeps record sets in sync with Ingress and HTTPRoute objects.
+The cluster module wires identity into both consumers: an IAM Role
+plus Pod Identity on EKS, Workload Identity on AKS. cert-manager
+solves DNS-01 ACME challenges to issue real Let's Encrypt
+certificates. external-dns keeps record sets in sync with Ingress and
+HTTPRoute objects.
 
 ## Recipes
 
@@ -59,15 +61,16 @@ dns:
   public_domain: example.windsorcli.dev
 ```
 
-Provisions a Route53 public hosted zone in the active account. The
-cluster module then provisions a scoped IAM role for cert-manager
-(record-write actions limited to this zone's ID via
-`cert_manager_hosted_zone_ids`) and the Pod Identity association.
+The module provisions a Route53 public hosted zone in the active
+account. The cluster module then provisions a scoped IAM role for
+cert-manager (the role's record-write actions are limited to this
+zone's ID via `cert_manager_hosted_zone_ids`) and the Pod Identity
+association.
 
-Post-apply: delegate the parent domain at your registrar to the four
-name servers in the module output (`name_servers`). Until delegation
-propagates, ACME challenges will fail and external-dns will warn but
-not block.
+After the apply, delegate the parent domain at your registrar to the
+four name servers in the module output (`name_servers`). Until
+delegation propagates, ACME challenges fail and external-dns warns
+but doesn't block.
 
 ### Azure DNS
 
@@ -77,9 +80,9 @@ dns:
   public_domain: example.windsorcli.dev
 ```
 
-Provisions an Azure DNS public zone in the resource group. Workload
-Identity is configured on the AKS cluster for cert-manager and
-external-dns to write records into this zone.
+The module provisions an Azure DNS public zone in the resource group.
+Workload Identity is configured on the AKS cluster for cert-manager
+and external-dns to write records into this zone.
 
 ### Self-signed (no public domain)
 
@@ -89,43 +92,51 @@ platform: aws    # or any platform
 ```
 
 No DNS zone module runs. The cluster uses a self-signed ClusterIssuer
-for gateway TLS — the "just-works" mode for dev clusters and local
-deployments. Browsers will warn on the cert but everything else works.
+for gateway TLS, which is the just-works mode for dev clusters and
+local deployments. Browsers will warn on the cert, but everything
+else works.
 
 ## Operations
 
-- **ACME challenges fail with NXDOMAIN** — NS delegation at the
-  registrar hasn't propagated. Check `dig NS example.windsorcli.dev`
-  against the public root resolvers; until it returns the zone's name
-  servers, cert-manager can't write the DNS-01 record where ACME
-  expects to read it.
-- **external-dns logs `AccessDenied` (AWS)** — the cluster's
-  cert-manager IAM role is scoped to one zone ID. If the zone was
-  re-created out-of-band (different ID), the role's resource ARN no
-  longer matches. Re-apply the cluster module to refresh the binding.
-- **Zone destroyed but records remain** — Route53 zones with active
-  records refuse to delete. `terraform destroy` on the dns-zone stack
-  will fail until external-dns has cleaned up record sets. Drain the
-  cluster first, then destroy the zone.
-- **`dns.private_domain` set without a zone module** — `private_domain`
-  is consumed by the network module's VPC-scoped private Route53 zone
-  (AWS) and by in-cluster CoreDNS; no separate `dns/zone/private/*`
-  module exists.
+ACME challenges that fail with NXDOMAIN almost always mean NS
+delegation at the registrar hasn't propagated yet. Run
+`dig NS example.windsorcli.dev` against the public root resolvers;
+until that returns the zone's name servers, cert-manager can't write
+the DNS-01 record where ACME expects to read it.
+
+When external-dns logs `AccessDenied` on AWS, the cluster's
+cert-manager IAM role is scoped to a single zone ID. If the zone was
+re-created out-of-band (different ID), the role's resource ARN no
+longer matches. Re-apply the cluster module to refresh the binding.
+
+Destroying a Route53 zone with active records fails, because Route53
+refuses to delete a zone that still contains record sets.
+`terraform destroy` on the dns-zone stack won't succeed until
+external-dns has cleaned up. Drain the cluster first, then destroy
+the zone.
+
+`dns.private_domain` doesn't trigger a separate zone module. It's
+consumed by the network module's VPC-scoped private Route53 zone on
+AWS, and by in-cluster CoreDNS. There's no `dns/zone/private/*`
+module.
 
 ## Security
 
-- IAM (EKS) and Workload Identity (AKS) bindings scope write access to
-  the single zone provisioned by this module. Compromised cert-manager
-  or external-dns cannot write into unrelated zones in the same
-  account.
-- The zone module exports name servers but no credentials. Delegation
-  is an out-of-band operation done by the operator at their registrar.
-- Self-signed mode generates a root CA inside the cluster; trust it
-  manually on developer machines rather than disabling TLS verification.
+The IAM role on EKS and the Workload Identity binding on AKS are both
+scoped to the single zone provisioned by this module. A compromised
+cert-manager or external-dns can't write into unrelated zones in the
+same account.
+
+The zone module exports name servers but no credentials. Delegation
+is an out-of-band operation the operator does at their registrar.
+
+Self-signed mode generates a root CA inside the cluster. Trust that
+CA manually on developer machines rather than disabling TLS
+verification.
 
 ## See also
 
-- [zone/route53/](zone/route53/), [zone/azure-dns/](zone/azure-dns/) — per-driver Terraform reference.
-- [../cluster/](../cluster/) — provisions the identity binding (IAM Pod Identity, Workload Identity).
-- [../../kustomize/pki/](../../kustomize/pki/) — cert-manager and ClusterIssuers.
-- [../../kustomize/dns/](../../kustomize/dns/) — external-dns reconciler.
+- [zone/route53/](zone/route53/) and [zone/azure-dns/](zone/azure-dns/) for the per-driver Terraform reference.
+- [../cluster/](../cluster/) for the cluster module that provisions the identity binding (IAM Pod Identity, Workload Identity).
+- [../../kustomize/pki/](../../kustomize/pki/) for cert-manager and the ClusterIssuers.
+- [../../kustomize/dns/](../../kustomize/dns/) for the external-dns reconciler.

--- a/terraform/dns/README.md
+++ b/terraform/dns/README.md
@@ -16,44 +16,36 @@ Zones are provisioned in their own Terraform stack so they have an
 independent lifecycle. Tearing down the cluster doesn't drag the zone
 (and its NS delegation effort) along with it.
 
-## Architecture
-
-```mermaid
-flowchart LR
-  values[values.yaml<br/>dns.public_domain]
-
-  subgraph awspath[AWS]
-    tfR53[terraform/dns/zone/route53]
-    r53[Route53 hosted zone]
-  end
-
-  subgraph azurepath[Azure]
-    tfAz[terraform/dns/zone/azure-dns]
-    azz[Azure DNS zone]
-  end
-
-  certmgr[cert-manager<br/>ACME ClusterIssuer]
-  extdns[external-dns]
-
-  values -->|aws| tfR53
-  values -->|azure| tfAz
-  tfR53 --> r53
-  tfAz --> azz
-  r53 --> certmgr
-  r53 --> extdns
-  azz --> certmgr
-  azz --> extdns
-```
-
-The cluster module wires identity into both consumers: an IAM Role
-plus Pod Identity on EKS, Workload Identity on AKS. cert-manager
-solves DNS-01 ACME challenges to issue real Let's Encrypt
-certificates. external-dns keeps record sets in sync with Ingress and
-HTTPRoute objects.
+cert-manager solves DNS-01 ACME challenges to issue real Let's
+Encrypt certificates. external-dns keeps record sets in sync with
+Ingress and HTTPRoute objects. The cluster module wires the identity
+binding for both consumers on the matching cloud.
 
 ## Recipes
 
 ### AWS Route53
+
+```mermaid
+flowchart LR
+  registrar[Domain registrar<br/>NS delegation]
+
+  subgraph aws[AWS account]
+    zone[Route53 hosted zone<br/>example.windsorcli.dev]
+    iam[IAM Role<br/>cert-manager DNS-01<br/>scoped to zone ID]
+    pi[Pod Identity association]
+  end
+
+  subgraph cluster[Cluster]
+    cm[cert-manager]
+    ed[external-dns]
+  end
+
+  registrar -.delegates.-> zone
+  cm -.assumes.-> pi
+  pi -.binds.-> iam
+  iam -.writes ACME TXT.-> zone
+  ed -.writes A and CNAME.-> zone
+```
 
 ```yaml
 platform: aws
@@ -73,6 +65,28 @@ delegation propagates, ACME challenges fail and external-dns warns
 but doesn't block.
 
 ### Azure DNS
+
+```mermaid
+flowchart LR
+  registrar[Domain registrar<br/>NS delegation]
+
+  subgraph azure[Azure resource group]
+    zone[Azure DNS zone<br/>example.windsorcli.dev]
+    uami[User-Assigned MI<br/>cert-manager + external-dns]
+    fed[Federated credential<br/>via OIDC issuer]
+  end
+
+  subgraph cluster[AKS cluster]
+    cm[cert-manager]
+    ed[external-dns]
+  end
+
+  registrar -.delegates.-> zone
+  cm -.via Workload ID.-> fed
+  ed -.via Workload ID.-> fed
+  fed -.binds.-> uami
+  uami -.writes records.-> zone
+```
 
 ```yaml
 platform: azure

--- a/terraform/dns/README.md
+++ b/terraform/dns/README.md
@@ -20,7 +20,7 @@ independent lifecycle. Tearing down the cluster doesn't drag the zone
 
 ```mermaid
 flowchart LR
-  schema[schema.yaml<br/>dns.public_domain]
+  values[values.yaml<br/>dns.public_domain]
 
   subgraph awspath[AWS]
     tfR53[terraform/dns/zone/route53]
@@ -35,8 +35,8 @@ flowchart LR
   certmgr[cert-manager<br/>ACME ClusterIssuer]
   extdns[external-dns]
 
-  schema -->|aws| tfR53
-  schema -->|azure| tfAz
+  values -->|aws| tfR53
+  values -->|azure| tfAz
   tfR53 --> r53
   tfAz --> azz
   r53 --> certmgr

--- a/terraform/gitops/README.md
+++ b/terraform/gitops/README.md
@@ -17,33 +17,38 @@ is `push`, which creates a Flux Receiver so a webhook POST from the repo
 triggers reconciliation immediately. `pull` mode skips the Receiver and
 relies on the interval poll on the GitRepository.
 
-## Architecture
-
-```mermaid
-flowchart LR
-  values[values.yaml<br/>gitops.mode + repository]
-
-  tfGitops[terraform/gitops/flux]
-  flux[Flux controllers<br/>+ CRDs]
-  root[GitRepository + root Kustomization]
-
-  kustomize[kustomize/ layer<br/>cni, csi, pki, ...]
-
-  values --> tfGitops
-  tfGitops --> flux
-  tfGitops --> root
-  root ==reconciles==> kustomize
-```
-
-After the initial install, this module is mostly inert. Flux watches
-the GitRepository (or the Receiver in push mode), notices new commits,
-and reconciles the kustomize layer. A subsequent `windsor apply` that
-doesn't change anything in this module just confirms Flux is still
-healthy.
-
 ## Recipes
 
 ### Push mode (default)
+
+```mermaid
+flowchart LR
+  repo[(GitOps repo)]
+
+  subgraph cluster[Kubernetes cluster]
+    subgraph fluxsys[flux-system namespace]
+      sc[source-controller]
+      kc[kustomize-controller]
+      hc[helm-controller]
+      nc[notification-controller]
+      gr[GitRepository<br/>local]
+      ks[Kustomization<br/>root]
+      rcv[Receiver]
+      sec[Secret<br/>webhook token]
+    end
+    layer[kustomize/ layer<br/>cni, csi, pki, ...]
+  end
+
+  repo ==webhook POST==> nc
+  nc -.notifies.-> sc
+  sc --> gr
+  gr --> kc
+  kc --> ks
+  ks ==reconciles==> layer
+  hc --> layer
+  rcv -.signed by.-> sec
+  nc -.serves.-> rcv
+```
 
 ```yaml
 gitops:
@@ -56,11 +61,35 @@ gitops:
 
 A Flux Receiver Secret is created with the value of `webhook.token`.
 The repo's webhook configuration posts to the Receiver URL on every
-push, and Flux reconciles immediately. The intervals on the
-GitRepository still apply, but they're acting as a safety-net poll
-rather than the primary trigger.
+push, and notification-controller signals source-controller to
+reconcile immediately. The intervals on the GitRepository still
+apply, but they're acting as a safety-net poll rather than the
+primary trigger.
 
 ### Pull mode
+
+```mermaid
+flowchart LR
+  repo[(GitOps repo)]
+
+  subgraph cluster[Kubernetes cluster]
+    subgraph fluxsys[flux-system namespace]
+      sc[source-controller]
+      kc[kustomize-controller]
+      hc[helm-controller]
+      gr[GitRepository<br/>local]
+      ks[Kustomization<br/>root]
+    end
+    layer[kustomize/ layer<br/>cni, csi, pki, ...]
+  end
+
+  sc -.poll on interval.-> repo
+  sc --> gr
+  gr --> kc
+  kc --> ks
+  ks ==reconciles==> layer
+  hc --> layer
+```
 
 ```yaml
 gitops:
@@ -69,10 +98,11 @@ gitops:
     name: local
 ```
 
-No Receiver is created. Flux polls the GitRepository at its configured
-interval and reconciles when the commit hash changes. Use this when
-webhooks aren't an option, for example on private clusters with no
-inbound HTTP, or on source-of-truth repos that don't support webhooks.
+No Receiver is created. source-controller polls the GitRepository at
+its configured interval and reconciles when the commit hash changes.
+Use this when webhooks aren't an option, for example on private
+clusters with no inbound HTTP, or on source-of-truth repos that don't
+support webhooks.
 
 ## Operations
 

--- a/terraform/gitops/README.md
+++ b/terraform/gitops/README.md
@@ -25,19 +25,18 @@ relies on the interval poll on the GitRepository.
 flowchart LR
   repo[(GitOps repo)]
 
-  subgraph cluster[Kubernetes cluster]
-    subgraph fluxsys[flux-system namespace]
-      sc[source-controller]
-      kc[kustomize-controller]
-      hc[helm-controller]
-      nc[notification-controller]
-      gr[GitRepository<br/>local]
-      ks[Kustomization<br/>root]
-      rcv[Receiver]
-      sec[Secret<br/>webhook token]
-    end
-    layer[kustomize/ layer<br/>cni, csi, pki, ...]
+  subgraph fluxsys[flux-system namespace]
+    sc[source-controller]
+    kc[kustomize-controller]
+    hc[helm-controller]
+    nc[notification-controller]
+    gr[GitRepository<br/>local]
+    ks[Kustomization<br/>root]
+    rcv[Receiver]
+    sec[Secret<br/>webhook token]
   end
+
+  layer[kustomize/ layer<br/>cni, csi, pki, ...]
 
   repo ==webhook POST==> nc
   nc -.notifies.-> sc
@@ -72,16 +71,15 @@ primary trigger.
 flowchart LR
   repo[(GitOps repo)]
 
-  subgraph cluster[Kubernetes cluster]
-    subgraph fluxsys[flux-system namespace]
-      sc[source-controller]
-      kc[kustomize-controller]
-      hc[helm-controller]
-      gr[GitRepository<br/>local]
-      ks[Kustomization<br/>root]
-    end
-    layer[kustomize/ layer<br/>cni, csi, pki, ...]
+  subgraph fluxsys[flux-system namespace]
+    sc[source-controller]
+    kc[kustomize-controller]
+    hc[helm-controller]
+    gr[GitRepository<br/>local]
+    ks[Kustomization<br/>root]
   end
+
+  layer[kustomize/ layer<br/>cni, csi, pki, ...]
 
   sc -.poll on interval.-> repo
   sc --> gr

--- a/terraform/gitops/README.md
+++ b/terraform/gitops/README.md
@@ -1,20 +1,21 @@
 ---
 title: GitOps
-description: Flux installation that hands reconciliation to the kustomize/ layer.
+description: Flux installation that hands reconciliation to the kustomize layer.
 ---
 
 # GitOps
 
-One driver: `flux`. Runs after `cluster` on every platform. Installs
-Flux's CRDs and controllers, then stamps a root `GitRepository` and
-`Kustomization` that point at the context's GitOps repo. From that
-point on, Flux self-manages and the kustomize/ layer drives every
-day-2 change.
+The gitops category has one module, `flux`, which runs after the cluster
+module on every platform. It installs the Flux CRDs and controllers and
+then creates a root `GitRepository` plus root `Kustomization` pointing at
+the context's GitOps repo. Once those exist, Flux watches the repo and
+reconciles whatever's under `kustomize/`. The terraform module itself
+doesn't have much to do on subsequent applies.
 
-`gitops.mode` picks how Flux learns about repo changes: `push` (the
-default) wires a Flux Receiver so webhook POSTs trigger immediate
-reconciliation; `pull` falls back to interval polling without a
-Receiver.
+`gitops.mode` controls how Flux learns about new commits. The default
+is `push`, which creates a Flux Receiver so a webhook POST from the repo
+triggers reconciliation immediately. `pull` mode skips the Receiver and
+relies on the interval poll on the GitRepository.
 
 ## Architecture
 
@@ -34,10 +35,11 @@ flowchart LR
   root ==reconciles==> kustomize
 ```
 
-After bootstrap, this module is mostly inert. Flux watches the
-GitRepository (or the Receiver in push mode), notices new commits, and
-reconciles the kustomize/ layer. Subsequent `windsor apply` runs that
-don't change anything in this module just confirm Flux is still healthy.
+After the initial install, this module is mostly inert. Flux watches
+the GitRepository (or the Receiver in push mode), notices new commits,
+and reconciles the kustomize layer. A subsequent `windsor apply` that
+doesn't change anything in this module just confirms Flux is still
+healthy.
 
 ## Recipes
 
@@ -52,10 +54,11 @@ gitops:
     token: ${env.FLUX_WEBHOOK_TOKEN}    # set in production
 ```
 
-A Flux Receiver Secret is created with `webhook.token`. The repo's
-webhook configuration posts to the Receiver URL on push, and Flux
-reconciles immediately. Intervals on the GitRepository act as a
-safety-net poll only.
+A Flux Receiver Secret is created with the value of `webhook.token`.
+The repo's webhook configuration posts to the Receiver URL on every
+push, and Flux reconciles immediately. The intervals on the
+GitRepository still apply, but they're acting as a safety-net poll
+rather than the primary trigger.
 
 ### Pull mode
 
@@ -67,31 +70,34 @@ gitops:
 ```
 
 No Receiver is created. Flux polls the GitRepository at its configured
-interval. Use this when webhooks aren't an option (private clusters
-without inbound HTTP, source-of-truth repos with no webhook support).
+interval and reconciles when the commit hash changes. Use this when
+webhooks aren't an option, for example on private clusters with no
+inbound HTTP, or on source-of-truth repos that don't support webhooks.
 
 ## Operations
 
-- **Push-mode reconciliation doesn't fire on push** — the Receiver
-  Secret token must match the token the repo's webhook is signing
-  with. Verify both sides; rotate `gitops.webhook.token` if the
-  workstation default leaked into production.
-- **Flux controllers stuck CrashLoopBackOff after install** — usually
-  pod networking isn't up. On Talos+Cilium, the `cni/cilium` bootstrap
-  step must complete before this module runs (the stack ordering
-  enforces this in `platform-*` facets).
-- **Root Kustomization perpetually NotReady** — the GitOps repo doesn't
-  contain the expected path, or the repo URL/branch doesn't match
-  what the module configured. `flux get sources git` shows the active
-  GitRepository state; `flux get kustomizations` shows the
-  reconciliation status.
-- **Webhook token leaked from workstation defaults** — workstation mode
-  uses a placeholder token. Production clusters must set
-  `gitops.webhook.token` explicitly and ensure the value comes from a
-  secret store, not the values file.
+If push-mode reconciliation doesn't fire on a push, the Receiver
+Secret token has to match the token the repo's webhook is signing
+with. Check both sides. The workstation default value is a placeholder
+and should be rotated if it ever leaked into production.
+
+Flux controllers stuck in CrashLoopBackOff after install almost always
+mean pod networking isn't up. On Talos + Cilium, the `cni/cilium`
+bootstrap step has to complete before this module runs, which the
+stack ordering in the `platform-*` facets enforces.
+
+A root Kustomization stuck in NotReady usually means the GitOps repo
+doesn't contain the path the module configured, or the URL or branch
+is wrong. `flux get sources git` shows the active GitRepository state,
+and `flux get kustomizations` shows the reconciliation status.
+
+The webhook token in workstation mode is a known placeholder.
+Production clusters need to set `gitops.webhook.token` explicitly and
+pull the value from a secret store rather than checking it into the
+values file.
 
 ## See also
 
-- [flux/](flux/) — per-module Terraform reference.
-- [../cluster/](../cluster/) — produces the kubeconfig this module installs into.
-- [../../kustomize/](../../kustomize/) — the layer Flux reconciles from this point forward.
+- [flux/](flux/) for the per-module Terraform reference.
+- [../cluster/](../cluster/) for the cluster module that produces the kubeconfig used here.
+- [../../kustomize/](../../kustomize/) for the layer Flux reconciles once the install completes.

--- a/terraform/gitops/README.md
+++ b/terraform/gitops/README.md
@@ -26,27 +26,21 @@ flowchart LR
   repo[(GitOps repo)]
 
   subgraph fluxsys[flux-system namespace]
-    sc[source-controller]
-    kc[kustomize-controller]
-    hc[helm-controller]
-    nc[notification-controller]
-    gr[GitRepository<br/>local]
-    ks[Kustomization<br/>root]
-    rcv[Receiver]
-    sec[Secret<br/>webhook token]
+    rcv[Receiver<br/>+ webhook secret]
+    src[source-controller]
+    kus[kustomize-controller]
+    gr[GitRepository]
+    ks[Kustomization]
   end
 
-  layer[kustomize/ layer<br/>cni, csi, pki, ...]
+  layer[kustomize/ layer]
 
-  repo ==webhook POST==> nc
-  nc -.notifies.-> sc
-  sc --> gr
-  gr --> kc
-  kc --> ks
+  repo ==webhook POST==> rcv
+  rcv -.triggers.-> src
+  src --> gr
+  gr --> kus
+  kus --> ks
   ks ==reconciles==> layer
-  hc --> layer
-  rcv -.signed by.-> sec
-  nc -.serves.-> rcv
 ```
 
 ```yaml
@@ -72,21 +66,19 @@ flowchart LR
   repo[(GitOps repo)]
 
   subgraph fluxsys[flux-system namespace]
-    sc[source-controller]
-    kc[kustomize-controller]
-    hc[helm-controller]
-    gr[GitRepository<br/>local]
-    ks[Kustomization<br/>root]
+    src[source-controller]
+    kus[kustomize-controller]
+    gr[GitRepository]
+    ks[Kustomization]
   end
 
-  layer[kustomize/ layer<br/>cni, csi, pki, ...]
+  layer[kustomize/ layer]
 
-  sc -.poll on interval.-> repo
-  sc --> gr
-  gr --> kc
-  kc --> ks
+  src -.poll on interval.-> repo
+  src --> gr
+  gr --> kus
+  kus --> ks
   ks ==reconciles==> layer
-  hc --> layer
 ```
 
 ```yaml

--- a/terraform/gitops/README.md
+++ b/terraform/gitops/README.md
@@ -1,0 +1,97 @@
+---
+title: GitOps
+description: Flux installation that hands reconciliation to the kustomize/ layer.
+---
+
+# GitOps
+
+One driver: `flux`. Runs after `cluster` on every platform. Installs
+Flux's CRDs and controllers, then stamps a root `GitRepository` and
+`Kustomization` that point at the context's GitOps repo. From that
+point on, Flux self-manages and the kustomize/ layer drives every
+day-2 change.
+
+`gitops.mode` picks how Flux learns about repo changes: `push` (the
+default) wires a Flux Receiver so webhook POSTs trigger immediate
+reconciliation; `pull` falls back to interval polling without a
+Receiver.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  schema[schema.yaml<br/>gitops.mode + repository]
+
+  tfGitops[terraform/gitops/flux]
+  flux[Flux controllers<br/>+ CRDs]
+  root[GitRepository + root Kustomization]
+
+  kustomize[kustomize/ layer<br/>cni, csi, pki, ...]
+
+  schema --> tfGitops
+  tfGitops --> flux
+  tfGitops --> root
+  root ==reconciles==> kustomize
+```
+
+After bootstrap, this module is mostly inert. Flux watches the
+GitRepository (or the Receiver in push mode), notices new commits, and
+reconciles the kustomize/ layer. Subsequent `windsor apply` runs that
+don't change anything in this module just confirm Flux is still healthy.
+
+## Recipes
+
+### Push mode (default)
+
+```yaml
+gitops:
+  mode: push
+  repository:
+    name: local
+  webhook:
+    token: ${env.FLUX_WEBHOOK_TOKEN}    # set in production
+```
+
+A Flux Receiver Secret is created with `webhook.token`. The repo's
+webhook configuration posts to the Receiver URL on push, and Flux
+reconciles immediately. Intervals on the GitRepository act as a
+safety-net poll only.
+
+### Pull mode
+
+```yaml
+gitops:
+  mode: pull
+  repository:
+    name: local
+```
+
+No Receiver is created. Flux polls the GitRepository at its configured
+interval. Use this when webhooks aren't an option (private clusters
+without inbound HTTP, source-of-truth repos with no webhook support).
+
+## Operations
+
+- **Push-mode reconciliation doesn't fire on push** — the Receiver
+  Secret token must match the token the repo's webhook is signing
+  with. Verify both sides; rotate `gitops.webhook.token` if the
+  workstation default leaked into production.
+- **Flux controllers stuck CrashLoopBackOff after install** — usually
+  pod networking isn't up. On Talos+Cilium, the `cni/cilium` bootstrap
+  step must complete before this module runs (the stack ordering
+  enforces this in `platform-*` facets).
+- **Root Kustomization perpetually NotReady** — the GitOps repo doesn't
+  contain the expected path, or the repo URL/branch doesn't match
+  what the module configured. `flux get sources git` shows the active
+  GitRepository state; `flux get kustomizations` shows the
+  reconciliation status.
+- **Webhook token leaked from workstation defaults** — workstation mode
+  uses a placeholder token. Production clusters must set
+  `gitops.webhook.token` explicitly and ensure the value comes from a
+  secret store, not the values file.
+
+## See also
+
+- [flux/](flux/) — per-module Terraform reference.
+- [../cluster/](../cluster/) — produces the kubeconfig this module installs into.
+- [../../kustomize/](../../kustomize/) — the layer Flux reconciles from this point forward.

--- a/terraform/gitops/README.md
+++ b/terraform/gitops/README.md
@@ -21,7 +21,7 @@ relies on the interval poll on the GitRepository.
 
 ```mermaid
 flowchart LR
-  schema[schema.yaml<br/>gitops.mode + repository]
+  values[values.yaml<br/>gitops.mode + repository]
 
   tfGitops[terraform/gitops/flux]
   flux[Flux controllers<br/>+ CRDs]
@@ -29,7 +29,7 @@ flowchart LR
 
   kustomize[kustomize/ layer<br/>cni, csi, pki, ...]
 
-  schema --> tfGitops
+  values --> tfGitops
   tfGitops --> flux
   tfGitops --> root
   root ==reconciles==> kustomize

--- a/terraform/network/README.md
+++ b/terraform/network/README.md
@@ -27,32 +27,19 @@ inputs.
 flowchart LR
   internet((Internet))
 
-  subgraph vpc[VPC network.cidr_block]
+  subgraph vpc[VPC network.cidr_block, replicated per AZ]
     igw[Internet Gateway]
+    pub[Public subnet]
+    nat[NAT Gateway<br/>in each public subnet]
+    priv[Private subnet]
     rtPub[Public route table<br/>0.0.0.0/0 → IGW]
-
-    subgraph az1[AZ-1]
-      pub1[Public subnet]
-      nat1[NAT Gateway]
-      priv1[Private subnet]
-      rtPriv1[Private route table<br/>0.0.0.0/0 → NAT-1]
-    end
-
-    subgraph az2[AZ-2]
-      pub2[Public subnet]
-      nat2[NAT Gateway]
-      priv2[Private subnet]
-      rtPriv2[Private route table<br/>0.0.0.0/0 → NAT-2]
-    end
+    rtPriv[Private route table<br/>0.0.0.0/0 → NAT]
   end
 
   internet <--> igw
-  pub1 -.uses.-> rtPub
-  pub2 -.uses.-> rtPub
-  nat1 -.lives in.-> pub1
-  nat2 -.lives in.-> pub2
-  priv1 -.uses.-> rtPriv1
-  priv2 -.uses.-> rtPriv2
+  pub -.uses.-> rtPub
+  priv -.uses.-> rtPriv
+  nat -.lives in.-> pub
 ```
 
 ```yaml
@@ -78,22 +65,16 @@ flowchart LR
   internet((Internet))
 
   subgraph rg[Resource group]
-    subgraph vnet[VNet network.cidr_block]
-      pub[Public subnet]
-      priv[Private subnet]
-      iso[Isolated subnet]
-    end
-
-    natGw[NAT Gateway]
-    natIp[Public IP for NAT]
-    rtPriv[Route table<br/>0.0.0.0/0 → NAT]
+    vnet[VNet network.cidr_block<br/>public + private + isolated subnets]
+    natGw[NAT Gateway<br/>+ public IP]
+    rtPriv[Route table<br/>0.0.0.0/0 → NAT, attached to private subnet]
     pdns[Private DNS zone<br/>linked to VNet]
   end
 
-  internet <--> natIp
-  natIp -.attached to.-> natGw
-  natGw -.attached to.-> priv
-  priv -.uses.-> rtPriv
+  internet <--> natGw
+  natGw -.routes.-> rtPriv
+  rtPriv -.attaches to.-> vnet
+  pdns -.linked to.-> vnet
 ```
 
 ```yaml

--- a/terraform/network/README.md
+++ b/terraform/network/README.md
@@ -30,14 +30,10 @@ flowchart LR
     vnet[VNet + subnets]
   end
 
-  cluster[terraform/cluster/aws-eks<br/>terraform/cluster/azure-aks]
-
   values -->|aws| tfVpc
   values -->|azure| tfVnet
   tfVpc --> vpc
   tfVnet --> vnet
-  vpc --> cluster
-  vnet --> cluster
 ```
 
 The network module runs after `backend` and before `cluster`. The

--- a/terraform/network/README.md
+++ b/terraform/network/README.md
@@ -7,34 +7,13 @@ description: Cloud network fabric for managed Kubernetes clusters.
 
 The network category has two drivers. `aws-vpc` builds a VPC with
 public and private subnets, an Internet Gateway, and per-AZ NAT
-Gateways. `azure-vnet` builds a VNet with private subnets. The driver
-is selected by `platform`. Local platforms (`docker`, `hyperv`,
-`incus`, and `metal`) don't use this layer; their compute driver
-creates networking directly on the host (bridges, NAT, NodePort
-forwards). The shared `network.cidr_block` schema field is what drives
-both paths.
-
-## Architecture
-
-```mermaid
-flowchart LR
-  values[values.yaml<br/>network.cidr_block]
-
-  subgraph awspath[AWS]
-    tfVpc[terraform/network/aws-vpc]
-    vpc[VPC + subnets + NAT]
-  end
-
-  subgraph azurepath[Azure]
-    tfVnet[terraform/network/azure-vnet]
-    vnet[VNet + subnets]
-  end
-
-  values -->|aws| tfVpc
-  values -->|azure| tfVnet
-  tfVpc --> vpc
-  tfVnet --> vnet
-```
+Gateways. `azure-vnet` builds a VNet with public, private, and
+isolated subnets along with a NAT Gateway for private egress. The
+driver is selected by `platform`. Local platforms (`docker`,
+`hyperv`, `incus`, and `metal`) don't use this layer; their compute
+driver creates networking directly on the host (bridges, NAT,
+NodePort forwards). The shared `network.cidr_block` schema field is
+what drives both paths.
 
 The network module runs after `backend` and before `cluster`. The
 cluster modules then consume the VPC or VNet IDs and subnet IDs as
@@ -44,6 +23,38 @@ inputs.
 
 ### AWS VPC
 
+```mermaid
+flowchart LR
+  internet((Internet))
+
+  subgraph vpc[VPC network.cidr_block]
+    igw[Internet Gateway]
+    rtPub[Public route table<br/>0.0.0.0/0 → IGW]
+
+    subgraph az1[AZ-1]
+      pub1[Public subnet]
+      nat1[NAT Gateway]
+      priv1[Private subnet]
+      rtPriv1[Private route table<br/>0.0.0.0/0 → NAT-1]
+    end
+
+    subgraph az2[AZ-2]
+      pub2[Public subnet]
+      nat2[NAT Gateway]
+      priv2[Private subnet]
+      rtPriv2[Private route table<br/>0.0.0.0/0 → NAT-2]
+    end
+  end
+
+  internet <--> igw
+  pub1 -.uses.-> rtPub
+  pub2 -.uses.-> rtPub
+  nat1 -.lives in.-> pub1
+  nat2 -.lives in.-> pub2
+  priv1 -.uses.-> rtPriv1
+  priv2 -.uses.-> rtPriv2
+```
+
 ```yaml
 platform: aws
 network:
@@ -52,13 +63,38 @@ dns:
   private_domain: corp.example.internal    # optional
 ```
 
-The module provisions a multi-AZ VPC with public and private subnets,
-an Internet Gateway, and per-AZ NAT Gateways for private-subnet
-egress. When `dns.private_domain` is set, it also creates a
-VPC-scoped private Route53 zone so workloads inside the VPC resolve
-internal names.
+The module provisions a multi-AZ VPC. Each AZ has a public and a
+private subnet, with the public subnet routed through the Internet
+Gateway and the private subnet routed through a NAT Gateway that
+lives in the public subnet. When `dns.private_domain` is set, the
+module also creates a VPC-scoped private Route53 zone so workloads
+inside the VPC resolve internal names. The module also enables VPC
+flow logs (delivered to CloudWatch under a KMS key) for audit.
 
 ### Azure VNet
+
+```mermaid
+flowchart LR
+  internet((Internet))
+
+  subgraph rg[Resource group]
+    subgraph vnet[VNet network.cidr_block]
+      pub[Public subnet]
+      priv[Private subnet]
+      iso[Isolated subnet]
+    end
+
+    natGw[NAT Gateway]
+    natIp[Public IP for NAT]
+    rtPriv[Route table<br/>0.0.0.0/0 → NAT]
+    pdns[Private DNS zone<br/>linked to VNet]
+  end
+
+  internet <--> natIp
+  natIp -.attached to.-> natGw
+  natGw -.attached to.-> priv
+  priv -.uses.-> rtPriv
+```
 
 ```yaml
 platform: azure
@@ -66,8 +102,11 @@ network:
   cidr_block: 10.30.0.0/16
 ```
 
-The module provisions a VNet with private subnets carved from
-`cidr_block`. Subnet sizing matters more here than on AWS, because
+The module provisions a resource group, a VNet with three subnets
+(public, private, isolated), and a NAT Gateway with a dedicated
+public IP. The NAT Gateway is associated with the private subnet so
+egress goes through it. A private DNS zone is linked to the VNet so
+internal names resolve inside it. Subnet sizing matters here because
 AKS with Azure CNI pulls Pod IPs straight from the VNet (each Pod
 consumes one VNet IP). Undersized subnets exhaust quickly. The
 default `/16` accommodates production-scale clusters; smaller blocks
@@ -113,7 +152,8 @@ VPC private subnets have no public IPs and no inbound routes from the
 Internet. Egress flows through NAT Gateways (one per AZ for HA).
 
 The AWS VPC module creates a private Route53 zone, and the records in
-that zone are visible only inside the VPC.
+that zone are visible only inside the VPC. VPC flow logs land in
+CloudWatch and are encrypted by a KMS key the module manages.
 
 Azure VNet subnets carry no NSG by default. Security boundaries are
 enforced by AKS network policies and the cluster's CNI rather than at

--- a/terraform/network/README.md
+++ b/terraform/network/README.md
@@ -5,12 +5,14 @@ description: Cloud network fabric for managed Kubernetes clusters.
 
 # Network
 
-Two drivers build the cloud-side network fabric: `aws-vpc` (VPC, subnets,
-NAT, IGW) and `azure-vnet` (VNet, subnets). Selection is by `platform`.
-Local platforms (`docker`, `hyperv`, `incus`, `metal`) do not use this
-layer — their compute driver creates networking directly on the host
-(bridges, NAT, NodePort forwards). The shared `network.cidr_block` schema
-field drives both paths.
+The network category has two drivers. `aws-vpc` builds a VPC with
+public and private subnets, an Internet Gateway, and per-AZ NAT
+Gateways. `azure-vnet` builds a VNet with private subnets. The driver
+is selected by `platform`. Local platforms (`docker`, `hyperv`,
+`incus`, and `metal`) don't use this layer; their compute driver
+creates networking directly on the host (bridges, NAT, NodePort
+forwards). The shared `network.cidr_block` schema field is what drives
+both paths.
 
 ## Architecture
 
@@ -38,8 +40,9 @@ flowchart LR
   vnet --> cluster
 ```
 
-The network module runs after `backend` and before `cluster`. Cluster
-modules consume the VPC/VNet IDs and subnet IDs as inputs.
+The network module runs after `backend` and before `cluster`. The
+cluster modules then consume the VPC or VNet IDs and subnet IDs as
+inputs.
 
 ## Recipes
 
@@ -53,10 +56,11 @@ dns:
   private_domain: corp.example.internal    # optional
 ```
 
-Provisions a multi-AZ VPC with public and private subnets, an Internet
-Gateway, and per-AZ NAT Gateways for private-subnet egress. When
-`dns.private_domain` is set, the module also creates a VPC-scoped
-private Route53 zone so workloads inside the VPC resolve internal names.
+The module provisions a multi-AZ VPC with public and private subnets,
+an Internet Gateway, and per-AZ NAT Gateways for private-subnet
+egress. When `dns.private_domain` is set, it also creates a
+VPC-scoped private Route53 zone so workloads inside the VPC resolve
+internal names.
 
 ### Azure VNet
 
@@ -66,13 +70,14 @@ network:
   cidr_block: 10.30.0.0/16
 ```
 
-Provisions a VNet with private subnets carved from `cidr_block`. Subnet
-sizing matters more here than on AWS: when AKS runs Azure CNI each Pod
-consumes one VNet IP, so undersized subnets exhaust quickly. The default
-`/16` accommodates production-scale clusters; smaller blocks are fine
-only for fixed-size clusters with known pod counts.
+The module provisions a VNet with private subnets carved from
+`cidr_block`. Subnet sizing matters more here than on AWS, because
+AKS with Azure CNI pulls Pod IPs straight from the VNet (each Pod
+consumes one VNet IP). Undersized subnets exhaust quickly. The
+default `/16` accommodates production-scale clusters; smaller blocks
+are only fine for fixed-size clusters with known pod counts.
 
-### Local (no terraform/network/ module)
+### Local (no terraform/network module)
 
 ```yaml
 platform: hyperv    # or docker, incus, metal
@@ -80,41 +85,47 @@ network:
   cidr_block: 10.5.0.0/16
 ```
 
-No terraform module runs. The compute driver creates the host-local
-network (Hyper-V NetNat, Incus bridge, Docker bridge). `cidr_block` is
-still authoritative — node IPs, the cluster API endpoint, and the load
-balancer IP pool all derive from it.
+No terraform module runs here. The compute driver creates the
+host-local network (Hyper-V NetNat, Incus bridge, Docker bridge).
+`cidr_block` is still authoritative though, since node IPs, the
+cluster API endpoint, and the load balancer IP pool all derive from
+it.
 
 ## Operations
 
-- **CIDR conflicts with existing routes** — the default `10.5.0.0/16`
-  collides with corporate VPNs in some environments. Pick an unused
-  /16 in private space before the first apply; changing it later
-  requires destroying compute and re-provisioning.
-- **AKS pod IP exhaustion** — Azure CNI pulls Pod IPs from the VNet,
-  not from an overlay. If `cidr_block` is too small for the max pods
-  per node times the node count, AKS Pods stay Pending with no
-  obvious error. Size the VNet for peak pod density.
-- **`dns.private_domain` unset on AWS** — no private Route53 zone is
-  created. In-VPC workloads only resolve via public DNS or VPC DNS
-  (no operator-defined internal names).
-- **AZ count mismatch on AWS** — `azs`, `public_subnets`, and
-  `private_subnets` are positional: entry `i` of each list describes
-  one AZ. Length mismatch is an error at plan time.
+The default `network.cidr_block` of `10.5.0.0/16` collides with
+corporate VPNs in some environments. Pick an unused /16 in private
+space before the first apply, because changing it later requires
+destroying compute and re-provisioning.
+
+AKS pod IP exhaustion is a quiet failure mode. Azure CNI pulls Pod
+IPs from the VNet rather than from an overlay. If `cidr_block` is too
+small for the max pods per node times the node count, AKS Pods stay
+Pending with no obvious error. Size the VNet for peak pod density.
+
+If `dns.private_domain` is unset on AWS, no private Route53 zone is
+created. In-VPC workloads then only resolve via public DNS or VPC
+DNS, so any operator-defined internal names won't work.
+
+The AWS VPC module's `azs`, `public_subnets`, and `private_subnets`
+lists are positional. Entry `i` of each list describes the same AZ. A
+length mismatch is an error at plan time.
 
 ## Security
 
-- VPC private subnets have no public IPs and no inbound routes from the
-  Internet. Egress flows through NAT Gateways (one per AZ for HA).
-- The AWS VPC module creates a private Route53 zone; record contents
-  are visible only inside the VPC.
-- Azure VNet subnets carry no NSG by default — security boundaries are
-  enforced by AKS network policies and the cluster's CNI, not at the
-  subnet layer.
+VPC private subnets have no public IPs and no inbound routes from the
+Internet. Egress flows through NAT Gateways (one per AZ for HA).
+
+The AWS VPC module creates a private Route53 zone, and the records in
+that zone are visible only inside the VPC.
+
+Azure VNet subnets carry no NSG by default. Security boundaries are
+enforced by AKS network policies and the cluster's CNI rather than at
+the subnet layer.
 
 ## See also
 
-- [aws-vpc/](aws-vpc/), [azure-vnet/](azure-vnet/) — per-driver Terraform reference.
-- [../cluster/](../cluster/) — managed-cluster modules that consume the network.
-- [../dns/](../dns/) — public DNS zones (separate from the private zone inside the VPC module).
-- [../compute/](../compute/) — local compute drivers that create their own host networking.
+- [aws-vpc/](aws-vpc/) and [azure-vnet/](azure-vnet/) for the per-driver Terraform reference.
+- [../cluster/](../cluster/) for the managed-cluster modules that consume the network.
+- [../dns/](../dns/) for the public DNS zones (the private zone inside the VPC module is separate).
+- [../compute/](../compute/) for the local compute drivers that create their own host networking.

--- a/terraform/network/README.md
+++ b/terraform/network/README.md
@@ -1,0 +1,120 @@
+---
+title: Network
+description: Cloud network fabric for managed Kubernetes clusters.
+---
+
+# Network
+
+Two drivers build the cloud-side network fabric: `aws-vpc` (VPC, subnets,
+NAT, IGW) and `azure-vnet` (VNet, subnets). Selection is by `platform`.
+Local platforms (`docker`, `hyperv`, `incus`, `metal`) do not use this
+layer — their compute driver creates networking directly on the host
+(bridges, NAT, NodePort forwards). The shared `network.cidr_block` schema
+field drives both paths.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  schema[schema.yaml<br/>network.cidr_block]
+
+  subgraph awspath[AWS]
+    tfVpc[terraform/network/aws-vpc]
+    vpc[VPC + subnets + NAT]
+  end
+
+  subgraph azurepath[Azure]
+    tfVnet[terraform/network/azure-vnet]
+    vnet[VNet + subnets]
+  end
+
+  cluster[terraform/cluster/aws-eks<br/>terraform/cluster/azure-aks]
+
+  schema -->|aws| tfVpc
+  schema -->|azure| tfVnet
+  tfVpc --> vpc
+  tfVnet --> vnet
+  vpc --> cluster
+  vnet --> cluster
+```
+
+The network module runs after `backend` and before `cluster`. Cluster
+modules consume the VPC/VNet IDs and subnet IDs as inputs.
+
+## Recipes
+
+### AWS VPC
+
+```yaml
+platform: aws
+network:
+  cidr_block: 10.20.0.0/16    # default 10.5.0.0/16
+dns:
+  private_domain: corp.example.internal    # optional
+```
+
+Provisions a multi-AZ VPC with public and private subnets, an Internet
+Gateway, and per-AZ NAT Gateways for private-subnet egress. When
+`dns.private_domain` is set, the module also creates a VPC-scoped
+private Route53 zone so workloads inside the VPC resolve internal names.
+
+### Azure VNet
+
+```yaml
+platform: azure
+network:
+  cidr_block: 10.30.0.0/16
+```
+
+Provisions a VNet with private subnets carved from `cidr_block`. Subnet
+sizing matters more here than on AWS: when AKS runs Azure CNI each Pod
+consumes one VNet IP, so undersized subnets exhaust quickly. The default
+`/16` accommodates production-scale clusters; smaller blocks are fine
+only for fixed-size clusters with known pod counts.
+
+### Local (no terraform/network/ module)
+
+```yaml
+platform: hyperv    # or docker, incus, metal
+network:
+  cidr_block: 10.5.0.0/16
+```
+
+No terraform module runs. The compute driver creates the host-local
+network (Hyper-V NetNat, Incus bridge, Docker bridge). `cidr_block` is
+still authoritative — node IPs, the cluster API endpoint, and the load
+balancer IP pool all derive from it.
+
+## Operations
+
+- **CIDR conflicts with existing routes** — the default `10.5.0.0/16`
+  collides with corporate VPNs in some environments. Pick an unused
+  /16 in private space before the first apply; changing it later
+  requires destroying compute and re-provisioning.
+- **AKS pod IP exhaustion** — Azure CNI pulls Pod IPs from the VNet,
+  not from an overlay. If `cidr_block` is too small for the max pods
+  per node times the node count, AKS Pods stay Pending with no
+  obvious error. Size the VNet for peak pod density.
+- **`dns.private_domain` unset on AWS** — no private Route53 zone is
+  created. In-VPC workloads only resolve via public DNS or VPC DNS
+  (no operator-defined internal names).
+- **AZ count mismatch on AWS** — `azs`, `public_subnets`, and
+  `private_subnets` are positional: entry `i` of each list describes
+  one AZ. Length mismatch is an error at plan time.
+
+## Security
+
+- VPC private subnets have no public IPs and no inbound routes from the
+  Internet. Egress flows through NAT Gateways (one per AZ for HA).
+- The AWS VPC module creates a private Route53 zone; record contents
+  are visible only inside the VPC.
+- Azure VNet subnets carry no NSG by default — security boundaries are
+  enforced by AKS network policies and the cluster's CNI, not at the
+  subnet layer.
+
+## See also
+
+- [aws-vpc/](aws-vpc/), [azure-vnet/](azure-vnet/) — per-driver Terraform reference.
+- [../cluster/](../cluster/) — managed-cluster modules that consume the network.
+- [../dns/](../dns/) — public DNS zones (separate from the private zone inside the VPC module).
+- [../compute/](../compute/) — local compute drivers that create their own host networking.

--- a/terraform/network/README.md
+++ b/terraform/network/README.md
@@ -18,7 +18,7 @@ both paths.
 
 ```mermaid
 flowchart LR
-  schema[schema.yaml<br/>network.cidr_block]
+  values[values.yaml<br/>network.cidr_block]
 
   subgraph awspath[AWS]
     tfVpc[terraform/network/aws-vpc]
@@ -32,8 +32,8 @@ flowchart LR
 
   cluster[terraform/cluster/aws-eks<br/>terraform/cluster/azure-aks]
 
-  schema -->|aws| tfVpc
-  schema -->|azure| tfVnet
+  values -->|aws| tfVpc
+  values -->|azure| tfVnet
   tfVpc --> vpc
   tfVnet --> vnet
   vpc --> cluster

--- a/terraform/workstation/README.md
+++ b/terraform/workstation/README.md
@@ -5,14 +5,16 @@ description: Local-host networking, registry, and DNS for developer clusters.
 
 # Workstation
 
-Two drivers provision the host-side substrate for local clusters:
-`docker` (Docker network + optional local OCI registry) and `incus`
-(LXC bridge + optional registry). Selection follows `platform`; the
-workstation pass runs **before** `compute` so compute drivers can attach
-nodes to a network the workstation already created.
+The workstation category has two drivers that provision the host-side
+substrate for local clusters. `docker` creates a Docker network and
+an optional local OCI registry. `incus` creates an LXC bridge and an
+optional registry. The driver is selected by `platform`. The
+workstation pass runs before `compute`, so the compute drivers have a
+network to attach Talos nodes to.
 
-`workstation.runtime` is the switch that turns the workstation stack on.
-With it unset, no workstation module runs even on a local platform.
+`workstation.runtime` is the switch that turns the workstation stack
+on. With it unset, no workstation module runs even on a local
+platform.
 
 ## Architecture
 
@@ -40,14 +42,14 @@ flowchart LR
   incusBr --> compute
 ```
 
-Hyper-V, bare metal (`platform: metal`), and managed clouds do not use
+Hyper-V, bare metal (`platform: metal`), and managed clouds don't use
 the workstation layer. Hyper-V manages its NetNat inside the compute
-module; `metal` expects an existing network; AWS / Azure have no local
-workstation concept.
+module, `metal` expects an existing network, and AWS and Azure have
+no local workstation concept.
 
 ## Recipes
 
-### Docker (macOS / Linux dev)
+### Docker (macOS or Linux dev)
 
 ```yaml
 platform: docker
@@ -56,60 +58,68 @@ workstation:
   arch: arm64                # match host architecture
 ```
 
-Provisions a Docker bridge network sized from `network.cidr_block` and
-optionally a local registry that the `compute/docker` step then attaches
-Talos containers to. `workstation.runtime: colima` is the lighter macOS
-path; plain `docker` is the Linux engine path; `docker-desktop` is the
-Docker Desktop path on macOS or Windows.
+The module provisions a Docker bridge network sized from
+`network.cidr_block` and (optionally) a local registry that the
+`compute/docker` step then attaches Talos containers to.
+`workstation.runtime: colima` is the lighter macOS path, plain
+`docker` is the Linux engine path, and `docker-desktop` is the Docker
+Desktop path on macOS or Windows.
 
 ### Incus (Linux host)
 
 ```yaml
 platform: incus
 workstation:
-  runtime: colima            # or docker, docker-desktop — registry runtime only
+  runtime: colima            # or docker, docker-desktop; registry runtime only
   arch: amd64
 ```
 
-Provisions an Incus LXC bridge and (optionally) a local registry. The
-registry is delivered via the runtime mentioned in `workstation.runtime`,
-which on Incus contexts only controls where the registry container
-lives — not the cluster VM host (those are always Incus instances).
+The module provisions an Incus LXC bridge and (optionally) a local
+registry. The registry is delivered through the runtime named in
+`workstation.runtime`, which on Incus contexts only controls where
+the registry container lives, not the cluster VM host. The cluster
+VMs are always Incus instances.
 
 ## Operations
 
-- **`workstation.runtime` unset on a local platform** — no workstation
-  module runs, no host-local network exists, and `compute` will fail
-  to attach Talos nodes. The fix is to set `workstation.runtime` to a
-  value that matches the host's container runtime.
-- **Network CIDR conflicts with the host LAN** — `network.cidr_block`
-  defaults to `10.5.0.0/16`. If the developer's home or corp network
-  uses this range, the workstation bridge will route incorrectly. Pick
-  a different /16 in private space before the first apply.
-- **Local registry pulls fail from inside the cluster** — the
-  workstation provisions registry instances by hostname and a CoreDNS
-  that resolves them. Pulls failing with DNS errors usually mean the
-  cluster nodes can't reach `workstation.dns.address`. Pulls failing
-  with HTTP errors usually mean the registry containers aren't running.
-- **Workstation destroyed but cluster still running** — destroying the
-  workstation tears down the network the compute module attached to.
-  Always `windsor destroy --force` from the top to tear down compute
-  first, then workstation, then backend.
+When `workstation.runtime` is unset on a local platform, no
+workstation module runs and there's no host-local network for compute
+to attach to. The fix is to set `workstation.runtime` to a value that
+matches the host's container runtime.
+
+A `network.cidr_block` conflict with the host LAN is a common
+first-time issue. The default is `10.5.0.0/16`. If the developer's
+home or corporate network uses that range, the workstation bridge
+will route incorrectly. Pick a different /16 in private space before
+the first apply.
+
+If local registry pulls fail from inside the cluster, the workstation
+provisions registry instances by hostname and a CoreDNS that resolves
+them. Pulls failing with DNS errors usually mean the cluster nodes
+can't reach `workstation.dns.address`. Pulls failing with HTTP errors
+usually mean the registry containers aren't running.
+
+Destroying the workstation while the cluster is still running tears
+down the network that compute attached to. Always run
+`windsor destroy --force` from the top so the layers come down in
+order (compute first, then workstation, then backend).
 
 ## Security
 
-- The Docker driver uses the host Docker socket and runs containers
-  with bridge-network privileges. This is root-equivalent on the host
-  and inappropriate for shared developer machines.
-- The local registry runs without authentication. Workloads pull
-  through the cluster's containerd mirror, but the registry endpoint
-  is reachable from any process on the host that knows the address.
-- Incus VMs run as full KVM instances; the bridge does not isolate
-  hosts on the LAN from the VMs unless host firewall rules are added
-  explicitly.
+The Docker driver uses the host Docker socket and runs containers
+with bridge-network privileges. That's root-equivalent on the host
+and inappropriate for shared developer machines.
+
+The local registry runs without authentication. Workloads pull
+through the cluster's containerd mirror, but the registry endpoint
+itself is reachable from any process on the host that knows the
+address.
+
+Incus VMs run as full KVM instances. The bridge doesn't isolate the
+LAN from the VMs unless the host firewall rules are added explicitly.
 
 ## See also
 
-- [docker/](docker/), [incus/](incus/) — per-driver Terraform reference.
-- [../compute/](../compute/) — compute drivers that attach to the workstation network.
-- [../network/](../network/) — `network.cidr_block` derivation for both layers.
+- [docker/](docker/) and [incus/](incus/) for the per-driver Terraform reference.
+- [../compute/](../compute/) for the compute drivers that attach to the workstation network.
+- [../network/](../network/) for `network.cidr_block`, which is the shared knob for both layers.

--- a/terraform/workstation/README.md
+++ b/terraform/workstation/README.md
@@ -1,0 +1,115 @@
+---
+title: Workstation
+description: Local-host networking, registry, and DNS for developer clusters.
+---
+
+# Workstation
+
+Two drivers provision the host-side substrate for local clusters:
+`docker` (Docker network + optional local OCI registry) and `incus`
+(LXC bridge + optional registry). Selection follows `platform`; the
+workstation pass runs **before** `compute` so compute drivers can attach
+nodes to a network the workstation already created.
+
+`workstation.runtime` is the switch that turns the workstation stack on.
+With it unset, no workstation module runs even on a local platform.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  schema[schema.yaml<br/>platform + workstation.runtime]
+
+  subgraph dockerpath[Docker]
+    tfDocker[terraform/workstation/docker]
+    dockerNet[Docker network<br/>+ registry]
+  end
+
+  subgraph incuspath[Incus]
+    tfIncus[terraform/workstation/incus]
+    incusBr[LXC bridge<br/>+ registry]
+  end
+
+  compute[terraform/compute/*]
+
+  schema -->|docker| tfDocker
+  schema -->|incus| tfIncus
+  tfDocker --> dockerNet
+  tfIncus --> incusBr
+  dockerNet --> compute
+  incusBr --> compute
+```
+
+Hyper-V, bare metal (`platform: metal`), and managed clouds do not use
+the workstation layer. Hyper-V manages its NetNat inside the compute
+module; `metal` expects an existing network; AWS / Azure have no local
+workstation concept.
+
+## Recipes
+
+### Docker (macOS / Linux dev)
+
+```yaml
+platform: docker
+workstation:
+  runtime: docker-desktop    # or colima, docker
+  arch: arm64                # match host architecture
+```
+
+Provisions a Docker bridge network sized from `network.cidr_block` and
+optionally a local registry that the `compute/docker` step then attaches
+Talos containers to. `workstation.runtime: colima` is the lighter macOS
+path; plain `docker` is the Linux engine path; `docker-desktop` is the
+Docker Desktop path on macOS or Windows.
+
+### Incus (Linux host)
+
+```yaml
+platform: incus
+workstation:
+  runtime: colima            # or docker, docker-desktop — registry runtime only
+  arch: amd64
+```
+
+Provisions an Incus LXC bridge and (optionally) a local registry. The
+registry is delivered via the runtime mentioned in `workstation.runtime`,
+which on Incus contexts only controls where the registry container
+lives — not the cluster VM host (those are always Incus instances).
+
+## Operations
+
+- **`workstation.runtime` unset on a local platform** — no workstation
+  module runs, no host-local network exists, and `compute` will fail
+  to attach Talos nodes. The fix is to set `workstation.runtime` to a
+  value that matches the host's container runtime.
+- **Network CIDR conflicts with the host LAN** — `network.cidr_block`
+  defaults to `10.5.0.0/16`. If the developer's home or corp network
+  uses this range, the workstation bridge will route incorrectly. Pick
+  a different /16 in private space before the first apply.
+- **Local registry pulls fail from inside the cluster** — the
+  workstation provisions registry instances by hostname and a CoreDNS
+  that resolves them. Pulls failing with DNS errors usually mean the
+  cluster nodes can't reach `workstation.dns.address`. Pulls failing
+  with HTTP errors usually mean the registry containers aren't running.
+- **Workstation destroyed but cluster still running** — destroying the
+  workstation tears down the network the compute module attached to.
+  Always `windsor destroy --force` from the top to tear down compute
+  first, then workstation, then backend.
+
+## Security
+
+- The Docker driver uses the host Docker socket and runs containers
+  with bridge-network privileges. This is root-equivalent on the host
+  and inappropriate for shared developer machines.
+- The local registry runs without authentication. Workloads pull
+  through the cluster's containerd mirror, but the registry endpoint
+  is reachable from any process on the host that knows the address.
+- Incus VMs run as full KVM instances; the bridge does not isolate
+  hosts on the LAN from the VMs unless host firewall rules are added
+  explicitly.
+
+## See also
+
+- [docker/](docker/), [incus/](incus/) — per-driver Terraform reference.
+- [../compute/](../compute/) — compute drivers that attach to the workstation network.
+- [../network/](../network/) — `network.cidr_block` derivation for both layers.

--- a/terraform/workstation/README.md
+++ b/terraform/workstation/README.md
@@ -26,14 +26,12 @@ network, and AWS / Azure have no local workstation concept.
 
 ```mermaid
 flowchart LR
-  subgraph host[Docker host<br/>docker-desktop / colima / linux]
-    subgraph net[Docker bridge<br/>network.cidr_block]
-      dns[CoreDNS<br/>workstation.dns.address]
-      reg1[Registry: gcr-io]
-      reg2[Registry: ghcr-io]
-      reg3[Registry: registry-k8s-io]
-      regN[Registry: ...]
-    end
+  subgraph host[Docker host on Docker bridge network.cidr_block]
+    dns[CoreDNS<br/>workstation.dns.address]
+    reg1[Registry: gcr-io]
+    reg2[Registry: ghcr-io]
+    reg3[Registry: registry-k8s-io]
+    regN[Registry: ...]
   end
 ```
 
@@ -55,13 +53,11 @@ is the Docker Desktop path on macOS or Windows.
 
 ```mermaid
 flowchart LR
-  subgraph host[Linux host]
-    subgraph bridge[LXC bridge]
-      dns[CoreDNS]
-      reg1[Registry: gcr-io]
-      reg2[Registry: ghcr-io]
-      regN[Registry: ...]
-    end
+  subgraph host[Linux host on LXC bridge]
+    dns[CoreDNS]
+    reg1[Registry: gcr-io]
+    reg2[Registry: ghcr-io]
+    regN[Registry: ...]
   end
 ```
 

--- a/terraform/workstation/README.md
+++ b/terraform/workstation/README.md
@@ -6,46 +6,36 @@ description: Local-host networking, registry, and DNS for developer clusters.
 # Workstation
 
 The workstation category has two drivers that provision the host-side
-substrate for local clusters. `docker` creates a Docker network and
-an optional local OCI registry. `incus` creates an LXC bridge and an
-optional registry. The driver is selected by `platform`. The
-workstation pass runs before `compute`, so the compute drivers have a
-network to attach Talos nodes to.
+substrate for local clusters. `docker` creates a Docker network with
+a CoreDNS resolver and a set of local OCI registry containers.
+`incus` creates an LXC bridge with the same companions. The driver
+is selected by `platform`. The workstation pass runs before
+`compute`, so the compute drivers have a network to attach Talos
+nodes to.
 
 `workstation.runtime` is the switch that turns the workstation stack
 on. With it unset, no workstation module runs even on a local
-platform.
-
-## Architecture
-
-```mermaid
-flowchart LR
-  values[values.yaml<br/>platform + workstation.runtime]
-
-  subgraph dockerpath[Docker]
-    tfDocker[terraform/workstation/docker]
-    dockerNet[Docker network<br/>+ registry]
-  end
-
-  subgraph incuspath[Incus]
-    tfIncus[terraform/workstation/incus]
-    incusBr[LXC bridge<br/>+ registry]
-  end
-
-  values -->|docker| tfDocker
-  values -->|incus| tfIncus
-  tfDocker --> dockerNet
-  tfIncus --> incusBr
-```
-
-Hyper-V, bare metal (`platform: metal`), and managed clouds don't use
-the workstation layer. Hyper-V manages its NetNat inside the compute
-module, `metal` expects an existing network, and AWS and Azure have
-no local workstation concept.
+platform. Hyper-V, bare metal (`platform: metal`), and managed
+clouds don't use the workstation layer either: Hyper-V manages its
+NetNat inside the compute module, `metal` expects an existing
+network, and AWS / Azure have no local workstation concept.
 
 ## Recipes
 
 ### Docker (macOS or Linux dev)
+
+```mermaid
+flowchart LR
+  subgraph host[Docker host<br/>docker-desktop / colima / linux]
+    subgraph net[Docker bridge<br/>network.cidr_block]
+      dns[CoreDNS<br/>workstation.dns.address]
+      reg1[Registry: gcr-io]
+      reg2[Registry: ghcr-io]
+      reg3[Registry: registry-k8s-io]
+      regN[Registry: ...]
+    end
+  end
+```
 
 ```yaml
 platform: docker
@@ -55,13 +45,25 @@ workstation:
 ```
 
 The module provisions a Docker bridge network sized from
-`network.cidr_block` and (optionally) a local registry that the
-`compute/docker` step then attaches Talos containers to.
-`workstation.runtime: colima` is the lighter macOS path, plain
-`docker` is the Linux engine path, and `docker-desktop` is the Docker
-Desktop path on macOS or Windows.
+`network.cidr_block`, a CoreDNS container that resolves the local
+registry hostnames, and one container per upstream registry the
+context mirrors. `workstation.runtime: colima` is the lighter macOS
+path, plain `docker` is the Linux engine path, and `docker-desktop`
+is the Docker Desktop path on macOS or Windows.
 
 ### Incus (Linux host)
+
+```mermaid
+flowchart LR
+  subgraph host[Linux host]
+    subgraph bridge[LXC bridge]
+      dns[CoreDNS]
+      reg1[Registry: gcr-io]
+      reg2[Registry: ghcr-io]
+      regN[Registry: ...]
+    end
+  end
+```
 
 ```yaml
 platform: incus
@@ -70,11 +72,11 @@ workstation:
   arch: amd64
 ```
 
-The module provisions an Incus LXC bridge and (optionally) a local
-registry. The registry is delivered through the runtime named in
-`workstation.runtime`, which on Incus contexts only controls where
-the registry container lives, not the cluster VM host. The cluster
-VMs are always Incus instances.
+The module provisions an Incus LXC bridge and the same CoreDNS plus
+registry containers. The registry container runtime is whatever
+`workstation.runtime` names; on Incus contexts that selector controls
+where the registry containers live, not the cluster VM host. The
+cluster VMs are always Incus instances.
 
 ## Operations
 

--- a/terraform/workstation/README.md
+++ b/terraform/workstation/README.md
@@ -20,7 +20,7 @@ platform.
 
 ```mermaid
 flowchart LR
-  schema[schema.yaml<br/>platform + workstation.runtime]
+  values[values.yaml<br/>platform + workstation.runtime]
 
   subgraph dockerpath[Docker]
     tfDocker[terraform/workstation/docker]
@@ -34,8 +34,8 @@ flowchart LR
 
   compute[terraform/compute/*]
 
-  schema -->|docker| tfDocker
-  schema -->|incus| tfIncus
+  values -->|docker| tfDocker
+  values -->|incus| tfIncus
   tfDocker --> dockerNet
   tfIncus --> incusBr
   dockerNet --> compute

--- a/terraform/workstation/README.md
+++ b/terraform/workstation/README.md
@@ -32,14 +32,10 @@ flowchart LR
     incusBr[LXC bridge<br/>+ registry]
   end
 
-  compute[terraform/compute/*]
-
   values -->|docker| tfDocker
   values -->|incus| tfIncus
   tfDocker --> dockerNet
   tfIncus --> incusBr
-  dockerNet --> compute
-  incusBr --> compute
 ```
 
 Hyper-V, bare metal (`platform: metal`), and managed clouds don't use


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> Pure documentation — no code, configuration, or behavior changes.
>
> **Overview**
>
> Introduces category-level READMEs for eight Terraform module groups, each following a consistent shape: prose overview, Mermaid architecture diagram, YAML recipe examples, an Operations section covering common failure modes, and a Security section with per-driver notes. The root `terraform/README.md` index gains parent-level rows alongside the existing leaf-module entries.
>
> Two medium-severity findings are worth verifying before the docs ship. `backend/README.md` describes `type: none` as writing to an in-memory location, but Terraform's actual default when no backend is configured is a local file backend. `cluster/README.md` calls Cilium the "in-box CNI" for AKS, when Azure CNI is the Azure default; if the Windsor AKS module configures Cilium explicitly, the docs should say so.
>
> Reviewed by Claude for commit `e0c9add`.

<!-- /claude-code-review:summary -->
