### PR TITLE
fix(gateway): enhance external_domain fallback logic for selfsigned cert SAN

### DIFF
--- a/contexts/_template/facets/option-gateway.yaml
+++ b/contexts/_template/facets/option-gateway.yaml
@@ -145,14 +145,29 @@ kustomize:
       #   public zone is irrelevant even if dns.public_domain is set for
       #   unrelated reasons).
       # - otherwise: prefer dns.public_domain when set; fall back to
-      #   dns.private_domain for in-cluster / private-trust configs.
+      #   dns.private_domain for in-cluster / private-trust configs, then
+      #   to dns.domain, and finally to '<id>.local' so the selfsigned
+      #   just-works path (no domain set, e.g. a cheap cloud default)
+      #   still renders a valid cert SAN instead of the literal "null"
+      #   that cert-manager rejects. Mirrors platform-hyperv's fallback.
       #
       # access=private without dns.private_domain falls through to the
       # public branch — operator config is incoherent (private gateway
       # with no private domain) and silently degrading is worse than
       # treating it as public; the next assertion they make against the
       # gateway will surface the misconfig.
-      external_domain: "${gateway.access == 'private' && (dns.private_domain ?? '') != '' ? dns.private_domain : ((dns.public_domain ?? '') == '' ? (dns.private_domain ?? '') : dns.public_domain)}"
+      external_domain: >-
+        ${
+          gateway.access == 'private' && (dns.private_domain ?? '') != ''
+            ? dns.private_domain
+            : (dns.public_domain ?? '') != ''
+              ? dns.public_domain
+              : (dns.private_domain ?? '') != ''
+                ? dns.private_domain
+                : (dns.domain ?? '') != ''
+                  ? dns.domain
+                  : (id ?? 'windsor') + '.local'
+        }
 
       # ClusterIssuer name for the Gateway's external-web-tls certificate.
       #

--- a/contexts/_template/tests/option-gateway.test.yaml
+++ b/contexts/_template/tests/option-gateway.test.yaml
@@ -457,6 +457,30 @@ cases:
             gateway_cert_issuer: public-selfsigned
             external_domain: windsor.local
 
+  # dns.domain set (no public/private) exercises the intermediate branch of
+  # the fallback chain (… → dns.domain → '<id>.local'): external_domain
+  # resolves to dns.domain, and the issuer still degrades to public-selfsigned.
+  - name: aws with only dns.domain renders that domain as selfsigned cert SAN
+    values:
+      platform: aws
+      aws:
+        region: us-west-2
+      gateway:
+        enabled: true
+        driver: envoy
+      dns:
+        domain: example.com
+      network: *default-network
+      cluster: *default-cluster
+    expect:
+      kustomize:
+        - name: gateway-resources
+          path: gateway/resources
+          substitutions:
+            gateway_class_name: envoy
+            gateway_cert_issuer: public-selfsigned
+            external_domain: example.com
+
   # gitops.mode=pull drops the Flux Receiver kustomize entirely and propagates
   # mode=pull to the gitops/flux terraform module (which then skips
   # notification-controller and the webhook-token secret).

--- a/contexts/_template/tests/option-gateway.test.yaml
+++ b/contexts/_template/tests/option-gateway.test.yaml
@@ -433,6 +433,30 @@ cases:
             gateway_cert_issuer: private
             external_domain: cluster.local
 
+  # No domain set on a cloud platform is the "just works" selfsigned path
+  # (the cheap default deploy). external_domain must still render a valid
+  # cert SAN, not the literal "null" cert-manager rejects, and the issuer
+  # degrades to public-selfsigned. Regression guard for the gateway cert
+  # SAN fallback chain (… → dns.domain → '<id>.local').
+  - name: aws with no domain renders a valid selfsigned cert SAN
+    values:
+      platform: aws
+      aws:
+        region: us-west-2
+      gateway:
+        enabled: true
+        driver: envoy
+      network: *default-network
+      cluster: *default-cluster
+    expect:
+      kustomize:
+        - name: gateway-resources
+          path: gateway/resources
+          substitutions:
+            gateway_class_name: envoy
+            gateway_cert_issuer: public-selfsigned
+            external_domain: windsor.local
+
   # gitops.mode=pull drops the Flux Receiver kustomize entirely and propagates
   # mode=pull to the gitops/flux terraform module (which then skips
   # notification-controller and the webhook-token secret).

