### PR TITLE
chore(facets): Refactor to use fallback ladders

### DIFF
--- a/contexts/_template/facets/option-gateway.yaml
+++ b/contexts/_template/facets/option-gateway.yaml
@@ -31,6 +31,46 @@ config:
     value:
       public_issuer: "${(dns.public_domain ?? '') != '' ? 'public-acme' : 'public-selfsigned'}"
 
+  # gateway_effective.external_domain — cert SAN, resolved as an ordered
+  # fallback (last matching entry wins). Floor is '<id>.local' so the
+  # no-domain selfsigned path still renders a valid SAN, never "null".
+  # Private access pins the private domain even when a public one is set.
+  - name: gateway_effective
+    value:
+      external_domain: "${(id ?? 'windsor') + '.local'}"
+  - name: gateway_effective
+    when: (dns.domain ?? '') != ''
+    value:
+      external_domain: "${dns.domain}"
+  - name: gateway_effective
+    when: (dns.private_domain ?? '') != ''
+    value:
+      external_domain: "${dns.private_domain}"
+  - name: gateway_effective
+    when: (dns.public_domain ?? '') != ''
+    value:
+      external_domain: "${dns.public_domain}"
+  - name: gateway_effective
+    when: gateway.access == 'private' && (dns.private_domain ?? '') != ''
+    value:
+      external_domain: "${dns.private_domain}"
+
+  # gateway_effective.cert_issuer — ClusterIssuer for the gateway TLS cert
+  # (last match wins). Floor is 'private' selfsigned; clouds and any
+  # public_domain get the public issuer; private access forces 'private'
+  # because ACME DNS-01 can't validate a VPC-only zone.
+  - name: gateway_effective
+    value:
+      cert_issuer: private
+  - name: gateway_effective
+    when: platform == 'aws' || platform == 'azure' || (dns.public_domain ?? '') != ''
+    value:
+      cert_issuer: "${cert_effective.public_issuer}"
+  - name: gateway_effective
+    when: gateway.access == 'private' && (dns.private_domain ?? '') != ''
+    value:
+      cert_issuer: private
+
 # =============================================================================
 # Kustomize — Gateway API controller + shared Gateway resource
 # =============================================================================
@@ -139,51 +179,10 @@ kustomize:
     substitutions:
       gateway_class_name: ${gateway.driver}
       gateway_dns_target: "${lb_effective.enabled == true ? network.loadbalancer_ips.start : ''}"
-      # Cert SAN domain.
-      # - access=private (with dns.private_domain set): gateway is reachable
-      #   only inside the VPC, so the cert covers the private domain (the
-      #   public zone is irrelevant even if dns.public_domain is set for
-      #   unrelated reasons).
-      # - otherwise: prefer dns.public_domain when set; fall back to
-      #   dns.private_domain for in-cluster / private-trust configs, then
-      #   to dns.domain, and finally to '<id>.local' so the selfsigned
-      #   just-works path (no domain set, e.g. a cheap cloud default)
-      #   still renders a valid cert SAN instead of the literal "null"
-      #   that cert-manager rejects. Mirrors platform-hyperv's fallback.
-      #
-      # access=private without dns.private_domain falls through to the
-      # public branch — operator config is incoherent (private gateway
-      # with no private domain) and silently degrading is worse than
-      # treating it as public; the next assertion they make against the
-      # gateway will surface the misconfig.
-      external_domain: >-
-        ${
-          gateway.access == 'private' && (dns.private_domain ?? '') != ''
-            ? dns.private_domain
-            : (dns.public_domain ?? '') != ''
-              ? dns.public_domain
-              : (dns.private_domain ?? '') != ''
-                ? dns.private_domain
-                : (dns.domain ?? '') != ''
-                  ? dns.domain
-                  : (id ?? 'windsor') + '.local'
-        }
-
-      # ClusterIssuer name for the Gateway's external-web-tls certificate.
-      #
-      #   private mode (gateway.access=private + dns.private_domain set)
-      #     → 'private': ACME DNS-01 can't validate against a VPC-only zone,
-      #     so fall back to private selfsigned until an operator wires a
-      #     private CA.
-      #   AWS or Azure, or any platform with dns.public_domain set
-      #     → cert_effective.public_issuer (resolves to 'public-acme' or
-      #     'public-selfsigned'). Both cloud facets always render
-      #     public-issuer/* via pki-resources, so the public branch is
-      #     always available.
-      #   anything else → 'private': no public ClusterIssuer is deployed
-      #     on those platforms, so falling back to private selfsigned is
-      #     the only safe option.
-      gateway_cert_issuer: "${gateway.access == 'private' && (dns.private_domain ?? '') != '' ? 'private' : (platform == 'aws' || platform == 'azure' || (dns.public_domain ?? '') != '' ? cert_effective.public_issuer : 'private')}"
+      # Cert SAN domain and TLS ClusterIssuer — both resolved as ordered
+      # fallback ladders in the config section above.
+      external_domain: "${gateway_effective.external_domain}"
+      gateway_cert_issuer: "${gateway_effective.cert_issuer}"
       # Only emitted when a consumer is active: the lb-address patch (in-cluster
       # LB) or the cilium gateway component. NodePort/cloud-managed-LB paths
       # have no consumer, so leave it empty and the harness drops it.

