### PR TITLE
fix(facets): gate eager dns-zone terraform_output on public_domain

### DIFF
--- a/contexts/_template/facets/platform-aws.yaml
+++ b/contexts/_template/facets/platform-aws.yaml
@@ -104,7 +104,7 @@ terraform:
       private_subnet_ids: ${terraform_output('network', 'private_subnet_ids')}
       manage_log_group: ${!(ephemeral ?? false)}
       create_cert_manager_role: "${(dns.public_domain ?? '') != ''}"
-      cert_manager_hosted_zone_ids: "${(terraform_output('dns-zone', 'zone_id') ?? '') != '' ? [terraform_output('dns-zone', 'zone_id')] : []}"
+      cert_manager_hosted_zone_ids: "${(dns.public_domain ?? '') != '' ? [terraform_output('dns-zone', 'zone_id')] : []}"
       # cluster.pools is the portable node-pool shape (class + count|min/max +
       # lifecycle). When unset, the cluster module falls back to its
       # var.node_groups default — no behavior change for existing configs.
@@ -409,10 +409,11 @@ kustomize:
     timeout: 5m
     interval: 5m
     substitutions:
-      # ACME-only substitutions; harmless when selfsigned is selected
-      # (component doesn't reference them).
+      # ACME-only substitutions; the selfsigned component doesn't reference
+      # them. acme_hosted_zone_id gates its terraform_output on public_domain
+      # because dns-zone isn't registered in private/selfsigned mode.
       acme_server: "${dev == true ? 'https://acme-staging-v02.api.letsencrypt.org/directory' : 'https://acme-v02.api.letsencrypt.org/directory'}"
       acme_email: "${email ?? ''}"
       acme_dns_zone: "${dns.public_domain ?? ''}"
       acme_region: "${aws.region ?? 'us-east-1'}"
-      acme_hosted_zone_id: "${terraform_output('dns-zone', 'zone_id') ?? ''}"
+      acme_hosted_zone_id: "${(dns.public_domain ?? '') != '' ? (terraform_output('dns-zone', 'zone_id') ?? '') : ''}"

--- a/contexts/_template/facets/platform-azure.yaml
+++ b/contexts/_template/facets/platform-azure.yaml
@@ -213,14 +213,13 @@ kustomize:
       acme_email: "${email ?? ''}"
       acme_dns_zone: "${dns.public_domain ?? ''}"
       # Deferred terraform_outputs from the dns-zone and cluster stacks.
-      # terraform_output() returns nil whenever the requested output is
-      # absent — component never composed, output not exported, or
-      # mid-destroy — so ?? '' covers dns.public_domain-unset and
-      # create_cert_manager_identity-not-fired without an outer guard.
-      # Real state-read errors still propagate. Selfsigned-issuer in
-      # private mode doesn't read these; empty values are inert there.
-      acme_dns_zone_resource_group: "${terraform_output('dns-zone', 'resource_group_name') ?? ''}"
-      acme_dns_zone_subscription_id: "${terraform_output('dns-zone', 'subscription_id') ?? ''}"
+      # Gate the dns-zone reads on public_domain: the component isn't
+      # registered in private/selfsigned mode, and referencing an
+      # unregistered component is a hard error (?? '' only defaults an
+      # absent output, not an absent component). Selfsigned in private
+      # mode doesn't read these; empty values are inert there.
+      acme_dns_zone_resource_group: "${(dns.public_domain ?? '') != '' ? (terraform_output('dns-zone', 'resource_group_name') ?? '') : ''}"
+      acme_dns_zone_subscription_id: "${(dns.public_domain ?? '') != '' ? (terraform_output('dns-zone', 'subscription_id') ?? '') : ''}"
       cert_manager_client_id: "${terraform_output('cluster', 'cert_manager_client_id') ?? ''}"
       cert_manager_tenant_id: "${terraform_output('cluster', 'tenant_id') ?? ''}"
 

--- a/contexts/_template/tests/platform-aws.test.yaml
+++ b/contexts/_template/tests/platform-aws.test.yaml
@@ -165,6 +165,10 @@ cases:
             - network
           inputs:
             create_cert_manager_role: "false"
