### PR TITLE
chore(docs): Update README links to reference blueprint paths

### DIFF
--- a/kustomize/README.md
+++ b/kustomize/README.md
@@ -16,17 +16,17 @@ composition. Links from there land here.
 
 | Path | Purpose |
 |---|---|
-| [cni](cni/) | Cilium as the cluster CNI, bootstrapped via Terraform and adopted by Flux. |
-| [compute](compute/) | Node-lifecycle controllers for elastic clusters (EKS cluster-autoscaler). |
-| [csi](csi/) | Persistent storage drivers and StorageClasses. AWS EBS, Azure Disk, OpenEBS host-path, and Longhorn distributed. |
-| [database](database/) | CloudNativePG operator for in-cluster PostgreSQL. |
-| [demo](demo/) | Sample applications (PostgreSQL cluster, static website, Istio bookinfo) for blueprint validation. |
-| [dns](dns/) | external-dns for hostname publication and (opt-in) coredns for in-cluster private DNS. |
-| [gateway](gateway/) | Gateway API implementation (Envoy Gateway or Cilium) and the cluster's external Gateway. |
-| [lb](lb/) | LoadBalancer Service implementation (AWS LB Controller, MetalLB, or kube-vip) for non-managed clusters. |
-| [object-store](object-store/) | MinIO Operator for in-cluster S3-compatible object storage. |
-| [observability](observability/) | Grafana dashboards and the cluster's log store (stdout, Quickwit, or Elasticsearch + Kibana). |
-| [pki](pki/) | cert-manager, trust-manager, and the cluster's ClusterIssuers (selfsigned, private CA, ACME). |
-| [policy](policy/) | Kyverno admission controller and the cluster's baseline ClusterPolicies. |
-| [telemetry](telemetry/) | kube-prometheus-stack and FluentBit for cluster-level metrics and log collection. |
+| [cni](/reference/blueprints/core/kustomize/cni) | Cilium as the cluster CNI, bootstrapped via Terraform and adopted by Flux. |
+| [compute](/reference/blueprints/core/kustomize/compute) | Node-lifecycle controllers for elastic clusters (EKS cluster-autoscaler). |
+| [csi](/reference/blueprints/core/kustomize/csi) | Persistent storage drivers and StorageClasses. AWS EBS, Azure Disk, OpenEBS host-path, and Longhorn distributed. |
+| [database](/reference/blueprints/core/kustomize/database) | CloudNativePG operator for in-cluster PostgreSQL. |
+| [demo](/reference/blueprints/core/kustomize/demo) | Sample applications (PostgreSQL cluster, static website, Istio bookinfo) for blueprint validation. |
+| [dns](/reference/blueprints/core/kustomize/dns) | external-dns for hostname publication and (opt-in) coredns for in-cluster private DNS. |
+| [gateway](/reference/blueprints/core/kustomize/gateway) | Gateway API implementation (Envoy Gateway or Cilium) and the cluster's external Gateway. |
+| [lb](/reference/blueprints/core/kustomize/lb) | LoadBalancer Service implementation (AWS LB Controller, MetalLB, or kube-vip) for non-managed clusters. |
+| [object-store](/reference/blueprints/core/kustomize/object-store) | MinIO Operator for in-cluster S3-compatible object storage. |
+| [observability](/reference/blueprints/core/kustomize/observability) | Grafana dashboards and the cluster's log store (stdout, Quickwit, or Elasticsearch + Kibana). |
+| [pki](/reference/blueprints/core/kustomize/pki) | cert-manager, trust-manager, and the cluster's ClusterIssuers (selfsigned, private CA, ACME). |
+| [policy](/reference/blueprints/core/kustomize/policy) | Kyverno admission controller and the cluster's baseline ClusterPolicies. |
+| [telemetry](/reference/blueprints/core/kustomize/telemetry) | kube-prometheus-stack and FluentBit for cluster-level metrics and log collection. |
 <!-- END_INDEX -->

--- a/kustomize/cni/README.md
+++ b/kustomize/cni/README.md
@@ -148,6 +148,6 @@ cert-manager is not required for Hubble.
 
 ## See also
 
