### PR TITLE
fix(cluster): add null guards for autoscaling validation in pools

### DIFF
--- a/terraform/backend/azurerm/test.tftest.hcl
+++ b/terraform/backend/azurerm/test.tftest.hcl
@@ -148,7 +148,7 @@ run "backend_config_without_context_path" {
   }
 
   assert {
-    condition     = local_file.backend_config == null || length(local_file.backend_config) == 0
+    condition     = try(length(local_file.backend_config), 0) == 0
     error_message = "No backend config should be generated without context path"
   }
 }

--- a/terraform/backend/s3/test.tftest.hcl
+++ b/terraform/backend/s3/test.tftest.hcl
@@ -105,7 +105,7 @@ run "noncurrent_versions_expire_on_90_day_lifecycle" {
   assert {
     condition = length([
       for rule in aws_s3_bucket_lifecycle_configuration.this.rule :
-      rule if rule.id == "expire-noncurrent-versions" && length(rule.noncurrent_version_expiration) > 0 && rule.noncurrent_version_expiration[0].noncurrent_days == 90
+      rule if rule.id == "expire-noncurrent-versions" && try(rule.noncurrent_version_expiration[0].noncurrent_days == 90, false)
     ]) == 1
     error_message = "expire-noncurrent-versions rule must expire noncurrent versions after 90 days."
   }

--- a/terraform/cluster/aws-eks/README.md
+++ b/terraform/cluster/aws-eks/README.md
@@ -20,13 +20,13 @@ and EBS CSI driver helpers that EKS expects out-of-band.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 6.51.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 6.52.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.52.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | 2.6.1 |
 | <a name="provider_null"></a> [null](#provider\_null) | 3.2.4 |
 
@@ -38,71 +38,71 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_autoscaling_group_tag.cluster_autoscaler_enabled](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/autoscaling_group_tag) | resource |
-| [aws_autoscaling_group_tag.cluster_autoscaler_owned](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/autoscaling_group_tag) | resource |
-| [aws_cloudwatch_event_rule.karpenter](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/cloudwatch_event_rule) | resource |
-| [aws_cloudwatch_event_target.karpenter](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/cloudwatch_event_target) | resource |
-| [aws_cloudwatch_log_group.eks_cluster](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/cloudwatch_log_group) | resource |
-| [aws_ec2_tag.karpenter_discovery_sg](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/ec2_tag) | resource |
-| [aws_ec2_tag.karpenter_discovery_subnet](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/ec2_tag) | resource |
-| [aws_eks_addon.main](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/eks_addon) | resource |
-| [aws_eks_cluster.main](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/eks_cluster) | resource |
-| [aws_eks_fargate_profile.main](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/eks_fargate_profile) | resource |
-| [aws_eks_node_group.main](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/eks_node_group) | resource |
-| [aws_eks_pod_identity_association.aws_lb_controller](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/eks_pod_identity_association) | resource |
-| [aws_eks_pod_identity_association.cert_manager](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/eks_pod_identity_association) | resource |
-| [aws_eks_pod_identity_association.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/eks_pod_identity_association) | resource |
-| [aws_eks_pod_identity_association.external_dns](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/eks_pod_identity_association) | resource |
-| [aws_eks_pod_identity_association.karpenter](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/eks_pod_identity_association) | resource |
-| [aws_iam_instance_profile.karpenter_node](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_instance_profile) | resource |
-| [aws_iam_policy.aws_lb_controller](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.cert_manager](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.external_dns](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.karpenter_controller](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.pod_identity_agent](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_policy) | resource |
-| [aws_iam_role.aws_lb_controller](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.cert_manager](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.cluster](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.ebs_csi](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.efs_csi](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.external_dns](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.fargate](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.karpenter_controller](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.karpenter_node](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.node_group](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.pod_identity_agent](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.vpc_cni](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy_attachment.aws_lb_controller](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.cert_manager](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.cluster_AmazonEKSClusterPolicy](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.cluster_AmazonEKSVPCResourceController](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.ebs_csi](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.efs_csi](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.external_dns](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.fargate_pod_execution_role_policy](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.karpenter_controller](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.karpenter_node](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.node_group_AmazonEC2ContainerRegistryReadOnly](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.node_group_AmazonEKSWorkerNodePolicy](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.node_group_AmazonEKS_CNI_Policy](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.pod_identity_agent](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.vpc_cni](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_kms_alias.ebs_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/kms_alias) | resource |
-| [aws_kms_alias.eks_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/kms_alias) | resource |
-| [aws_kms_key.ebs_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/kms_key) | resource |
-| [aws_kms_key.eks_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/kms_key) | resource |
-| [aws_launch_template.node_group](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/launch_template) | resource |
-| [aws_security_group.cluster_api_access](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/security_group) | resource |
-| [aws_sqs_queue.karpenter](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/sqs_queue) | resource |
-| [aws_sqs_queue_policy.karpenter](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/sqs_queue_policy) | resource |
+| [aws_autoscaling_group_tag.cluster_autoscaler_enabled](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/autoscaling_group_tag) | resource |
+| [aws_autoscaling_group_tag.cluster_autoscaler_owned](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/autoscaling_group_tag) | resource |
+| [aws_cloudwatch_event_rule.karpenter](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_target.karpenter](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/cloudwatch_event_target) | resource |
+| [aws_cloudwatch_log_group.eks_cluster](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/cloudwatch_log_group) | resource |
+| [aws_ec2_tag.karpenter_discovery_sg](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/ec2_tag) | resource |
+| [aws_ec2_tag.karpenter_discovery_subnet](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/ec2_tag) | resource |
+| [aws_eks_addon.main](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/eks_addon) | resource |
+| [aws_eks_cluster.main](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/eks_cluster) | resource |
+| [aws_eks_fargate_profile.main](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/eks_fargate_profile) | resource |
+| [aws_eks_node_group.main](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/eks_node_group) | resource |
+| [aws_eks_pod_identity_association.aws_lb_controller](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/eks_pod_identity_association) | resource |
+| [aws_eks_pod_identity_association.cert_manager](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/eks_pod_identity_association) | resource |
+| [aws_eks_pod_identity_association.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/eks_pod_identity_association) | resource |
+| [aws_eks_pod_identity_association.external_dns](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/eks_pod_identity_association) | resource |
+| [aws_eks_pod_identity_association.karpenter](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/eks_pod_identity_association) | resource |
+| [aws_iam_instance_profile.karpenter_node](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_instance_profile) | resource |
+| [aws_iam_policy.aws_lb_controller](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.cert_manager](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.external_dns](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.karpenter_controller](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.pod_identity_agent](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_policy) | resource |
+| [aws_iam_role.aws_lb_controller](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_role) | resource |
+| [aws_iam_role.cert_manager](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_role) | resource |
+| [aws_iam_role.cluster](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_role) | resource |
+| [aws_iam_role.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_role) | resource |
+| [aws_iam_role.ebs_csi](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_role) | resource |
+| [aws_iam_role.efs_csi](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_role) | resource |
+| [aws_iam_role.external_dns](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_role) | resource |
+| [aws_iam_role.fargate](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_role) | resource |
+| [aws_iam_role.karpenter_controller](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_role) | resource |
+| [aws_iam_role.karpenter_node](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_role) | resource |
+| [aws_iam_role.node_group](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_role) | resource |
+| [aws_iam_role.pod_identity_agent](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_role) | resource |
+| [aws_iam_role.vpc_cni](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.aws_lb_controller](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.cert_manager](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.cluster_AmazonEKSClusterPolicy](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.cluster_AmazonEKSVPCResourceController](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.ebs_csi](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.efs_csi](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.external_dns](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.fargate_pod_execution_role_policy](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.karpenter_controller](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.karpenter_node](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.node_group_AmazonEC2ContainerRegistryReadOnly](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.node_group_AmazonEKSWorkerNodePolicy](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.node_group_AmazonEKS_CNI_Policy](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.pod_identity_agent](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.vpc_cni](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_kms_alias.ebs_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/kms_alias) | resource |
+| [aws_kms_alias.eks_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/kms_alias) | resource |
+| [aws_kms_key.ebs_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/kms_key) | resource |
+| [aws_kms_key.eks_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/kms_key) | resource |
+| [aws_launch_template.node_group](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/launch_template) | resource |
+| [aws_security_group.cluster_api_access](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/security_group) | resource |
+| [aws_sqs_queue.karpenter](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/sqs_queue) | resource |
+| [aws_sqs_queue_policy.karpenter](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/sqs_queue_policy) | resource |
 | [local_sensitive_file.kubeconfig](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/sensitive_file) | resource |
 | [null_resource.create_kubeconfig_dir](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/data-sources/caller_identity) | data source |
-| [aws_eks_addon_version.default](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/data-sources/eks_addon_version) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/data-sources/region) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/data-sources/caller_identity) | data source |
+| [aws_eks_addon_version.default](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/data-sources/eks_addon_version) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/data-sources/region) | data source |
 
 ## Inputs
 