+            # Empty list (not an eager terraform_output('dns-zone', ...) call)
+            # when ACME is off — dns-zone isn't registered, so referencing its
+            # output would hard-error at bootstrap.
+            cert_manager_hosted_zone_ids: []
       kustomize:
         - name: pki-resources
           path: pki/resources

--- a/contexts/_template/tests/platform-azure.test.yaml
+++ b/contexts/_template/tests/platform-azure.test.yaml
@@ -272,10 +272,9 @@ cases:
   # Private mode flips the AKS Standard LB to internal so the gateway only
   # exposes a private subnet IP. Same gating as the AWS aws-nlb internal
   # toggle (requires dns.private_domain, otherwise the rest of the private
-  # cascade no-ops and the gateway runs as public). Also set
-  # dns.public_domain so the public DNS / cert cascade still wires up.
-  # Azure private mode currently relies on the public dns / pki path being
-  # active for downstream wiring.
+  # cascade no-ops and the gateway runs as public). public_domain is also
+  # set here to exercise the public+private overlap; the private-only path
+  # is covered by the case below.
   - name: gateway.access=private flips the Azure LB to internal
     values:
       platform: azure
@@ -296,6 +295,50 @@ cases:
             - envoy/loadbalancer
             - envoy/loadbalancer/azure-lb-internal
             - envoy/prometheus
+
+  # Private-only mode: dns.private_domain set, no public_domain. The dns-zone
+  # stack is never registered, so every dns-zone terraform_output must be
+  # gated on public_domain — referencing an unregistered component is a hard
+  # error. external-dns targets the private zone via the azure-private-dns
+  # provider, and pki-resources falls to the private (selfsigned) issuer.
+  - name: private-only mode targets external-dns at the private Azure DNS zone
+    values:
+      platform: azure
+      gateway:
+        enabled: true
+        driver: envoy
+        access: private
+      dns:
+        private_domain: internal.example.com
+    terraformOutputs:
+      network:
+        private_zone_id: /subscriptions/sub-123/resourceGroups/rg-net/providers/Microsoft.Network/privateDnsZones/internal.example.com
+        subscription_id: sub-123
+        resource_group_name: rg-net
+    expect:
+      kustomize:
+        - name: dns
+          path: dns
+          dependsOn:
+            - policy-resources
+            - gateway-base
+          components:
+            - external-dns
+            - external-dns/providers/azure
+            - external-dns/sources/gateway-httproute
+          substitutions:
+            external_domain: internal.example.com
+            external_dns_azure_provider: azure-private-dns
+            zone_id_filter: /subscriptions/sub-123/resourceGroups/rg-net/providers/Microsoft.Network/privateDnsZones/internal.example.com
+            external_dns_dns_zone_subscription_id: sub-123
+            external_dns_dns_zone_resource_group: rg-net
+        # Private mode falls to the selfsigned issuer; its acme_* dns-zone
+        # substitutions resolve to empty without touching the unregistered
+        # dns-zone component.
+        - name: pki-resources
+          path: pki/resources
+          components:
+            - private-issuer/selfsigned
 
   # Negative branch: Cilium provides its own gateway implementation, so
   # there's no Envoy data-plane Service to annotate. The azure-lb-internal


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> Expression-level fix in template facets, isolated to two platform files and their test counterparts, with new test coverage for the previously untested private-only path.
>
> **Overview**
>
> Fixes a hard evaluation error triggered when `dns.public_domain` is absent and the dns-zone component is therefore unregistered. All `terraform_output('dns-zone', …)` calls across the AWS and Azure platform facets are now gated on `(dns.public_domain ?? '') != ''`, matching the guard to the component's registration condition rather than the output's runtime value. The fix correctly distinguishes between a missing output (nil, handled by `?? ''`) and a missing component (hard error, requiring the outer guard) — the replaced comment in the Azure facet had conflated these two cases.
>
> A new Azure test case exercises private-only mode end-to-end, verifying that external-dns routes to the azure-private-dns provider and pki falls to the selfsigned issuer without touching the unregistered dns-zone component. The AWS test gains an explicit `cert_manager_hosted_zone_ids: []` assertion for the no-public-domain case.
>
> Reviewed by Claude for commit `3016dec`.

<!-- /claude-code-review:summary -->
