### PR TITLE
docs(terraform): make module README structure consistent

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -21,7 +21,7 @@ layer. Links from there land here.
 | [backend/s3](backend/s3/) | Remote Terraform state on S3 + DynamoDB lock. |
 | [cluster](cluster/) | Kubernetes control plane provisioning across Talos, EKS, and AKS. |
 | [cluster/aws-eks](cluster/aws-eks/) | Managed Kubernetes control plane on AWS. |
-| [cluster/aws-eks/additions](cluster/aws-eks/additions/) | VPC CNI and EBS CSI driver helpers for EKS. |
+| [cluster/aws-eks/additions](cluster/aws-eks/additions/) | system-dns namespace and external-dns ConfigMap for EKS. |
 | [cluster/azure-aks](cluster/azure-aks/) | Managed Kubernetes control plane on Azure. |
 | [cluster/talos](cluster/talos/) | Self-hosted Kubernetes control plane via the Talos API. |
 | [cluster/talos/config](cluster/talos/config/) | Per-node Talos machine config + CIDATA seeds. |

--- a/terraform/cluster/README.md
+++ b/terraform/cluster/README.md
@@ -93,8 +93,9 @@ managed node groups from `cluster.pools`. `cluster.workers` is ignored
 on elastic providers, so use `pools` instead. The IAM role and Pod
 Identity association are created when `dns.public_domain` is set; the
 role is scoped to the Route53 zone provisioned by `dns/zone/route53`.
-The `cluster/aws-eks/additions` module installs IAM entries that
-survive across cluster destroys.
+The `cluster/aws-eks/additions` module applies the in-cluster
+external-dns prerequisites (the `system-dns` namespace and external-dns
+ConfigMap).
 
 ### AKS (managed Azure)
 

--- a/terraform/cluster/aws-eks/additions/README.md
+++ b/terraform/cluster/aws-eks/additions/README.md
@@ -1,9 +1,14 @@
 ---
 title: cluster/aws-eks/additions
-description: VPC CNI and EBS CSI driver helpers for EKS.
+description: system-dns namespace and external-dns ConfigMap for EKS.
 ---
 
 # cluster/aws-eks/additions
+
+The in-cluster pieces external-dns needs on EKS: the `system-dns` namespace
+(baseline Pod Security) and an `external-dns` ConfigMap carrying the Route53
+region and TXT owner ID. Applied by `cluster/aws-eks` against the cluster's
+Kubernetes API once the control plane is reachable.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/terraform/cluster/azure-aks/README.md
+++ b/terraform/cluster/azure-aks/README.md
@@ -11,26 +11,20 @@ can federate to Entra apps without static credentials), key-vault-backed
 disk encryption, and the supporting role assignments. Consumes private
 subnet IDs from the `network/azure-vnet` outputs.
 
-## Prerequisites
+## Notes
 
-The following features must be enabled in your Azure subscription before using this module:
+### Prerequisites
 
-- EncryptionAtHost feature for Microsoft.Compute provider
-  ```bash
-  az feature register --namespace Microsoft.Compute --name EncryptionAtHost
-  az provider register --namespace Microsoft.Compute
-  ```
+Enable the EncryptionAtHost feature on the subscription before first apply:
 
-### Subscription Requirements
+```bash
+az feature register --namespace Microsoft.Compute --name EncryptionAtHost
+az provider register --namespace Microsoft.Compute
+```
 
-This module requires a paid Azure subscription. Free tier subscriptions are not supported due to:
-- Insufficient vCPU quotas
-- Restricted VM sizes
-- Limited node pool operations
+Requires a paid Azure subscription; free-tier vCPU quotas, VM sizes, and node-pool operations are too restricted.
 
-## Upgrading
-
-### `azurerm_role_assignment.subnet_network_contributor_cp` for_each migration
+### Upgrading: `subnet_network_contributor_cp` for_each migration
 
 This resource moved from a single instance to `for_each` over `var.private_subnet_ids`. Without intervention, `terraform apply` will destroy the existing assignment and recreate it as a keyed instance, briefly leaving the control plane without `Network Contributor` on the first subnet (transient LB provisioning failures are possible during that window).
 
@@ -44,7 +38,7 @@ terraform state mv \
 
 The remaining for_each entries (other private subnets) are net-new assignments and do not affect the existing one.
 
-### `azurerm_role_assignment.external_dns_zones` is scoped to the resource group
+### Upgrading: `external_dns_zones` resource-group scope
 
 The DNS Zone Contributor role assignment for the external-dns identity is scoped to the resource group of each enumerated zone, not to the individual zones. This is required by the external-dns Azure provider, which calls `ListByResourceGroup` on every reconcile to discover zones — an action that the zone-scoped `DNS Zone Contributor` does not authorize. A zone-scoped grant would leave external-dns unable to enumerate, regardless of which zones were enumerated in `external_dns_dns_zone_ids`.
 

--- a/terraform/cluster/talos/config/README.md
+++ b/terraform/cluster/talos/config/README.md
@@ -5,6 +5,13 @@ description: Per-node Talos machine config + CIDATA seeds.
 
 # cluster/talos/config
 
+The before-compute stage for hypervisors with no metadata service or DHCP
+(Hyper-V today). Generates the cluster identity, signs per-node machine
+configs, and wraps each config plus its static-network cloud-init into a
+CIDATA seed ISO that `compute/hyperv` attaches as the node's second DVD.
+Exports the same identity back to `cluster/talos` so its bootstrap and
+kubeconfig flow run without a redundant machine-config apply.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/terraform/cluster/talos/extensions/README.md
+++ b/terraform/cluster/talos/extensions/README.md
@@ -5,6 +5,11 @@ description: Talos image build with system extensions.
 
 # cluster/talos/extensions
 