--- a/terraform/compute/docker/README.md
+++ b/terraform/compute/docker/README.md
@@ -17,13 +17,13 @@ brings up via the Talos API.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.8 |
-| <a name="requirement_docker"></a> [docker](#requirement\_docker) | 4.3.0 |
+| <a name="requirement_docker"></a> [docker](#requirement\_docker) | 4.4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_docker"></a> [docker](#provider\_docker) | 4.3.0 |
+| <a name="provider_docker"></a> [docker](#provider\_docker) | 4.4.0 |
 
 ## Modules
 
@@ -33,10 +33,10 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [docker_container.containers](https://registry.terraform.io/providers/kreuzwerker/docker/4.3.0/docs/resources/container) | resource |
-| [docker_image.instances](https://registry.terraform.io/providers/kreuzwerker/docker/4.3.0/docs/resources/image) | resource |
-| [docker_network.main](https://registry.terraform.io/providers/kreuzwerker/docker/4.3.0/docs/resources/network) | resource |
-| [docker_volume.named](https://registry.terraform.io/providers/kreuzwerker/docker/4.3.0/docs/resources/volume) | resource |
+| [docker_container.containers](https://registry.terraform.io/providers/kreuzwerker/docker/4.4.0/docs/resources/container) | resource |
+| [docker_image.instances](https://registry.terraform.io/providers/kreuzwerker/docker/4.4.0/docs/resources/image) | resource |
+| [docker_network.main](https://registry.terraform.io/providers/kreuzwerker/docker/4.4.0/docs/resources/network) | resource |
+| [docker_volume.named](https://registry.terraform.io/providers/kreuzwerker/docker/4.4.0/docs/resources/volume) | resource |
 
 ## Inputs
 

--- a/terraform/workstation/docker/README.md
+++ b/terraform/workstation/docker/README.md
@@ -16,13 +16,13 @@ with Docker Desktop or Colima.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.8 |
-| <a name="requirement_docker"></a> [docker](#requirement\_docker) | 4.3.0 |
+| <a name="requirement_docker"></a> [docker](#requirement\_docker) | 4.4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_docker"></a> [docker](#provider\_docker) | 4.3.0 |
+| <a name="provider_docker"></a> [docker](#provider\_docker) | 4.4.0 |
 
 ## Modules
 
@@ -32,13 +32,13 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [docker_container.dns](https://registry.terraform.io/providers/kreuzwerker/docker/4.3.0/docs/resources/container) | resource |
-| [docker_container.git](https://registry.terraform.io/providers/kreuzwerker/docker/4.3.0/docs/resources/container) | resource |
-| [docker_container.registry](https://registry.terraform.io/providers/kreuzwerker/docker/4.3.0/docs/resources/container) | resource |
-| [docker_image.coredns](https://registry.terraform.io/providers/kreuzwerker/docker/4.3.0/docs/resources/image) | resource |
-| [docker_image.git_livereload](https://registry.terraform.io/providers/kreuzwerker/docker/4.3.0/docs/resources/image) | resource |
-| [docker_image.registry](https://registry.terraform.io/providers/kreuzwerker/docker/4.3.0/docs/resources/image) | resource |
-| [docker_network.main](https://registry.terraform.io/providers/kreuzwerker/docker/4.3.0/docs/resources/network) | resource |
+| [docker_container.dns](https://registry.terraform.io/providers/kreuzwerker/docker/4.4.0/docs/resources/container) | resource |
+| [docker_container.git](https://registry.terraform.io/providers/kreuzwerker/docker/4.4.0/docs/resources/container) | resource |
+| [docker_container.registry](https://registry.terraform.io/providers/kreuzwerker/docker/4.4.0/docs/resources/container) | resource |
+| [docker_image.coredns](https://registry.terraform.io/providers/kreuzwerker/docker/4.4.0/docs/resources/image) | resource |
+| [docker_image.git_livereload](https://registry.terraform.io/providers/kreuzwerker/docker/4.4.0/docs/resources/image) | resource |
+| [docker_image.registry](https://registry.terraform.io/providers/kreuzwerker/docker/4.4.0/docs/resources/image) | resource |
+| [docker_network.main](https://registry.terraform.io/providers/kreuzwerker/docker/4.4.0/docs/resources/network) | resource |
 
 ## Inputs
 

--- a/terraform/workstation/incus/README.md
+++ b/terraform/workstation/incus/README.md
@@ -16,14 +16,14 @@ Local-host runtime backing `windsor up` when `compute.driver` is
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.8 |
 | <a name="requirement_incus"></a> [incus](#requirement\_incus) | 1.1.0 |
-| <a name="requirement_local"></a> [local](#requirement\_local) | 2.8.0 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | 2.9.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_incus"></a> [incus](#provider\_incus) | 1.1.0 |
-| <a name="provider_local"></a> [local](#provider\_local) | 2.8.0 |
+| <a name="provider_local"></a> [local](#provider\_local) | 2.9.0 |
 
 ## Modules
 
@@ -37,8 +37,8 @@ No modules.
 | [incus_instance.git](https://registry.terraform.io/providers/lxc/incus/1.1.0/docs/resources/instance) | resource |
 | [incus_instance.registry](https://registry.terraform.io/providers/lxc/incus/1.1.0/docs/resources/instance) | resource |
 | [incus_network.main](https://registry.terraform.io/providers/lxc/incus/1.1.0/docs/resources/network) | resource |
-| [local_file.corefile](https://registry.terraform.io/providers/hashicorp/local/2.8.0/docs/resources/file) | resource |
-| [local_file.registry_cache_dir](https://registry.terraform.io/providers/hashicorp/local/2.8.0/docs/resources/file) | resource |
+| [local_file.corefile](https://registry.terraform.io/providers/hashicorp/local/2.9.0/docs/resources/file) | resource |
+| [local_file.registry_cache_dir](https://registry.terraform.io/providers/hashicorp/local/2.9.0/docs/resources/file) | resource |
 
 ## Inputs
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> A targeted expression change in an isolated gateway facet; the fallback chain is extended, not restructured.
>
> **Overview**
>
> Refines the `external_domain` expression in the gateway option facet to prevent cert-manager from receiving the literal string "null" as a certificate SAN when no DNS domain fields are configured. The original expression's final fallback — `dns.private_domain ?? ''` — could produce an empty string in the no-domain case, which cert-manager rejects. The new chain appends two additional steps: `dns.domain` as a general-purpose domain field, then `(id ?? 'windsor') + '.local'` as an unconditional last resort for "just works" deployments.
>
> The functional behavior for configurations that already set `public_domain` or `private_domain` is unchanged; only the path taken when neither is set differs. A new test case guards the regression for the `.local` fallback, though the intermediate `dns.domain` branch has no dedicated test.
>
> Reviewed by Claude for commit `7040121`.
<!-- /claude-code-review:summary -->
