### PR TITLE
feat(cluster): Make node pool configuration symmetrical between AWS and Azure

### DIFF
--- a/contexts/_template/facets/platform-aws.yaml
+++ b/contexts/_template/facets/platform-aws.yaml
@@ -138,7 +138,10 @@ terraform:
       # cluster.pools is the portable node-pool input (class + count, optional
       # autoscaling + lifecycle). When unset, default to a small fixed system
       # pool plus an autoscaling general pool — the same arrangement AKS gets
-      # (inline system pool + general). Declaring cluster.pools replaces this.
+      # (inline system pool + general). The defaults carry only class + count;
+      # the aws-eks module's class-conditional defaulting fixes class=system and
+      # autoscales the rest at min 1 / max 3 (see pools_autoscaling in
+      # terraform/cluster/aws-eks/main.tf). Declaring cluster.pools replaces this.
       pools: >-
         ${cluster.pools ?? {"system": {"class": "system", "count": 1}, "general": {"class": "general", "count": 1}}}
 

--- a/contexts/_template/facets/platform-aws.yaml
+++ b/contexts/_template/facets/platform-aws.yaml
@@ -136,9 +136,11 @@ terraform:
       create_cert_manager_role: "${(dns.public_domain ?? '') != ''}"
       cert_manager_hosted_zone_ids: "${(dns.public_domain ?? '') != '' ? [terraform_output('dns-zone', 'zone_id')] : []}"
       # cluster.pools is the portable node-pool input (class + count, optional
-      # autoscaling + lifecycle). When unset, the cluster module falls back to
-      # its var.node_groups default — no behavior change for existing configs.
-      pools: ${cluster.pools ?? {}}
+      # autoscaling + lifecycle). When unset, default to a small fixed system
+      # pool plus an autoscaling general pool — the same arrangement AKS gets
+      # (inline system pool + general). Declaring cluster.pools replaces this.
+      pools: >-
+        ${cluster.pools ?? {"system": {"class": "system", "count": 1}, "general": {"class": "general", "count": 1}}}
 
   # Path-less dependency-edge injector: when ACME is on, cluster must wait for
   # dns-zone so terraform_output('dns-zone', 'zone_id') is resolved before the

--- a/contexts/_template/facets/platform-azure.yaml
+++ b/contexts/_template/facets/platform-azure.yaml
@@ -137,10 +137,14 @@ terraform:
       create_cert_manager_identity: "${(dns.public_domain ?? '') != ''}"
       cert_manager_dns_zone_ids: "${(dns.public_domain ?? '') != '' && (terraform_output('dns-zone', 'zone_id') ?? '') != '' ? [terraform_output('dns-zone', 'zone_id')] : []}"
       external_dns_dns_zone_ids: "${gateway.access == 'private' && (dns.private_domain ?? '') != '' && (terraform_output('network', 'private_zone_id') ?? '') != '' ? [terraform_output('network', 'private_zone_id')] : ((dns.public_domain ?? '') != '' && (terraform_output('dns-zone', 'zone_id') ?? '') != '' ? [terraform_output('dns-zone', 'zone_id')] : [])}"
-      # Portable user-pool shape (mirrors AWS-EKS). Renders as additional
-      # azurerm_kubernetes_cluster_node_pool resources alongside the
-      # cluster's inline default (system) pool.
-      pools: ${cluster.pools ?? {}}
+      # Portable user pools (mirrors AWS-EKS). Render as additional
+      # azurerm_kubernetes_cluster_node_pool resources alongside the cluster's
+      # inline default (system) pool. When unset, default to one autoscaling
+      # general pool; the inline pool already covers the fixed system role, so
+      # AWS and AKS land on the same arrangement. Declaring cluster.pools
+      # replaces this.
+      pools: >-
+        ${cluster.pools ?? {"general": {"class": "general", "count": 1}}}
 
   # Path-less dependency-edge injector: when ACME is on, cluster must wait
   # for dns-zone so terraform_output('dns-zone', 'zone_id') is resolved
@@ -326,7 +330,7 @@ kustomize:
   # internal for private clusters. Done by conditionally including the
   # azure-lb-internal component, which hardcodes the annotation to "true".
   #