+Resolves a Talos installer image carrying the requested system extensions
+through the Talos Image Factory, returning a stable schematic ID and the
+pinned installer URL. Also drives in-place upgrades of control-plane and
+worker nodes when the image changes.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/terraform/cni/cilium/README.md
+++ b/terraform/cni/cilium/README.md
@@ -5,6 +5,10 @@ description: Out-of-band Cilium bootstrap for Talos clusters.
 
 # cni/cilium
 
+Installs Cilium directly via Helm against the Talos API before Flux exists,
+so Pods can network during cluster bring-up. `kustomize/cni/` adopts the
+running release afterward and takes over day-2 changes.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/terraform/dns/zone/azure-dns/README.md
+++ b/terraform/dns/zone/azure-dns/README.md
@@ -5,6 +5,11 @@ description: DNS zone on Azure DNS.
 
 # dns/zone/azure-dns
 
+Creates a public Azure DNS zone for a domain in a self-contained resource
+group, so the zone's lifecycle is independent of any cluster — destroying
+the stack removes the zone and its resource group without touching unrelated
+resources.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/terraform/dns/zone/route53/README.md
+++ b/terraform/dns/zone/route53/README.md
@@ -6,27 +6,18 @@ description: Public DNS zone on AWS Route53.
 # dns/zone/route53
 
 Creates a public Route53 hosted zone for a domain. Kept independent of any
-network/cluster module so a domain can be provisioned standalone — useful
-for zone-only deployments and for cases where DNS infra has a different
-lifecycle than compute.
+network or cluster module so a domain can be provisioned standalone, for
+zone-only deployments or when DNS has a different lifecycle than compute.
 
-The zone is consumed by:
+## Notes
 
-- **cert-manager (ACME Route53 solver)** — DNS-01 challenges for Let's
-  Encrypt certificates issued via the `public` ClusterIssuer.
-- **external-dns** — automatic publication of Gateway / Service hostnames
-  as Route53 records.
+`force_destroy` is set to `true` unconditionally so `windsor destroy` can
+tear the zone down even when it still holds records (ACME TXTs, external-dns
+entries). The AWS provider reads `force_destroy` from state at delete time,
+so it has to be persisted from apply. Matches the `backend/s3` bucket
+pattern.
 
-After apply, point your domain registrar at the `name_servers` output so
-public DNS queries resolve through this zone.
-
-`force_destroy` is set to `true` unconditionally so `windsor destroy`
-can tear the zone down even when it still has records (ACME challenge
-TXTs, external-dns entries) — the AWS provider reads `force_destroy`
-from state at delete time, so it has to be persisted from apply.
-Matches the `backend/s3` bucket pattern.
-
-## DNSSEC (`enable_dnssec`)
+### DNSSEC (`enable_dnssec`)
 
 Off by default. When enabled, provisions a us-east-1 KSK KMS key
 (`ECC_NIST_P256` / `SIGN_VERIFY`), an `aws_route53_key_signing_key`,
@@ -41,7 +32,7 @@ After apply, publish the DS record at the domain registrar — the
 validating resolvers will fail to resolve the zone, so don't enable
 this without coordinating with whoever controls the registrar.
 
-## Query logging (`enable_query_logging`)
+### Query logging (`enable_query_logging`)
 
 Off by default. When enabled, provisions a CloudWatch log group at
 `/aws/route53/<domain>` in us-east-1 (Route53 only delivers query

--- a/terraform/workstation/docker/README.md
+++ b/terraform/workstation/docker/README.md
@@ -5,7 +5,7 @@ description: Local-host Docker network + registry.
 
 # workstation/docker
 
-Local-host runtime backing `windsor up` on developer machines. Stands up
+Local-host runtime backing `windsor apply` on developer machines. Stands up
 the Docker network, optional local OCI registry, and volumes the cluster
 needs before `compute/docker` brings up Talos containers on top. Works
 with Docker Desktop or Colima.

--- a/terraform/workstation/incus/README.md
+++ b/terraform/workstation/incus/README.md
@@ -5,7 +5,7 @@ description: Local-host Incus bridge + registry.
 
 # workstation/incus
 
-Local-host runtime backing `windsor up` when `compute.driver` is
+Local-host runtime backing `windsor apply` when `compute.driver` is
 `incus`. Provisions the LXC bridge and an optional local registry that
 `compute/incus` then attaches the Talos VMs to.
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> Documentation-only changes across twelve Markdown files; no Terraform, Kustomize, or workflow code is touched.
>
> **Overview**
>
> Refines the Terraform module READMEs by adding intro ledes to five modules that had none (aws-eks/additions, talos/config, talos/extensions, cni/cilium, azure-dns), consolidating scattered prerequisite and gotcha content under a unified `## Notes` heading, and correcting a stale description for the aws-eks/additions module that referenced VPC CNI and EBS CSI instead of the system-dns namespace and external-dns ConfigMap it actually provisions. Two `windsor up` references in the workstation READMEs are updated to `windsor apply`, and the Core blueprint landing page description is condensed.
>
> The most notable structural change is in `dns/zone/route53/README.md`, where the previous lede's "consumed by" list and post-apply registrar delegation instruction were removed when the notes were reorganized under `## Notes`. The registrar delegation step — pointing your domain registrar at the `name_servers` output after apply — is the one action outside of Terraform that users need to take for the zone to resolve publicly, and it no longer appears in the module README.
>
> Reviewed by Claude for commit `7bda493`.

<!-- /claude-code-review:summary -->
