### PR TITLE
feat(policy/kyverno): enhance webhook policies and add HA support for admission controller

### DIFF
--- a/contexts/_template/facets/platform-base.yaml
+++ b/contexts/_template/facets/platform-base.yaml
@@ -402,6 +402,7 @@ kustomize:
       - kyverno
       - "${(policies.reporting ?? 'disabled') == 'enabled' ? 'kyverno/reports' : ''}"
       - "${(policies.cleanup ?? 'disabled') == 'enabled' ? 'kyverno/cleanup' : ''}"
+      - "${topology == 'ha' ? 'kyverno/ha' : ''}"
     timeout: 30m
     interval: 5m
 

--- a/contexts/_template/tests/platform-base.test.yaml
+++ b/contexts/_template/tests/platform-base.test.yaml
@@ -323,6 +323,24 @@ cases:
             - kyverno/reports
             - kyverno/cleanup
 
+  # topology=ha layers in the kyverno/ha component (multi-replica admission
+  # controller + PDB) so the webhook backend survives drains and rollouts.
+  - name: topology ha adds kyverno/ha component
+    values:
+      platform: metal
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster: *default-cluster
+      topology: ha
+    expect:
+      kustomize:
+        - name: policy-base
+          path: policy/base
+          components:
+            - kyverno
+            - kyverno/ha
+
   # policies.enabled=false skips both policy kustomizations entirely and
   # drops the policy-resources dep from pki-base.
   - name: policies.enabled false excludes policy kustomizations and drops pki-base dep

--- a/kustomize/cni/cilium/gateway/cluster-policy.yaml
+++ b/kustomize/cni/cilium/gateway/cluster-policy.yaml
@@ -15,6 +15,9 @@ metadata:
       initialization. By injecting annotations before the object is persisted,
       LBIPAM always sees a complete sharing group from the start.
 spec:
+  # Fail closed so the sharing annotations are never missed. The match is scoped
+  # to CREATE on labeled Services in system-gateway, so the blast radius is small.
+  failurePolicy: Fail
   rules:
     - name: inject-lbipam-sharing-annotations
       match:

--- a/kustomize/dns/external-dns/localhost/cluster-policy.yaml
+++ b/kustomize/dns/external-dns/localhost/cluster-policy.yaml
@@ -3,6 +3,9 @@ kind: ClusterPolicy
 metadata:
   name: set-ingress-localhost-dns-target
 spec:
+  # Cosmetic annotation matching Ingress/Gateway/HTTPRoute in every namespace.
+  # Fail open so an unavailable Kyverno can't block those resources cluster-wide.
+  failurePolicy: Ignore
   validationFailureAction: audit
   background: true
   rules:

--- a/kustomize/pki/resources/private-issuer/ca/inject-private-ca-policy.yaml
+++ b/kustomize/pki/resources/private-issuer/ca/inject-private-ca-policy.yaml
@@ -3,6 +3,10 @@ kind: ClusterPolicy
 metadata:
   name: inject-private-ca
 spec:
+  # Fail closed: a pod must not start without the CA bundle it expects to trust.
+  # The pod-label match scopes the webhook to opted-in pods, so this never gates
+  # unrelated workloads or the control plane.
+  failurePolicy: Fail
   background: false
   rules:
     - name: inject-private-ca

--- a/kustomize/policy/.docs.yaml
+++ b/kustomize/policy/.docs.yaml
@@ -10,6 +10,11 @@ facets:
   - policy-base
   - policy-resources
 
+substitutions:
+  FLUX_SYSTEM_NAMESPACE:
+    required_when: "always (defaults to `system-gitops`)"
+    description: "Namespace excluded from the Kyverno admission webhooks alongside `kube-system`, so Flux can always reconcile even if the admission controller is unavailable."
+
 components:
   kyverno:
     facet: policy-base
@@ -23,6 +28,10 @@ components:
     facet: policy-base
     enable_when: "`policies.cleanup == 'enabled'`"
     description: "Patches the kyverno HelmRelease to set `cleanupController.enabled: true` so CleanupPolicy / ClusterCleanupPolicy CRs are executed on their cron schedules. Disabled by default because the blueprint ships no CleanupPolicy resources."
+  kyverno/ha:
+    facet: policy-base
+    enable_when: "`topology == 'ha'`"
+    description: "Patches the kyverno HelmRelease to run the admission controller with `replicas: 3` and a PodDisruptionBudget, keeping the webhook backend reachable during node drains and rollouts (pod anti-affinity is on by default)."
   kyverno/resource-limits-requests:
     facet: policy-resources
     enable_when: "`policies.resource_limits_requests != 'disabled'`"

--- a/kustomize/policy/README.md
+++ b/kustomize/policy/README.md
@@ -48,6 +48,25 @@ fails. The background controller audits existing Pods against Audit
 policies and writes Events and PolicyReports (the latter only when
 `kyverno/reports` is enabled).
 
+## Webhook availability
+
+A webhook with `failurePolicy: Fail` rejects matching requests when the
+admission controller is unreachable, so an unavailable Kyverno can lock
+out resource creation. Three things bound that risk:
+
+- The webhook `namespaceSelector` excludes `kube-system` and the GitOps
+  namespace (`FLUX_SYSTEM_NAMESPACE`, default `system-gitops`). The
+  kube-apiserver honours this even when Kyverno is down, so Flux can
+  always reconcile a recovery.
+- Validating policies and tightly scoped mutating policies stay `Fail`.
+  Fail closed is the safe default for a security gate or a CA-trust
+  injection, and a label or namespace match keeps the blast radius small.
+  Broad, cosmetic mutations such as the localhost DNS-target injection
+  use `Ignore` so they fail open.
+- On `topology == 'ha'`, `kyverno/ha` runs the controller with three
+  replicas and a PDB so the webhook backend stays reachable through
+  drains and rollouts.
+
 ## Recipes
 
 ### Baseline (admission + ClusterPolicies)