--- a/terraform/cluster/aws-eks/main.tf
+++ b/terraform/cluster/aws-eks/main.tf
@@ -321,7 +321,7 @@ locals {
   # otherwise system-class pools are fixed and every other class autoscales.
   pools_autoscaling = {
     for name, p in var.pools : name => {
-      enabled = p.autoscaling != null && p.autoscaling.enabled != null ? p.autoscaling.enabled : p.class != "system"
+      enabled = try(p.autoscaling.enabled, null) != null ? p.autoscaling.enabled : p.class != "system"
       min     = p.autoscaling != null ? p.autoscaling.min : null
       max     = p.autoscaling != null ? p.autoscaling.max : null
     }
@@ -329,7 +329,7 @@ locals {
 
   pools_node_groups = {
     for name, p in var.pools : name => {
-      instance_types = p.instance_types != null && length(p.instance_types) > 0 ? p.instance_types : lookup(var.class_instance_types, p.class, null)
+      instance_types = try(length(p.instance_types), 0) > 0 ? p.instance_types : lookup(var.class_instance_types, p.class, null)
       capacity_type  = p.lifecycle == "spot" ? "SPOT" : "ON_DEMAND"
       # desired_size is set once; the autoscaler owns it thereafter (ignore_changes).
       desired_size = p.count

--- a/terraform/cluster/aws-eks/variables.tf
+++ b/terraform/cluster/aws-eks/variables.tf
@@ -100,7 +100,7 @@ variable "private_subnet_ids" {
   type        = list(string)
   default     = null
   validation {
-    condition     = var.private_subnet_ids != null && length(var.private_subnet_ids) > 0
+    condition     = try(length(var.private_subnet_ids), 0) > 0
     error_message = "private_subnet_ids is required and must be non-empty. The tag-based subnet discovery this module previously used has been removed; pipe network/aws-vpc's private_subnet_ids output, e.g. inputs.private_subnet_ids = terraform_output('network', 'private_subnet_ids') in the platform-aws facet."
   }
 }
@@ -193,8 +193,7 @@ variable "pools" {
   validation {
     condition = alltrue([
       for k, v in var.pools :
-      v.autoscaling == null || v.autoscaling.min == null || v.autoscaling.max == null
-      || v.autoscaling.min <= v.autoscaling.max
+      try(v.autoscaling.min <= v.autoscaling.max, true)
     ])
     error_message = "Each pool's autoscaling.min must be <= autoscaling.max."
   }
@@ -205,10 +204,11 @@ variable "pools" {
   validation {
     condition = alltrue([
       for k, v in var.pools :
-      v.autoscaling == null
-      || v.autoscaling.enabled == false
-      || (v.autoscaling.enabled == null && v.class == "system")
-      || (v.count >= coalesce(v.autoscaling.min, min(v.count, 1)) && v.count <= coalesce(v.autoscaling.max, max(v.count, 3)))
+      v.autoscaling == null ? true : (
+        v.autoscaling.enabled == false
+        || (v.autoscaling.enabled == null && v.class == "system")
+        || (v.count >= coalesce(v.autoscaling.min, min(v.count, 1)) && v.count <= coalesce(v.autoscaling.max, max(v.count, 3)))
+      )
     ])
     error_message = "When a pool autoscales (explicitly or by class default), count must be within [min, max]."
   }

--- a/terraform/cluster/aws-eks/variables.tf
+++ b/terraform/cluster/aws-eks/variables.tf
@@ -94,7 +94,7 @@ variable "private_subnet_ids" {
   type        = list(string)
   default     = null
   validation {
-    condition     = var.private_subnet_ids != null && length(var.private_subnet_ids) > 0
+    condition     = try(length(var.private_subnet_ids), 0) > 0
     error_message = "private_subnet_ids is required and must be non-empty. The tag-based subnet discovery this module previously used has been removed; pipe network/aws-vpc's private_subnet_ids output, e.g. inputs.private_subnet_ids = terraform_output('network', 'private_subnet_ids') in the platform-aws facet."
   }
 }
@@ -187,8 +187,7 @@ variable "pools" {
   validation {
     condition = alltrue([
       for k, v in var.pools :
-      v.autoscaling == null || v.autoscaling.min == null || v.autoscaling.max == null
-      || v.autoscaling.min <= v.autoscaling.max
+      try(v.autoscaling.min <= v.autoscaling.max, true)
     ])
     error_message = "Each pool's autoscaling.min must be <= autoscaling.max."
   }
@@ -199,10 +198,11 @@ variable "pools" {
   validation {
     condition = alltrue([
       for k, v in var.pools :
-      v.autoscaling == null
-      || v.autoscaling.enabled == false
-      || (v.autoscaling.enabled == null && v.class == "system")
-      || (v.count >= coalesce(v.autoscaling.min, min(v.count, 1)) && v.count <= coalesce(v.autoscaling.max, max(v.count, 3)))
+      v.autoscaling == null ? true : (
+        v.autoscaling.enabled == false
+        || (v.autoscaling.enabled == null && v.class == "system")
+        || (v.count >= coalesce(v.autoscaling.min, min(v.count, 1)) && v.count <= coalesce(v.autoscaling.max, max(v.count, 3)))
+      )
     ])
     error_message = "When a pool autoscales (explicitly or by class default), count must be within [min, max]."
   }

--- a/terraform/cluster/azure-aks/README.md
+++ b/terraform/cluster/azure-aks/README.md
@@ -65,14 +65,14 @@ The next apply will then only show creates.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.78.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.79.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.78.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.79.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | 3.3.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.8.1 |
 | <a name="provider_time"></a> [time](#provider\_time) | 0.13.1 |

--- a/terraform/cluster/azure-aks/main.tf
+++ b/terraform/cluster/azure-aks/main.tf
@@ -458,7 +458,7 @@ locals {
   # otherwise system-class pools are fixed and every other class autoscales.
   pools_autoscaling = {
     for name, p in local.effective_pools : name => {
-      enabled = p.autoscaling != null && p.autoscaling.enabled != null ? p.autoscaling.enabled : p.class != "system"
+      enabled = try(p.autoscaling.enabled, null) != null ? p.autoscaling.enabled : p.class != "system"
       min     = p.autoscaling != null ? p.autoscaling.min : null
       max     = p.autoscaling != null ? p.autoscaling.max : null
     }
@@ -466,7 +466,7 @@ locals {
 
   pools_resolved = {
     for name, p in local.effective_pools : name => {
-      vm_size = (p.instance_types != null && length(p.instance_types) > 0
+      vm_size = (try(length(p.instance_types), 0) > 0
         ? p.instance_types[0]
       : lookup(var.class_instance_types, p.class, [""])[0])
       priority        = p.lifecycle == "spot" ? "Spot" : "Regular"

--- a/terraform/cluster/azure-aks/variables.tf
+++ b/terraform/cluster/azure-aks/variables.tf
@@ -43,7 +43,7 @@ variable "private_subnet_ids" {
   type        = list(string)
   default     = null
   validation {
-    condition     = var.private_subnet_ids != null && length(var.private_subnet_ids) > 0
+    condition     = try(length(var.private_subnet_ids), 0) > 0
     error_message = "private_subnet_ids is required and must be non-empty. The VNet/subnet data lookup this module previously used has been removed; pipe network/azure-vnet's private_subnet_ids output, e.g. inputs.private_subnet_ids = terraform_output('network', 'private_subnet_ids') in the platform-azure facet."
   }
 }
@@ -161,8 +161,7 @@ variable "pools" {
   validation {
     condition = alltrue([
       for k, v in var.pools :
-      v.autoscaling == null || v.autoscaling.min == null || v.autoscaling.max == null
-      || v.autoscaling.min <= v.autoscaling.max
+      try(v.autoscaling.min <= v.autoscaling.max, true)
     ])
     error_message = "Each pool's autoscaling.min must be <= autoscaling.max."
   }
@@ -173,10 +172,11 @@ variable "pools" {
   validation {
     condition = alltrue([
       for k, v in var.pools :
-      v.autoscaling == null
-      || v.autoscaling.enabled == false
-      || (v.autoscaling.enabled == null && v.class == "system")
-      || (v.count >= coalesce(v.autoscaling.min, min(v.count, 1)) && v.count <= coalesce(v.autoscaling.max, max(v.count, 3)))
+      v.autoscaling == null ? true : (
+        v.autoscaling.enabled == false
+        || (v.autoscaling.enabled == null && v.class == "system")
+        || (v.count >= coalesce(v.autoscaling.min, min(v.count, 1)) && v.count <= coalesce(v.autoscaling.max, max(v.count, 3)))
+      )
     ])
     error_message = "When a pool autoscales (explicitly or by class default), count must be within [min, max]."
   }

--- a/terraform/compute/docker/README.md
+++ b/terraform/compute/docker/README.md
@@ -17,13 +17,13 @@ brings up via the Talos API.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
-| <a name="requirement_docker"></a> [docker](#requirement\_docker) | 4.4.0 |
+| <a name="requirement_docker"></a> [docker](#requirement\_docker) | 4.5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_docker"></a> [docker](#provider\_docker) | 4.4.0 |
+| <a name="provider_docker"></a> [docker](#provider\_docker) | 4.5.0 |
 
 ## Modules
 
@@ -33,10 +33,10 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [docker_container.containers](https://registry.terraform.io/providers/kreuzwerker/docker/4.4.0/docs/resources/container) | resource |
-| [docker_image.instances](https://registry.terraform.io/providers/kreuzwerker/docker/4.4.0/docs/resources/image) | resource |
-| [docker_network.main](https://registry.terraform.io/providers/kreuzwerker/docker/4.4.0/docs/resources/network) | resource |
-| [docker_volume.named](https://registry.terraform.io/providers/kreuzwerker/docker/4.4.0/docs/resources/volume) | resource |
+| [docker_container.containers](https://registry.terraform.io/providers/kreuzwerker/docker/4.5.0/docs/resources/container) | resource |
+| [docker_image.instances](https://registry.terraform.io/providers/kreuzwerker/docker/4.5.0/docs/resources/image) | resource |
+| [docker_network.main](https://registry.terraform.io/providers/kreuzwerker/docker/4.5.0/docs/resources/network) | resource |
+| [docker_volume.named](https://registry.terraform.io/providers/kreuzwerker/docker/4.5.0/docs/resources/volume) | resource |
 
 ## Inputs
 

--- a/terraform/compute/docker/variables.tf
+++ b/terraform/compute/docker/variables.tf
@@ -91,7 +91,7 @@ variable "cluster_nodes" {
   default = null
 
   validation {
-    condition     = var.cluster_nodes == null || contains(["talos"], var.cluster_nodes.distribution)
+    condition     = var.cluster_nodes == null ? true : contains(["talos"], var.cluster_nodes.distribution)
     error_message = "cluster_nodes.distribution must be \"talos\" (k3s etc. reserved for future use)."
   }
 }

--- a/terraform/compute/hyperv/variables.tf
+++ b/terraform/compute/hyperv/variables.tf
@@ -170,7 +170,7 @@ variable "images" {
 
   validation {
     condition = alltrue([
-      for k, v in var.images : v.compression == null || contains(["gz", "gzip", "xz", "zst", "zstd", "bz2", "bzip2"], v.compression)
+      for k, v in var.images : v.compression == null ? true : contains(["gz", "gzip", "xz", "zst", "zstd", "bz2", "bzip2"], v.compression)
     ])
     error_message = "images: compression must be one of gz, gzip, xz, zst, zstd, bz2, bzip2"
   }

--- a/terraform/compute/incus/main.tf
+++ b/terraform/compute/incus/main.tf
@@ -202,7 +202,7 @@ locals {
       last_octet = instance.ipv4 != null ? tonumber(split(".", split("/", instance.ipv4)[0])[3]) : null
       max_octet  = instance.ipv4 != null && instance.count > 1 ? tonumber(split(".", split("/", instance.ipv4)[0])[3]) + (instance.count - 1) : null
     }
-    if instance.ipv4 != null && instance.count > 1 && tonumber(split(".", split("/", instance.ipv4)[0])[3]) + (instance.count - 1) > 255
+    if instance.ipv4 != null && instance.count > 1 && try(tonumber(split(".", split("/", instance.ipv4)[0])[3]) + (instance.count - 1) > 255, false)
   ]
 
   # Expand instances: when count > 1, name becomes prefix with -0, -1, etc.

--- a/terraform/compute/incus/modules/instance/main.tf
+++ b/terraform/compute/incus/modules/instance/main.tf
@@ -103,11 +103,11 @@ locals {
           # - File paths: start with "/" (Unix), "C:"/"D:" etc (Windows drive), or "\\" (UNC)
           # - Storage volumes: simple names without path separators
           # If source is not provided, we're creating a new volume (include pool, size required)
-          disk.source != null && disk.source != "" && (
+          disk.source != null && disk.source != "" && try(
             length(regexall("^/", disk.source)) > 0 ||         # Unix absolute path
             length(regexall("^[A-Za-z]:", disk.source)) > 0 || # Windows drive letter (C:, D:, etc.)
-            length(regexall("^\\\\", disk.source)) > 0         # Windows UNC path (\\server\share)
-            ) ? {
+            length(regexall("^\\\\", disk.source)) > 0,        # Windows UNC path (\\server\share)
+            false) ? {
             # File path bind mount - source is the host path, no pool needed
             source = disk.source
             } : {

--- a/terraform/compute/incus/modules/instance/test.tftest.hcl
+++ b/terraform/compute/incus/modules/instance/test.tftest.hcl
@@ -128,12 +128,12 @@ run "custom_networks_override_default" {
   }
 
   assert {
-    condition     = length([for d in incus_instance.this.device : d if d.name == "eth0" && d.properties.network == "network1"]) == 1
+    condition     = length([for d in incus_instance.this.device : d if try(d.name == "eth0" && d.properties.network == "network1", false)]) == 1
     error_message = "eth0 should be attached to network1"
   }
 
   assert {
-    condition     = length([for d in incus_instance.this.device : d if d.name == "eth1" && d.properties.network == "network2"]) == 1
+    condition     = length([for d in incus_instance.this.device : d if try(d.name == "eth1" && d.properties.network == "network2", false)]) == 1
     error_message = "eth1 should be attached to network2"
   }
 }
@@ -196,17 +196,17 @@ run "file_path_bind_mount" {
   }
 
   assert {
-    condition     = length([for d in incus_instance.this.device : d if d.name == "unix-mount" && d.properties.source == "/host/path/data" && !contains(keys(d.properties), "pool")]) == 1
+    condition     = length([for d in incus_instance.this.device : d if try(d.name == "unix-mount" && d.properties.source == "/host/path/data" && !contains(keys(d.properties), "pool"), false)]) == 1
     error_message = "Unix path bind mount should not include pool property"
   }
 
   assert {
-    condition     = length([for d in incus_instance.this.device : d if d.name == "windows-mount" && d.properties.source == "C:\\host\\path\\data"]) == 1
+    condition     = length([for d in incus_instance.this.device : d if try(d.name == "windows-mount" && d.properties.source == "C:\\host\\path\\data", false)]) == 1
     error_message = "Windows drive path should be recognized as bind mount"
   }
 
   assert {
-    condition     = length([for d in incus_instance.this.device : d if d.name == "unc-mount" && d.properties.source == "\\\\server\\share\\data"]) == 1
+    condition     = length([for d in incus_instance.this.device : d if try(d.name == "unc-mount" && d.properties.source == "\\\\server\\share\\data", false)]) == 1
     error_message = "UNC path should be recognized as bind mount"
   }
 }
@@ -240,7 +240,7 @@ run "ipv6_static_address_configuration" {
   }
 
   assert {
-    condition     = length([for d in incus_instance.this.device : d if d.name == "eth0" && d.properties["ipv6.address"] == "2001:db8::100"]) == 1
+    condition     = length([for d in incus_instance.this.device : d if try(d.name == "eth0" && d.properties["ipv6.address"] == "2001:db8::100", false)]) == 1
     error_message = "IPv6 address should be configured on eth0 with CIDR notation stripped"
   }
 }
@@ -259,7 +259,7 @@ run "dual_stack_static_addresses" {
   }
 
   assert {
-    condition     = length([for d in incus_instance.this.device : d if d.name == "eth0" && d.properties["ipv4.address"] == "10.5.0.100" && d.properties["ipv6.address"] == "2001:db8::100"]) == 1
+    condition     = length([for d in incus_instance.this.device : d if try(d.name == "eth0" && d.properties["ipv4.address"] == "10.5.0.100" && d.properties["ipv6.address"] == "2001:db8::100", false)]) == 1
     error_message = "Both IPv4 and IPv6 addresses should be configured on eth0"
   }
 }

--- a/terraform/compute/incus/modules/instance/variables.tf
+++ b/terraform/compute/incus/modules/instance/variables.tf
@@ -74,12 +74,14 @@ variable "ipv4" {
   type        = string
   default     = null
   validation {
-    condition = var.ipv4 == null || (
-      can(regex("^([0-9]{1,3}\\.){3}[0-9]{1,3}(/[0-9]{1,2})?$", var.ipv4)) &&
-      # Validate octets are in valid range (0-255)
-      alltrue([
+    condition = var.ipv4 == null ? true : (
+      # Octet-range check is gated on the structure match so tonumber never
+      # sees a non-numeric octet (matters pre-1.12, where && does not short-circuit)
+      can(regex("^([0-9]{1,3}\\.){3}[0-9]{1,3}(/[0-9]{1,2})?$", var.ipv4))
+      ? alltrue([
         for octet in split(".", split("/", var.ipv4)[0]) : tonumber(octet) >= 0 && tonumber(octet) <= 255
       ])
+      : false
     )
     error_message = "IPv4 address must be in format 'x.x.x.x' or 'x.x.x.x/prefix' with octets in range 0-255 (e.g., '10.5.0.87' or '10.5.0.87/24')"
   }

--- a/terraform/compute/incus/variables.tf
+++ b/terraform/compute/incus/variables.tf
@@ -148,7 +148,7 @@ variable "storage_pools" {
   default = {}
   validation {
     condition = alltrue([
-      for name, pool in var.storage_pools : pool.driver == null || contains(["dir", "zfs", "btrfs", "lvm", "ceph"], pool.driver)
+      for name, pool in var.storage_pools : pool.driver == null ? true : contains(["dir", "zfs", "btrfs", "lvm", "ceph"], pool.driver)
     ])
     error_message = "Storage pool drivers must be one of: dir, zfs, btrfs, lvm, ceph (or null to skip)"
   }


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> Isolated null-guard fixes in validation conditions and `locals` expressions across several modules; no resource definitions or variable schemas change.
>
> **Overview**
>
> Replaces pre-Terraform-1.12-unsafe `&&`/`||` operator chains with `try()` calls and explicit ternary guards that short-circuit correctly. Terraform evaluates both operands of `&&` and `||` regardless of the left-hand result in versions before 1.12, causing "attribute on null object" errors whenever a validation block or `locals` expression accessed a nested attribute after a null check. The change affects both cluster providers (aws-eks, azure-aks), several compute modules (incus, docker, hyperv), and backend test fixtures.
>
> The most structural edits are in the `pools` variable validations for EKS and AKS: the count-within-range and min-≤-max checks now gate their inner bodies behind `v.autoscaling == null ? true : (...)` rather than relying on `||` to skip the nested accesses. The IPv4 validator in the Incus instance module similarly converts a `can(regex(...)) &&` chain to a nested ternary so `tonumber` is never called on octets before the format check passes.
>
> Test assertions in the Incus instance fixture are wrapped with `try(..., false)` for the same reason; this trades a property-access error for a silent `false` inside the filter, which still produces a count-mismatch assertion failure but with a less precise error message — a minor diagnostic trade-off acceptable for test-only code.
>
> Reviewed by Claude for commit `9c81105`.

<!-- /claude-code-review:summary -->
