### PR TITLE
chore(docs): reword Core blueprint landing description

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,11 @@
 ---
 title: Core
-description: The default Windsor blueprint — the complete, self-hosted platform most projects start from, on any target.
+description: Core is the default blueprint Windsor ships with, covering the infrastructure, the cluster, and the workloads that run on it.
 ---
 
 # Core
 
-The default Windsor blueprint — and where most projects start. A complete,
-self-hosted platform you deploy on any target and make your own.
+The default blueprint that includes base infrastructure and services. Cloud "primitives" provide storage, networking, security, and observability required to run a consistent platform across major cloud providers, virtualization platforms, and bare metal.
 
 ## Infrastructure
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,17 +1,12 @@
 ---
 title: Core
-description: The default Windsor blueprint — Terraform-provisioned infrastructure handed to Flux for cluster reconciliation.
+description: The default Windsor blueprint — the complete, self-hosted platform most projects start from, on any target.
 ---
 
 # Core
 
-The default Windsor blueprint. Core provisions infrastructure with Terraform —
-remote state, networks, a compute substrate, and a Kubernetes control plane on
-Talos, EKS, or AKS — then installs Flux and hands the running cluster over to
-it. From there the platform is reconciled from the Kustomize layer: CNI,
-storage, PKI, gateways, observability, and more. Either half can stand alone,
-but together they bootstrap a complete self-hosted platform from a single
-`windsor bootstrap`.
+The default Windsor blueprint — and where most projects start. A complete,
+self-hosted platform you deploy on any target and make your own.
 
 ## Infrastructure
 


### PR DESCRIPTION
- Reword the landing-page `description:` frontmatter in docs/index.md so it frames Core as the default Windsor blueprint covering the infrastructure, the cluster, and the workloads that run on it.
- Replace the multi-line intro paragraph with a shorter summary of the base infrastructure and cloud primitives (storage, networking, security, observability) across cloud providers, virtualization platforms, and bare metal.