@@ -95,6 +114,12 @@ to add your own.
 
 <!-- BEGIN_KUSTOMIZE_DOCS -->
 
+## Substitutions
+
+| Name | Required when | Effect |
+|---|---|---|
+| `FLUX_SYSTEM_NAMESPACE` | always (defaults to `system-gitops`) | Namespace excluded from the Kyverno admission webhooks alongside `kube-system`, so Flux can always reconcile even if the admission controller is unavailable. |
+
 ## Components — `policy-base`
 
 | Component | Enable when | Effect |
@@ -102,6 +127,7 @@ to add your own.
 | `kyverno` | always | Helm release of Kyverno in `system-policy`. Installs the admission, background, and reports controllers (the cleanup controller is disabled at this layer; opt in via `kyverno/cleanup`). NO_COLOR is set on the admission and background containers. |
 | `kyverno/reports` | `policies.reporting == 'enabled'` | Patches the kyverno HelmRelease to set `reportsController.enabled: true` so PolicyReport / ClusterPolicyReport CRs are written for evaluated policies. |
 | `kyverno/cleanup` | `policies.cleanup == 'enabled'` | Patches the kyverno HelmRelease to set `cleanupController.enabled: true` so CleanupPolicy / ClusterCleanupPolicy CRs are executed on their cron schedules. Disabled by default because the blueprint ships no CleanupPolicy resources. |
+| `kyverno/ha` | `topology == 'ha'` | Patches the kyverno HelmRelease to run the admission controller with `replicas: 3` and a PodDisruptionBudget, keeping the webhook backend reachable during node drains and rollouts (pod anti-affinity is on by default). |
 
 ## Components — `policy-resources`
 

--- a/kustomize/policy/base/kyverno/ha/kustomization.yaml
+++ b/kustomize/policy/base/kyverno/ha/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: patches/helm-release.yaml

--- a/kustomize/policy/base/kyverno/ha/patches/helm-release.yaml
+++ b/kustomize/policy/base/kyverno/ha/patches/helm-release.yaml
@@ -1,0 +1,16 @@
+---
+# Run the admission controller with multiple replicas and a PDB so the webhook
+# backend stays reachable during node drains and rollouts. Pod anti-affinity is
+# already enabled by the chart. Layered in only on topology=ha.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kyverno
+  namespace: system-policy
+spec:
+  values:
+    admissionController:
+      replicas: 3
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1

--- a/kustomize/policy/base/kyverno/ha/patches/helm-release.yaml
+++ b/kustomize/policy/base/kyverno/ha/patches/helm-release.yaml
@@ -13,4 +13,7 @@ spec:
       replicas: 3
       podDisruptionBudget:
         enabled: true
-        minAvailable: 1
+        # With replicas: 3 this caps voluntary disruption at one pod at a time,
+        # so a drain can't degrade the fail-closed webhook backend to a single
+        # pod. Still permits one-node-at-a-time rolling drains.
+        minAvailable: 2

--- a/kustomize/policy/base/kyverno/helm-release.yaml
+++ b/kustomize/policy/base/kyverno/helm-release.yaml
@@ -15,6 +15,18 @@ spec:
         kind: HelmRepository
         name: kyverno
   values:
+    # The kube-apiserver enforces the webhook namespaceSelector even when the
+    # admission controller is unreachable. Excluding the GitOps and kube-system
+    # namespaces keeps Flux able to reconcile a fix if Kyverno is ever down.
+    config:
+      webhooks:
+        namespaceSelector:
+          matchExpressions:
+            - key: kubernetes.io/metadata.name
+              operator: NotIn
+              values:
+                - kube-system
+                - ${FLUX_SYSTEM_NAMESPACE:-system-gitops}
     crds:
       migration:
         image:


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> This PR affects admission-control configuration cluster-wide, but the changes are tightening and clarifying an existing system rather than introducing new behaviour — the blast radius of any individual policy stays the same or shrinks.
>
> **Overview**
>
> The PR makes explicit what was previously implicit in Kyverno policy definitions: each ClusterPolicy now carries a `failurePolicy` that matches its role — `Fail` for security gates and CA-trust injection (scoped by label or namespace), `Ignore` for broad cosmetic mutations where an unavailable Kyverno should never block resource creation. Alongside this, the Kyverno HelmRelease gains a webhook `namespaceSelector` that excludes `kube-system` and the Flux GitOps namespace, ensuring the controller can always be recovered even when it is completely unreachable.
>
> The new `kyverno/ha` component, gated on `topology == 'ha'`, patches the HelmRelease to run the admission controller with three replicas and a PodDisruptionBudget. The one open question is whether `minAvailable: 1` provides sufficient protection for a fail-closed webhook (see inline comment); `minAvailable: 2` would be the conventional setting for a three-replica HA service.
>
> Test coverage adds a focused case confirming the `kyverno/ha` component is included exactly when `topology == 'ha'`, consistent with the existing pattern-test suite.
>
> Reviewed by Claude for commit `46ca82c`.
<!-- /claude-code-review:summary -->