-- [contexts/_template/facets/option-cni.yaml](../../contexts/_template/facets/option-cni.yaml) for the canonical wiring.
-- [terraform/cni/cilium/](../../terraform/cni/cilium/) for the Terraform bootstrap module.
-- Related add-ons: [policy](../policy/), [telemetry](../telemetry/), [gateway](../gateway/), [csi](../csi/), [lb](../lb/).
+- [contexts/_template/facets/option-cni.yaml](https://github.com/windsorcli/core/blob/main/contexts/_template/facets/option-cni.yaml) for the canonical wiring.
+- [terraform/cni/cilium/](/reference/blueprints/core/terraform/cni/cilium) for the Terraform bootstrap module.
+- Related add-ons: [policy](/reference/blueprints/core/kustomize/policy), [telemetry](/reference/blueprints/core/kustomize/telemetry), [gateway](/reference/blueprints/core/kustomize/gateway), [csi](/reference/blueprints/core/kustomize/csi), [lb](/reference/blueprints/core/kustomize/lb).

--- a/kustomize/compute/README.md
+++ b/kustomize/compute/README.md
@@ -85,6 +85,6 @@ those bounds; raising a pool's ceiling is an in-place re-apply.
 
 ## See also
 
-- [contexts/_template/facets/platform-aws.yaml](../../contexts/_template/facets/platform-aws.yaml) for the `compute` wiring.
-- [terraform/cluster/aws-eks](../../terraform/cluster/aws-eks/) for the node-group autoscaling bounds, ASG discovery tags, and the autoscaler IAM role.
-- Related add-ons: [policy](../policy/) (admits the autoscaler pod), [lb](../lb/) (the other AWS-gated controller pattern).
+- [contexts/_template/facets/platform-aws.yaml](https://github.com/windsorcli/core/blob/main/contexts/_template/facets/platform-aws.yaml) for the `compute` wiring.
+- [terraform/cluster/aws-eks](/reference/blueprints/core/terraform/cluster/aws-eks) for the node-group autoscaling bounds, ASG discovery tags, and the autoscaler IAM role.
+- Related add-ons: [policy](/reference/blueprints/core/kustomize/policy) (admits the autoscaler pod), [lb](/reference/blueprints/core/kustomize/lb) (the other AWS-gated controller pattern).

--- a/kustomize/csi/README.md
+++ b/kustomize/csi/README.md
@@ -176,9 +176,9 @@ for explicit multi-replica volumes.
 
 ## See also
 
-- [contexts/_template/facets/platform-aws.yaml](../../contexts/_template/facets/platform-aws.yaml) for the AWS EBS wiring.
-- [contexts/_template/facets/platform-azure.yaml](../../contexts/_template/facets/platform-azure.yaml) for the Azure Disk wiring.
-- [contexts/_template/facets/option-storage.yaml](../../contexts/_template/facets/option-storage.yaml) for OpenEBS and Longhorn driver selection.
-- [contexts/_template/facets/option-single-node.yaml](../../contexts/_template/facets/option-single-node.yaml) for the single-node OpenEBS overlay.
-- [contexts/_template/facets/option-cni.yaml](../../contexts/_template/facets/option-cni.yaml) where the `cni` reverse dependency is added.
-- Related add-ons: [policy](../policy/), [cni](../cni/), [telemetry](../telemetry/), [observability](../observability/).
+- [contexts/_template/facets/platform-aws.yaml](https://github.com/windsorcli/core/blob/main/contexts/_template/facets/platform-aws.yaml) for the AWS EBS wiring.
+- [contexts/_template/facets/platform-azure.yaml](https://github.com/windsorcli/core/blob/main/contexts/_template/facets/platform-azure.yaml) for the Azure Disk wiring.
+- [contexts/_template/facets/option-storage.yaml](https://github.com/windsorcli/core/blob/main/contexts/_template/facets/option-storage.yaml) for OpenEBS and Longhorn driver selection.
+- [contexts/_template/facets/option-single-node.yaml](https://github.com/windsorcli/core/blob/main/contexts/_template/facets/option-single-node.yaml) for the single-node OpenEBS overlay.
+- [contexts/_template/facets/option-cni.yaml](https://github.com/windsorcli/core/blob/main/contexts/_template/facets/option-cni.yaml) where the `cni` reverse dependency is added.
+- Related add-ons: [policy](/reference/blueprints/core/kustomize/policy), [cni](/reference/blueprints/core/kustomize/cni), [telemetry](/reference/blueprints/core/kustomize/telemetry), [observability](/reference/blueprints/core/kustomize/observability).

--- a/kustomize/database/README.md
+++ b/kustomize/database/README.md
@@ -111,7 +111,7 @@ reconciling.
 
 ## See also
 
-- [contexts/_template/facets/addon-database.yaml](../../contexts/_template/facets/addon-database.yaml) for the canonical wiring and Grafana dashboard patch.
-- [contexts/_template/facets/option-single-node.yaml](../../contexts/_template/facets/option-single-node.yaml) for the `cloudnativepg/single-node` patch wiring.
-- [kustomize/demo/database/](../demo/database/) for a worked example (a `Cluster` CR named `demo-cluster`).
-- Related add-ons: [csi](../csi/), [observability](../observability/) (`grafana/dashboards/cloudnativepg`), [telemetry](../telemetry/).
+- [contexts/_template/facets/addon-database.yaml](https://github.com/windsorcli/core/blob/main/contexts/_template/facets/addon-database.yaml) for the canonical wiring and Grafana dashboard patch.
+- [contexts/_template/facets/option-single-node.yaml](https://github.com/windsorcli/core/blob/main/contexts/_template/facets/option-single-node.yaml) for the `cloudnativepg/single-node` patch wiring.
+- [kustomize/demo/database/](https://github.com/windsorcli/core/tree/main/kustomize/demo/database) for a worked example (a `Cluster` CR named `demo-cluster`).
+- Related add-ons: [csi](/reference/blueprints/core/kustomize/csi), [observability](/reference/blueprints/core/kustomize/observability) (`grafana/dashboards/cloudnativepg`), [telemetry](/reference/blueprints/core/kustomize/telemetry).

--- a/kustomize/demo/README.md
+++ b/kustomize/demo/README.md
@@ -121,6 +121,6 @@ instances against the default StorageClass.
 
 ## See also
 
-- [contexts/_template/facets/option-demo.yaml](../../contexts/_template/facets/option-demo.yaml) for the canonical wiring.
-- [kustomize/demo/static/assets/](static/assets/) for the Dockerfile and Node.js source for the static-site image. Build and push to `${REGISTRY_URL}` before enabling the static demo.
-- Related add-ons: [database](../database/) (operator for the Postgres demo), [gateway](../gateway/) or [ingress](../ingress/) (route handling), [csi](../csi/) (PVC for the static site).
+- [contexts/_template/facets/option-demo.yaml](https://github.com/windsorcli/core/blob/main/contexts/_template/facets/option-demo.yaml) for the canonical wiring.
+- [kustomize/demo/static/assets/](https://github.com/windsorcli/core/tree/main/kustomize/demo/static/assets) for the Dockerfile and Node.js source for the static-site image. Build and push to `${REGISTRY_URL}` before enabling the static demo.
+- Related add-ons: [database](/reference/blueprints/core/kustomize/database) (operator for the Postgres demo), [gateway](/reference/blueprints/core/kustomize/gateway) or [ingress](https://github.com/windsorcli/core/tree/main/kustomize/ingress) (route handling), [csi](/reference/blueprints/core/kustomize/csi) (PVC for the static site).

--- a/kustomize/dns/README.md
+++ b/kustomize/dns/README.md
@@ -199,9 +199,9 @@ In both cases `loadbalancer_start_ip` must fall inside
 
 ## See also
 
-- [contexts/_template/facets/platform-aws.yaml](../../contexts/_template/facets/platform-aws.yaml) for Route53 wiring.
-- [contexts/_template/facets/platform-azure.yaml](../../contexts/_template/facets/platform-azure.yaml) for Azure DNS wiring.
-- [contexts/_template/facets/addon-private-dns.yaml](../../contexts/_template/facets/addon-private-dns.yaml) for coredns and etcd wiring.
-- [terraform/dns/zone/route53/](../../terraform/dns/zone/route53/) for the Route53 zone creation (separate from this add-on).
-- [terraform/dns/zone/azure-dns/](../../terraform/dns/zone/azure-dns/) for the Azure DNS zone creation.
-- Related add-ons: [pki](../pki/) (etcd certs), [gateway](../gateway/) (HTTPRoute source), [policy](../policy/).
+- [contexts/_template/facets/platform-aws.yaml](https://github.com/windsorcli/core/blob/main/contexts/_template/facets/platform-aws.yaml) for Route53 wiring.
+- [contexts/_template/facets/platform-azure.yaml](https://github.com/windsorcli/core/blob/main/contexts/_template/facets/platform-azure.yaml) for Azure DNS wiring.
+- [contexts/_template/facets/addon-private-dns.yaml](https://github.com/windsorcli/core/blob/main/contexts/_template/facets/addon-private-dns.yaml) for coredns and etcd wiring.
+- [terraform/dns/zone/route53/](/reference/blueprints/core/terraform/dns/zone/route53) for the Route53 zone creation (separate from this add-on).
+- [terraform/dns/zone/azure-dns/](/reference/blueprints/core/terraform/dns/zone/azure-dns) for the Azure DNS zone creation.
+- Related add-ons: [pki](/reference/blueprints/core/kustomize/pki) (etcd certs), [gateway](/reference/blueprints/core/kustomize/gateway) (HTTPRoute source), [policy](/reference/blueprints/core/kustomize/policy).

--- a/kustomize/gateway/README.md
+++ b/kustomize/gateway/README.md
@@ -274,7 +274,7 @@ LBIPAM annotations so multiple Gateways can share one IP.
 
 ## See also
 
-- [contexts/_template/facets/option-gateway.yaml](../../contexts/_template/facets/option-gateway.yaml) for the canonical wiring.
-- [contexts/_template/facets/platform-aws.yaml](../../contexts/_template/facets/platform-aws.yaml) for the NLB merge on the AWS path.
-- [contexts/_template/facets/platform-azure.yaml](../../contexts/_template/facets/platform-azure.yaml) for the Azure ILB merge on the private-access path.
-- Related add-ons: [pki](../pki/) (gateway certificate), [lb](../lb/) (data-plane Service LB), [dns](../dns/) (external-dns publication), [cni](../cni/) (cilium driver).
+- [contexts/_template/facets/option-gateway.yaml](https://github.com/windsorcli/core/blob/main/contexts/_template/facets/option-gateway.yaml) for the canonical wiring.
+- [contexts/_template/facets/platform-aws.yaml](https://github.com/windsorcli/core/blob/main/contexts/_template/facets/platform-aws.yaml) for the NLB merge on the AWS path.
+- [contexts/_template/facets/platform-azure.yaml](https://github.com/windsorcli/core/blob/main/contexts/_template/facets/platform-azure.yaml) for the Azure ILB merge on the private-access path.
+- Related add-ons: [pki](/reference/blueprints/core/kustomize/pki) (gateway certificate), [lb](/reference/blueprints/core/kustomize/lb) (data-plane Service LB), [dns](/reference/blueprints/core/kustomize/dns) (external-dns publication), [cni](/reference/blueprints/core/kustomize/cni) (cilium driver).

--- a/kustomize/lb/README.md
+++ b/kustomize/lb/README.md
@@ -178,7 +178,7 @@ resources layer, advertising a VIP over ARP.
 
 ## See also
 
-- [contexts/_template/facets/platform-aws.yaml](../../contexts/_template/facets/platform-aws.yaml) for aws-lb-controller wiring.
-- [contexts/_template/facets/platform-docker.yaml](../../contexts/_template/facets/platform-docker.yaml) for MetalLB wiring on docker hosts.
-- [contexts/_template/facets/platform-incus.yaml](../../contexts/_template/facets/platform-incus.yaml) for MetalLB wiring on incus hosts.
-- Related add-ons: [gateway](../gateway/) (data-plane Service consumes lb), [cni](../cni/) (Cilium's L2 announcer is an alternative to lb on Talos, see `cilium/l2`), [policy](../policy/).
+- [contexts/_template/facets/platform-aws.yaml](https://github.com/windsorcli/core/blob/main/contexts/_template/facets/platform-aws.yaml) for aws-lb-controller wiring.
+- [contexts/_template/facets/platform-docker.yaml](https://github.com/windsorcli/core/blob/main/contexts/_template/facets/platform-docker.yaml) for MetalLB wiring on docker hosts.
+- [contexts/_template/facets/platform-incus.yaml](https://github.com/windsorcli/core/blob/main/contexts/_template/facets/platform-incus.yaml) for MetalLB wiring on incus hosts.
+- Related add-ons: [gateway](/reference/blueprints/core/kustomize/gateway) (data-plane Service consumes lb), [cni](/reference/blueprints/core/kustomize/cni) (Cilium's L2 announcer is an alternative to lb on Talos, see `cilium/l2`), [policy](/reference/blueprints/core/kustomize/policy).

--- a/kustomize/object-store/README.md
+++ b/kustomize/object-store/README.md
@@ -98,6 +98,6 @@ on the completed Job, not the Secret.
 
 ## See also
 
-- [contexts/_template/facets/addon-object-store.yaml](../../contexts/_template/facets/addon-object-store.yaml) for the canonical wiring.
-- [kustomize/object-store/resources/common/](resources/common/) for the reference Tenant config (not facet-wired).
-- Related add-ons: [csi](../csi/), [observability](../observability/) (Quickwit log store can use a MinIO Tenant as its object backend).
+- [contexts/_template/facets/addon-object-store.yaml](https://github.com/windsorcli/core/blob/main/contexts/_template/facets/addon-object-store.yaml) for the canonical wiring.
+- [kustomize/object-store/resources/common/](https://github.com/windsorcli/core/tree/main/kustomize/object-store/resources/common) for the reference Tenant config (not facet-wired).
+- Related add-ons: [csi](/reference/blueprints/core/kustomize/csi), [observability](/reference/blueprints/core/kustomize/observability) (Quickwit log store can use a MinIO Tenant as its object backend).

--- a/kustomize/observability/README.md
+++ b/kustomize/observability/README.md
@@ -193,9 +193,9 @@ and Kibana is exposed through the cluster Gateway.
 
 ## See also
 
-- [contexts/_template/facets/addon-observability.yaml](../../contexts/_template/facets/addon-observability.yaml) for the canonical wiring for dashboards and log stores.
-- [contexts/_template/facets/platform-base.yaml](../../contexts/_template/facets/platform-base.yaml) for the fluentd base shipper wiring.
-- [contexts/_template/facets/option-storage.yaml](../../contexts/_template/facets/option-storage.yaml) for Longhorn dashboard injection.
-- [contexts/_template/facets/option-cni.yaml](../../contexts/_template/facets/option-cni.yaml) for Cilium dashboard injection.
-- [contexts/_template/facets/addon-database.yaml](../../contexts/_template/facets/addon-database.yaml) for CloudNativePG dashboard injection.
-- Related add-ons: [telemetry](../telemetry/), [pki](../pki/), [object-store](../object-store/), [csi](../csi/), [gateway](../gateway/), [dns](../dns/).
+- [contexts/_template/facets/addon-observability.yaml](https://github.com/windsorcli/core/blob/main/contexts/_template/facets/addon-observability.yaml) for the canonical wiring for dashboards and log stores.
+- [contexts/_template/facets/platform-base.yaml](https://github.com/windsorcli/core/blob/main/contexts/_template/facets/platform-base.yaml) for the fluentd base shipper wiring.
+- [contexts/_template/facets/option-storage.yaml](https://github.com/windsorcli/core/blob/main/contexts/_template/facets/option-storage.yaml) for Longhorn dashboard injection.
+- [contexts/_template/facets/option-cni.yaml](https://github.com/windsorcli/core/blob/main/contexts/_template/facets/option-cni.yaml) for Cilium dashboard injection.
+- [contexts/_template/facets/addon-database.yaml](https://github.com/windsorcli/core/blob/main/contexts/_template/facets/addon-database.yaml) for CloudNativePG dashboard injection.
+- Related add-ons: [telemetry](/reference/blueprints/core/kustomize/telemetry), [pki](/reference/blueprints/core/kustomize/pki), [object-store](/reference/blueprints/core/kustomize/object-store), [csi](/reference/blueprints/core/kustomize/csi), [gateway](/reference/blueprints/core/kustomize/gateway), [dns](/reference/blueprints/core/kustomize/dns).

--- a/kustomize/pki/README.md
+++ b/kustomize/pki/README.md
@@ -228,8 +228,8 @@ namespaces can mount.
 
 ## See also
 
-- [contexts/_template/facets/platform-base.yaml](../../contexts/_template/facets/platform-base.yaml) for the base cert-manager and selfsigned defaults.
-- [contexts/_template/facets/platform-aws.yaml](../../contexts/_template/facets/platform-aws.yaml) for ACME on Route53 wiring.
-- [contexts/_template/facets/platform-azure.yaml](../../contexts/_template/facets/platform-azure.yaml) for ACME on AzureDNS plus workload-identity wiring.
-- [contexts/_template/facets/addon-private-ca.yaml](../../contexts/_template/facets/addon-private-ca.yaml) for trust-manager and private CA wiring.
-- Related add-ons: [policy](../policy/), [telemetry](../telemetry/), [gateway](../gateway/) (consumes the ClusterIssuer for the external gateway cert), [observability](../observability/) (Elasticsearch consumes the private CA).
+- [contexts/_template/facets/platform-base.yaml](https://github.com/windsorcli/core/blob/main/contexts/_template/facets/platform-base.yaml) for the base cert-manager and selfsigned defaults.
+- [contexts/_template/facets/platform-aws.yaml](https://github.com/windsorcli/core/blob/main/contexts/_template/facets/platform-aws.yaml) for ACME on Route53 wiring.
+- [contexts/_template/facets/platform-azure.yaml](https://github.com/windsorcli/core/blob/main/contexts/_template/facets/platform-azure.yaml) for ACME on AzureDNS plus workload-identity wiring.
+- [contexts/_template/facets/addon-private-ca.yaml](https://github.com/windsorcli/core/blob/main/contexts/_template/facets/addon-private-ca.yaml) for trust-manager and private CA wiring.
+- Related add-ons: [policy](/reference/blueprints/core/kustomize/policy), [telemetry](/reference/blueprints/core/kustomize/telemetry), [gateway](/reference/blueprints/core/kustomize/gateway) (consumes the ClusterIssuer for the external gateway cert), [observability](/reference/blueprints/core/kustomize/observability) (Elasticsearch consumes the private CA).

--- a/kustomize/policy/README.md
+++ b/kustomize/policy/README.md
@@ -140,7 +140,7 @@ to add your own.
 
 ## See also
 
-- [contexts/_template/facets/platform-base.yaml](../../contexts/_template/facets/platform-base.yaml) for the canonical wiring for both facets.
-- [kustomize/policy/resources/kyverno/resource-limits-requests/cluster-policies.yaml](resources/kyverno/resource-limits-requests/cluster-policies.yaml) for the Audit policy.
-- [kustomize/policy/resources/kyverno/require-image-digest/cluster-policy.yaml](resources/kyverno/require-image-digest/cluster-policy.yaml) for the Enforce policy.
-- Related add-ons: [observability](../observability/) (`grafana/dashboards/*` for Kyverno metrics if added), [cni](../cni/) (depends on `policy-resources` for the cilium/gateway LBIPAM ClusterPolicy).
+- [contexts/_template/facets/platform-base.yaml](https://github.com/windsorcli/core/blob/main/contexts/_template/facets/platform-base.yaml) for the canonical wiring for both facets.
+- [kustomize/policy/resources/kyverno/resource-limits-requests/cluster-policies.yaml](https://github.com/windsorcli/core/blob/main/kustomize/policy/resources/kyverno/resource-limits-requests/cluster-policies.yaml) for the Audit policy.
+- [kustomize/policy/resources/kyverno/require-image-digest/cluster-policy.yaml](https://github.com/windsorcli/core/blob/main/kustomize/policy/resources/kyverno/require-image-digest/cluster-policy.yaml) for the Enforce policy.
+- Related add-ons: [observability](/reference/blueprints/core/kustomize/observability) (`grafana/dashboards/*` for Kyverno metrics if added), [cni](/reference/blueprints/core/kustomize/cni) (depends on `policy-resources` for the cilium/gateway LBIPAM ClusterPolicy).

--- a/kustomize/telemetry/README.md
+++ b/kustomize/telemetry/README.md
@@ -171,6 +171,6 @@ removed and `filebeat` is added.
 
 ## See also
 
-- [contexts/_template/facets/platform-base.yaml](../../contexts/_template/facets/platform-base.yaml) for the canonical wiring for both facets.
-- [contexts/_template/facets/addon-observability.yaml](../../contexts/_template/facets/addon-observability.yaml) for the Elasticsearch override (replaces telemetry-base with filebeat).
-- Related add-ons: [observability](../observability/) (Grafana / log store downstream of telemetry), [policy](../policy/) (admission policies apply to system-telemetry pods).
+- [contexts/_template/facets/platform-base.yaml](https://github.com/windsorcli/core/blob/main/contexts/_template/facets/platform-base.yaml) for the canonical wiring for both facets.
+- [contexts/_template/facets/addon-observability.yaml](https://github.com/windsorcli/core/blob/main/contexts/_template/facets/addon-observability.yaml) for the Elasticsearch override (replaces telemetry-base with filebeat).
+- Related add-ons: [observability](/reference/blueprints/core/kustomize/observability) (Grafana / log store downstream of telemetry), [policy](/reference/blueprints/core/kustomize/policy) (admission policies apply to system-telemetry pods).

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -16,31 +16,31 @@ layer. Links from there land here.
 
 | Path | Purpose |
 |---|---|
-| [backend](backend/) | Remote Terraform state for cloud contexts (S3, AzureRM). |
-| [backend/azurerm](backend/azurerm/) | Remote Terraform state on Azure Blob + native lease. |
-| [backend/s3](backend/s3/) | Remote Terraform state on S3 + DynamoDB lock. |
-| [cluster](cluster/) | Kubernetes control plane provisioning across Talos, EKS, and AKS. |
-| [cluster/aws-eks](cluster/aws-eks/) | Managed Kubernetes control plane on AWS. |
-| [cluster/aws-eks/additions](cluster/aws-eks/additions/) | system-dns namespace and external-dns ConfigMap for EKS. |
-| [cluster/azure-aks](cluster/azure-aks/) | Managed Kubernetes control plane on Azure. |
-| [cluster/talos](cluster/talos/) | Self-hosted Kubernetes control plane via the Talos API. |
-| [cluster/talos/config](cluster/talos/config/) | Per-node Talos machine config + CIDATA seeds. |
-| [cluster/talos/extensions](cluster/talos/extensions/) | Talos image build with system extensions. |
-| [cni](cni/) | Out-of-band Cilium bootstrap for Talos clusters before Flux. |
-| [cni/cilium](cni/cilium/) | Out-of-band Cilium bootstrap for Talos clusters. |
-| [compute](compute/) | Local Talos compute substrate across Docker, Hyper-V, and Incus. |
-| [compute/docker](compute/docker/) | Talos containers on Docker. |
-| [compute/hyperv](compute/hyperv/) | Talos VMs on Hyper-V (Windows host). |
-| [compute/incus](compute/incus/) | Talos VMs on Incus. |
-| [dns](dns/) | Public DNS zones for ACME certificates and external-dns. |
-| [dns/zone/azure-dns](dns/zone/azure-dns/) | DNS zone on Azure DNS. |
-| [dns/zone/route53](dns/zone/route53/) | Public DNS zone on AWS Route53. |
-| [gitops](gitops/) | Flux installation that hands reconciliation to the kustomize layer. |
-| [gitops/flux](gitops/flux/) | Flux installation; hands reconciliation to the kustomize/ layer. |
-| [network](network/) | Cloud network fabric for managed Kubernetes clusters. |
-| [network/aws-vpc](network/aws-vpc/) | VPC + public/private subnets + NAT for EKS. |
-| [network/azure-vnet](network/azure-vnet/) | VNet + subnets for AKS. |
-| [workstation](workstation/) | Local-host networking, registry, and DNS for developer clusters. |
-| [workstation/docker](workstation/docker/) | Local-host Docker network + registry. |
-| [workstation/incus](workstation/incus/) | Local-host Incus bridge + registry. |
+| [backend](/reference/blueprints/core/terraform/backend) | Remote Terraform state for cloud contexts (S3, AzureRM). |
+| [backend/azurerm](/reference/blueprints/core/terraform/backend/azurerm) | Remote Terraform state on Azure Blob + native lease. |
+| [backend/s3](/reference/blueprints/core/terraform/backend/s3) | Remote Terraform state on S3 + DynamoDB lock. |
+| [cluster](/reference/blueprints/core/terraform/cluster) | Kubernetes control plane provisioning across Talos, EKS, and AKS. |
+| [cluster/aws-eks](/reference/blueprints/core/terraform/cluster/aws-eks) | Managed Kubernetes control plane on AWS. |
+| [cluster/aws-eks/additions](/reference/blueprints/core/terraform/cluster/aws-eks/additions) | system-dns namespace and external-dns ConfigMap for EKS. |
+| [cluster/azure-aks](/reference/blueprints/core/terraform/cluster/azure-aks) | Managed Kubernetes control plane on Azure. |
+| [cluster/talos](/reference/blueprints/core/terraform/cluster/talos) | Self-hosted Kubernetes control plane via the Talos API. |
+| [cluster/talos/config](/reference/blueprints/core/terraform/cluster/talos/config) | Per-node Talos machine config + CIDATA seeds. |
+| [cluster/talos/extensions](/reference/blueprints/core/terraform/cluster/talos/extensions) | Talos image build with system extensions. |
+| [cni](/reference/blueprints/core/terraform/cni) | Out-of-band Cilium bootstrap for Talos clusters before Flux. |
+| [cni/cilium](/reference/blueprints/core/terraform/cni/cilium) | Out-of-band Cilium bootstrap for Talos clusters. |
+| [compute](/reference/blueprints/core/terraform/compute) | Local Talos compute substrate across Docker, Hyper-V, and Incus. |
+| [compute/docker](/reference/blueprints/core/terraform/compute/docker) | Talos containers on Docker. |
+| [compute/hyperv](/reference/blueprints/core/terraform/compute/hyperv) | Talos VMs on Hyper-V (Windows host). |
+| [compute/incus](/reference/blueprints/core/terraform/compute/incus) | Talos VMs on Incus. |
+| [dns](/reference/blueprints/core/terraform/dns) | Public DNS zones for ACME certificates and external-dns. |
+| [dns/zone/azure-dns](/reference/blueprints/core/terraform/dns/zone/azure-dns) | DNS zone on Azure DNS. |
+| [dns/zone/route53](/reference/blueprints/core/terraform/dns/zone/route53) | Public DNS zone on AWS Route53. |
+| [gitops](/reference/blueprints/core/terraform/gitops) | Flux installation that hands reconciliation to the kustomize layer. |
+| [gitops/flux](/reference/blueprints/core/terraform/gitops/flux) | Flux installation; hands reconciliation to the kustomize/ layer. |
+| [network](/reference/blueprints/core/terraform/network) | Cloud network fabric for managed Kubernetes clusters. |
+| [network/aws-vpc](/reference/blueprints/core/terraform/network/aws-vpc) | VPC + public/private subnets + NAT for EKS. |
+| [network/azure-vnet](/reference/blueprints/core/terraform/network/azure-vnet) | VNet + subnets for AKS. |
+| [workstation](/reference/blueprints/core/terraform/workstation) | Local-host networking, registry, and DNS for developer clusters. |
+| [workstation/docker](/reference/blueprints/core/terraform/workstation/docker) | Local-host Docker network + registry. |
+| [workstation/incus](/reference/blueprints/core/terraform/workstation/incus) | Local-host Incus bridge + registry. |
 <!-- END_INDEX -->

--- a/terraform/backend/README.md
+++ b/terraform/backend/README.md
@@ -137,6 +137,6 @@ production.
 
 ## See also
 
-- [s3/](s3/) and [azurerm/](azurerm/) for the per-driver Terraform reference.
+- [s3/](/reference/blueprints/core/terraform/backend/s3) and [azurerm/](/reference/blueprints/core/terraform/backend/azurerm) for the per-driver Terraform reference.
 - [Terraform backend docs](https://developer.hashicorp.com/terraform/language/backend) for the upstream backend reference.
-- [../cluster/](../cluster/) and [../network/](../network/) for the downstream stacks that read state from the backend.
+- [../cluster/](/reference/blueprints/core/terraform/cluster) and [../network/](/reference/blueprints/core/terraform/network) for the downstream stacks that read state from the backend.

--- a/terraform/cluster/README.md
+++ b/terraform/cluster/README.md
@@ -174,8 +174,8 @@ worth reconsidering for anything multi-tenant.
 
 ## See also
 
-- [talos/](talos/), [aws-eks/](aws-eks/), [azure-aks/](azure-aks/) for the per-driver Terraform reference.
-- [../network/](../network/) for the VPC and VNet modules that back the cluster on AWS and Azure.
-- [../compute/](../compute/) for Talos compute providers.
-- [../cni/](../cni/) for the Cilium bootstrap module on Talos.
-- [../../kustomize/cni/](../../kustomize/cni/), [../../kustomize/csi/](../../kustomize/csi/), and [../../kustomize/pki/](../../kustomize/pki/) for the kustomize add-ons that adopt the cluster.
+- [talos/](/reference/blueprints/core/terraform/cluster/talos), [aws-eks/](/reference/blueprints/core/terraform/cluster/aws-eks), [azure-aks/](/reference/blueprints/core/terraform/cluster/azure-aks) for the per-driver Terraform reference.
+- [../network/](/reference/blueprints/core/terraform/network) for the VPC and VNet modules that back the cluster on AWS and Azure.
+- [../compute/](/reference/blueprints/core/terraform/compute) for Talos compute providers.
+- [../cni/](/reference/blueprints/core/terraform/cni) for the Cilium bootstrap module on Talos.
+- [../../kustomize/cni/](/reference/blueprints/core/kustomize/cni), [../../kustomize/csi/](/reference/blueprints/core/kustomize/csi), and [../../kustomize/pki/](/reference/blueprints/core/kustomize/pki) for the kustomize add-ons that adopt the cluster.

--- a/terraform/cni/README.md
+++ b/terraform/cni/README.md
@@ -75,6 +75,6 @@ entirely. Flannel is the Talos built-in and needs no bootstrap.
 
 ## See also
 
-- [cilium/](cilium/) for the per-module Terraform reference.
-- [../../kustomize/cni/](../../kustomize/cni/) for the adopting HelmRelease and the full operational guide for Cilium (substitutions, components, dependencies).
-- [../cluster/](../cluster/) for the cluster module that produces the kubeconfig this bootstrap uses.
+- [cilium/](/reference/blueprints/core/terraform/cni/cilium) for the per-module Terraform reference.
+- [../../kustomize/cni/](/reference/blueprints/core/kustomize/cni) for the adopting HelmRelease and the full operational guide for Cilium (substitutions, components, dependencies).
+- [../cluster/](/reference/blueprints/core/terraform/cluster) for the cluster module that produces the kubeconfig this bootstrap uses.

--- a/terraform/compute/README.md
+++ b/terraform/compute/README.md
@@ -171,7 +171,7 @@ operator's workstation in cleartext.
 
 ## See also
 
-- [docker/](docker/), [hyperv/](hyperv/), and [incus/](incus/) for the per-driver Terraform reference.
-- [../cluster/](../cluster/) for the Talos control plane that adopts the compute nodes.
-- [../workstation/](../workstation/) for the host-side networking (registry, DNS) that local clusters depend on.
-- [../network/](../network/) for the cloud networking modules, which are skipped on local compute.
+- [docker/](/reference/blueprints/core/terraform/compute/docker), [hyperv/](/reference/blueprints/core/terraform/compute/hyperv), and [incus/](/reference/blueprints/core/terraform/compute/incus) for the per-driver Terraform reference.
+- [../cluster/](/reference/blueprints/core/terraform/cluster) for the Talos control plane that adopts the compute nodes.
+- [../workstation/](/reference/blueprints/core/terraform/workstation) for the host-side networking (registry, DNS) that local clusters depend on.
+- [../network/](/reference/blueprints/core/terraform/network) for the cloud networking modules, which are skipped on local compute.

--- a/terraform/dns/README.md
+++ b/terraform/dns/README.md
@@ -144,7 +144,7 @@ verification.
 
 ## See also
 
-- [zone/route53/](zone/route53/) and [zone/azure-dns/](zone/azure-dns/) for the per-driver Terraform reference.
-- [../cluster/](../cluster/) for the cluster module that provisions the identity binding (IAM Pod Identity, Workload Identity).
-- [../../kustomize/pki/](../../kustomize/pki/) for cert-manager and the ClusterIssuers.
-- [../../kustomize/dns/](../../kustomize/dns/) for the external-dns reconciler.
+- [zone/route53/](/reference/blueprints/core/terraform/dns/zone/route53) and [zone/azure-dns/](/reference/blueprints/core/terraform/dns/zone/azure-dns) for the per-driver Terraform reference.
+- [../cluster/](/reference/blueprints/core/terraform/cluster) for the cluster module that provisions the identity binding (IAM Pod Identity, Workload Identity).
+- [../../kustomize/pki/](/reference/blueprints/core/kustomize/pki) for cert-manager and the ClusterIssuers.
+- [../../kustomize/dns/](/reference/blueprints/core/kustomize/dns) for the external-dns reconciler.

--- a/terraform/gitops/README.md
+++ b/terraform/gitops/README.md
@@ -118,6 +118,6 @@ values file.
 
 ## See also
 
-- [flux/](flux/) for the per-module Terraform reference.
-- [../cluster/](../cluster/) for the cluster module that produces the kubeconfig used here.
-- [../../kustomize/](../../kustomize/) for the layer Flux reconciles once the install completes.
+- [flux/](/reference/blueprints/core/terraform/gitops/flux) for the per-module Terraform reference.
+- [../cluster/](/reference/blueprints/core/terraform/cluster) for the cluster module that produces the kubeconfig used here.
+- [../../kustomize/](/reference/blueprints/core/kustomize) for the layer Flux reconciles once the install completes.

--- a/terraform/network/README.md
+++ b/terraform/network/README.md
@@ -142,7 +142,7 @@ the subnet layer.
 
 ## See also
 
-- [aws-vpc/](aws-vpc/) and [azure-vnet/](azure-vnet/) for the per-driver Terraform reference.
-- [../cluster/](../cluster/) for the managed-cluster modules that consume the network.
-- [../dns/](../dns/) for the public DNS zones (the private zone inside the VPC module is separate).
-- [../compute/](../compute/) for the local compute drivers that create their own host networking.
+- [aws-vpc/](/reference/blueprints/core/terraform/network/aws-vpc) and [azure-vnet/](/reference/blueprints/core/terraform/network/azure-vnet) for the per-driver Terraform reference.
+- [../cluster/](/reference/blueprints/core/terraform/cluster) for the managed-cluster modules that consume the network.
+- [../dns/](/reference/blueprints/core/terraform/dns) for the public DNS zones (the private zone inside the VPC module is separate).
+- [../compute/](/reference/blueprints/core/terraform/compute) for the local compute drivers that create their own host networking.

--- a/terraform/workstation/README.md
+++ b/terraform/workstation/README.md
@@ -114,6 +114,6 @@ LAN from the VMs unless the host firewall rules are added explicitly.
 
 ## See also
 
-- [docker/](docker/) and [incus/](incus/) for the per-driver Terraform reference.
-- [../compute/](../compute/) for the compute drivers that attach to the workstation network.
-- [../network/](../network/) for `network.cidr_block`, which is the shared knob for both layers.
+- [docker/](/reference/blueprints/core/terraform/workstation/docker) and [incus/](/reference/blueprints/core/terraform/workstation/incus) for the per-driver Terraform reference.
+- [../compute/](/reference/blueprints/core/terraform/compute) for the compute drivers that attach to the workstation network.
+- [../network/](/reference/blueprints/core/terraform/network) for `network.cidr_block`, which is the shared knob for both layers.


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> The change replaces relative inter-module links across 23 README files with absolute paths, splitting where those links resolve depending on the reader's context — a trade-off that will affect anyone browsing the repository on GitHub.
>
> **Overview**
>
> This PR retargets every "See also" cross-reference in the `kustomize/` and `terraform/` READMEs from repo-relative paths to docs-site paths (`/reference/blueprints/core/...`). Facet YAML and raw code directory links are separately retargeted to absolute `github.com/blob/main` or `tree/main` URLs. The substitution is mechanical and consistent across all 23 files.
>
> The `/reference/...` paths only resolve when the READMEs are rendered through the docs website; clicking them from GitHub's native file browser or an IDE returns a 404. The original relative paths worked in both contexts. One exception is the `ingress` add-on in `kustomize/demo/README.md`, which keeps a GitHub tree URL — presumably because no corresponding docs-site page for `ingress` exists yet.
>
> Reviewed by Claude for commit `0c6ba35`.

<!-- /claude-code-review:summary -->