-  # Shape differs from platform-aws on purpose. AWS always includes
+  # This differs from platform-aws on purpose. AWS always includes
   # aws-nlb and uses an lb_scheme substitution to toggle internal vs
   # internet-facing. The Azure annotation values are "true" or "false",
   # which YAML treats as bool tokens. They don't survive substitution

--- a/contexts/_template/tests/platform-aws.test.yaml
+++ b/contexts/_template/tests/platform-aws.test.yaml
@@ -322,6 +322,27 @@ cases:
   # cluster.pools threads through to the cluster module as-is. The module
   # converts class + count + lifecycle into EKS managed node group fields
   # internally (class → instance family, lifecycle → capacity_type).
+  # With no cluster.pools set, the facet defaults to a fixed system pool plus an
+  # autoscaling general pool — the same arrangement AKS lands on.
+  - name: default pools are a fixed system plus autoscaling general
+    values:
+      platform: aws
+      aws: *default-aws
+      gateway:
+        enabled: false
+    expect:
+      terraform:
+        - name: cluster
+          path: cluster/aws-eks
+          inputs:
+            pools:
+              system:
+                class: system
+                count: 1
+              general:
+                class: general
+                count: 1
+
   - name: cluster.pools flows through to the cluster module
     values:
       platform: aws

--- a/contexts/_template/tests/platform-azure.test.yaml
+++ b/contexts/_template/tests/platform-azure.test.yaml
@@ -28,6 +28,24 @@ cases:
             - azure-disk
 
   # cluster.pools wires to the azure-aks module's var.pools (mirrors AWS).
+  # With no cluster.pools set, the facet defaults to one autoscaling general
+  # pool; the cluster's inline default_node_pool already covers the fixed system
+  # role, so AWS and AKS land on the same arrangement.
+  - name: default pools are a single autoscaling general pool
+    values:
+      platform: azure
+      gateway:
+        enabled: false
+    expect:
+      terraform:
+        - name: cluster
+          path: cluster/azure-aks
+          inputs:
+            pools:
+              general:
+                class: general
+                count: 1
+
   - name: cluster.pools wires through to azure-aks module
     values:
       platform: azure

--- a/terraform/cluster/aws-eks/README.md
+++ b/terraform/cluster/aws-eks/README.md
@@ -7,10 +7,12 @@ description: Managed Kubernetes control plane on AWS.
 
 Managed Kubernetes control plane on AWS. The module consumes the VPC and
 private subnet IDs from the `network/aws-vpc` outputs, provisions the
-EKS cluster + a managed node group, and creates an OIDC provider so
-in-cluster ServiceAccounts can assume IAM roles via IRSA. The `additions/`
-submodule wires the VPC CNI and EBS CSI driver helpers that EKS expects
-out-of-band.
+EKS cluster and its managed node groups (from `var.pools`, or the
+`var.node_groups` fallback when pools is empty), and creates an OIDC
+provider so in-cluster ServiceAccounts can assume IAM roles via IRSA. The
+blueprint's platform-aws facet defaults to a fixed `system` pool plus an
+autoscaling `general` pool. The `additions/` submodule wires the VPC CNI
+and EBS CSI driver helpers that EKS expects out-of-band.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> Introduces non-empty pool defaults for both providers, changing behavior for any existing deployment that relied on the module-level `var.node_groups` fallback when `cluster.pools` was unset.
>
> **Overview**
>
> This PR makes the facet-layer default for `cluster.pools` symmetrical between AWS (EKS) and Azure (AKS). When `cluster.pools` is unset, both providers now receive a concrete pool map rather than an empty `{}` that fell through to each module's own `var.node_groups` fallback. AWS gets a fixed `system` pool plus a `general` pool; Azure gets only `general`, because its inline `default_node_pool` already covers the system role.
>
> The old code explicitly documented "no behavior change for existing configs" — a guarantee this PR intentionally removes. Any operator upgrading in place without a custom `cluster.pools` will see new or modified node groups in their next `terraform plan`. The `aws-eks` README is updated to describe the new fallback, but no migration note exists for currently-deployed clusters.
>
> Two test cases, one per provider, cover the new defaults.
>
> Reviewed by Claude for commit `ed380e1`.

<!-- /claude-code-review:summary -->