--- a/contexts/_template/facets/option-gateway.yaml
+++ b/contexts/_template/facets/option-gateway.yaml
@@ -57,8 +57,9 @@ config:
 
   # gateway_effective.cert_issuer — ClusterIssuer for the gateway TLS cert
   # (last match wins). Floor is 'private' selfsigned; clouds and any
-  # public_domain get the public issuer; private access forces 'private'
-  # because ACME DNS-01 can't validate a VPC-only zone.
+  # public_domain get the public issuer; private access with a private
+  # domain forces 'private' because ACME DNS-01 can't validate a VPC-only
+  # zone.
   - name: gateway_effective
     value:
       cert_issuer: private

--- a/contexts/_template/facets/platform-aws.yaml
+++ b/contexts/_template/facets/platform-aws.yaml
@@ -30,6 +30,29 @@ requires:
     message: Public DNS requires an operator email for TLS certificate registration.
 
 # =============================================================================
+# Config
+# =============================================================================
+#
+config:
+
+  # pki_effective.issuer_component — public ClusterIssuer variant rendered by
+  # pki-resources, resolved as an ordered selection (last match wins):
+  # selfsigned floor → ACME (route53) when a public domain is set → private
+  # selfsigned when access is private (creates the `private` ClusterIssuer the
+  # gateway cert references; the public path only ever creates `public`).
+  - name: pki_effective
+    value:
+      issuer_component: public-issuer/selfsigned
+  - name: pki_effective
+    when: (dns.public_domain ?? '') != ''
+    value:
+      issuer_component: public-issuer/acme/route53
+  - name: pki_effective
+    when: gateway.access == 'private' && (dns.private_domain ?? '') != ''
+    value:
+      issuer_component: private-issuer/selfsigned
+
+# =============================================================================
 # Terraform — S3 state backend, VPC, EKS, optional Cilium bootstrap
 # =============================================================================
 #
@@ -399,13 +422,8 @@ kustomize:
     # bootstrap because the dns-zone component isn't registered until
     # composition completes.)
     components:
-      # Private mode (gateway.access=private + dns.private_domain set) needs
-      # a ClusterIssuer named `private` for the gateway cert to reference —
-      # private-issuer/selfsigned creates exactly that. The public path (the
-      # original two branches) only ever produces a `public` ClusterIssuer,
-      # so without this branch the cert would reference a non-existent
-      # issuer in private mode.
-      - "${gateway.access == 'private' && (dns.private_domain ?? '') != '' ? 'private-issuer/selfsigned' : ((dns.public_domain ?? '') != '' ? 'public-issuer/acme/route53' : 'public-issuer/selfsigned')}"
+      # Issuer variant resolved in the config section above.
+      - "${pki_effective.issuer_component}"
     timeout: 5m
     interval: 5m
     substitutions:

--- a/contexts/_template/facets/platform-azure.yaml
+++ b/contexts/_template/facets/platform-azure.yaml
@@ -35,6 +35,23 @@ config:
     value:
       metrics_server_enabled: false
 
+  # pki_effective.issuer_component — public ClusterIssuer variant rendered by
+  # pki-resources, resolved as an ordered selection (last match wins):
+  # selfsigned floor → ACME (azuredns) when a public domain is set → private
+  # selfsigned when access is private (creates the `private` ClusterIssuer the
+  # gateway cert references; the public path only ever creates `public`).
+  - name: pki_effective
+    value:
+      issuer_component: public-issuer/selfsigned
+  - name: pki_effective
+    when: (dns.public_domain ?? '') != ''
+    value:
+      issuer_component: public-issuer/acme/azuredns
+  - name: pki_effective
+    when: gateway.access == 'private' && (dns.private_domain ?? '') != ''
+    value:
+      issuer_component: private-issuer/selfsigned
+
 # =============================================================================
 # Terraform — AzureRM state backend, VNet, AKS, optional public DNS zone
 # =============================================================================
@@ -205,7 +222,8 @@ kustomize:
       - pki-base
       - policy-resources
     components:
-      - "${gateway.access == 'private' && (dns.private_domain ?? '') != '' ? 'private-issuer/selfsigned' : ((dns.public_domain ?? '') != '' ? 'public-issuer/acme/azuredns' : 'public-issuer/selfsigned')}"
+      # Issuer variant resolved in the config section above.
+      - "${pki_effective.issuer_component}"
     timeout: 5m
     interval: 5m
     substitutions:

--- a/contexts/_template/facets/platform-hyperv.yaml
+++ b/contexts/_template/facets/platform-hyperv.yaml
@@ -323,9 +323,17 @@ config:
   # dns.private_domain. Empty-string check (not just `??`) because
   # platform-base may have already resolved private_domain to '' for
   # non-dev contexts.
+  # Ordered fallback, written only when private_domain is unset so we never
+  # self-overwrite an operator value (the guards are mutually exclusive):
+  # dns.domain when set, else '<id>.local'.
   - name: dns
+    when: (dns.private_domain ?? '') == '' && (dns.domain ?? '') != ''
     value:
-      private_domain: "${(dns.private_domain ?? '') != '' ? dns.private_domain : ((dns.domain ?? '') != '' ? dns.domain : (id ?? 'windsor') + '.local')}"
+      private_domain: "${dns.domain}"
+  - name: dns
+    when: (dns.private_domain ?? '') == '' && (dns.domain ?? '') == ''
+    value:
+      private_domain: "${(id ?? 'windsor') + '.local'}"
 
   # ---------------------------------------------------------------------------
   # cluster_endpoint_fallback

--- a/contexts/_template/tests/platform-hyperv.test.yaml
+++ b/contexts/_template/tests/platform-hyperv.test.yaml
@@ -445,6 +445,59 @@ cases:
         - path: compute/incus
         - path: compute/docker
 
+  # dns.private_domain fallback ladder (surfaced via the gateway cert SAN):
+  # an explicit private_domain is kept (never self-overwritten), dns.domain
+  # is the next fallback, and '<id>.local' is the floor so the cert is valid
+  # with no DNS configured at all.
+  - name: explicit dns.private_domain is kept for the gateway cert SAN
+    values:
+      platform: hyperv
+      gateway:
+        enabled: true
+        driver: envoy
+      dns:
+        private_domain: hv.example
+      network: *default-network
+      cluster: *default-cluster
+    terraformOutputs: *default-terraform-outputs
+    expect:
+      kustomize:
+        - name: gateway-resources
+          substitutions:
+            external_domain: hv.example
+
+  - name: dns.private_domain falls back to dns.domain
+    values:
+      platform: hyperv
+      gateway:
+        enabled: true
+        driver: envoy
+      dns:
+        domain: example.com
+      network: *default-network
+      cluster: *default-cluster
+    terraformOutputs: *default-terraform-outputs
+    expect:
+      kustomize:
+        - name: gateway-resources
+          substitutions:
+            external_domain: example.com
+
+  - name: dns.private_domain defaults to id.local with no DNS configured
+    values:
+      platform: hyperv
+      gateway:
+        enabled: true
+        driver: envoy
+      network: *default-network
+      cluster: *default-cluster
+    terraformOutputs: *default-terraform-outputs
+    expect:
+      kustomize:
+        - name: gateway-resources
+          substitutions:
+            external_domain: windsor.local
+
   # Requires: NodePort mode parses the bench IP from cluster.endpoint; without
   # it bench_ip is empty and the per-node port forwards become unreachable.
   - name: NodePort without cluster.endpoint fails composition


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> Pure refactor of existing conditional logic into named config sections; no behavioral change is intended and the ladder semantics are equivalent to the ternaries they replace.
>
> **Overview**
>
> This PR centralizes multi-clause ternary expressions — previously inlined in kustomize substitution blocks — into named config sections (`gateway_effective`, `pki_effective`) using Windsor's ordered fallback ladder. The `option-gateway`, `platform-aws`, and `platform-azure` facets gain dedicated config blocks, and `platform-hyperv`'s `dns.private_domain` resolution is split from one self-referential ternary into two mutually exclusive conditional entries that are easier to audit and extend.
>
> The priority ordering is preserved exactly. For `gateway_effective.cert_issuer` and `pki_effective.issuer_component`, the private-access override (step 3) correctly shadows the cloud-issuer assignment (step 2) when both conditions are true. Three new test cases cover the restructured hyperv ladder directly; the AWS and Azure private-access branches depend on pre-existing test coverage.
>
> Reviewed by Claude for commit `501aa03`.
<!-- /claude-code-review:summary -->
