### PR TITLE
fix(cluster/aws-eks): align Karpenter controller policy with upstream v1

### DIFF
--- a/terraform/cluster/aws-eks/iam-policies/karpenter-controller.json
+++ b/terraform/cluster/aws-eks/iam-policies/karpenter-controller.json
@@ -8,7 +8,8 @@
         "arn:aws:ec2:${region}::image/*",
         "arn:aws:ec2:${region}::snapshot/*",
         "arn:aws:ec2:${region}:*:security-group/*",
-        "arn:aws:ec2:${region}:*:subnet/*"
+        "arn:aws:ec2:${region}:*:subnet/*",
+        "arn:aws:ec2:${region}:*:capacity-reservation/*"
       ],
       "Action": ["ec2:RunInstances", "ec2:CreateFleet"]
     },
@@ -68,7 +69,7 @@
         "StringEquals": { "aws:ResourceTag/kubernetes.io/cluster/${cluster_name}": "owned" },
         "StringLike": { "aws:ResourceTag/karpenter.sh/nodepool": "*" },
         "ForAllValues:StringEquals": {
-          "aws:TagKeys": ["karpenter.sh/nodeclaim", "Name"]
+          "aws:TagKeys": ["eks:eks-cluster-name", "karpenter.sh/nodeclaim", "Name"]
         }
       }
     },
@@ -91,6 +92,7 @@
       "Resource": "*",
       "Action": [
         "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeCapacityReservations",
         "ec2:DescribeImages",
         "ec2:DescribeInstances",
         "ec2:DescribeInstanceTypeOfferings",

--- a/terraform/cluster/aws-eks/karpenter.tf
+++ b/terraform/cluster/aws-eks/karpenter.tf
@@ -11,7 +11,7 @@ locals {
   karpenter_node_managed_policies = var.enable_karpenter ? toset([
     "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
     "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
-    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPullOnly",
     "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
   ]) : toset([])
 
@@ -124,13 +124,23 @@ resource "aws_sqs_queue_policy" "karpenter" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = [{
-      Sid       = "EC2InterruptionPolicy"
-      Effect    = "Allow"
-      Principal = { Service = ["events.amazonaws.com", "sqs.amazonaws.com"] }
-      Action    = "sqs:SendMessage"
-      Resource  = aws_sqs_queue.karpenter[0].arn
-    }]
+    Statement = [
+      {
+        Sid       = "EC2InterruptionPolicy"
+        Effect    = "Allow"
+        Principal = { Service = ["events.amazonaws.com", "sqs.amazonaws.com"] }
+        Action    = "sqs:SendMessage"
+        Resource  = aws_sqs_queue.karpenter[0].arn
+      },
+      {
+        Sid       = "DenyHTTP"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "sqs:*"
+        Resource  = aws_sqs_queue.karpenter[0].arn
+        Condition = { Bool = { "aws:SecureTransport" = "false" } }
+      }
+    ]
   })
 }
 

--- a/terraform/compute/incus/README.md
+++ b/terraform/compute/incus/README.md
@@ -24,7 +24,7 @@ Docker-on-Mac can't expose (e.g. nested KVM, real iSCSI). Pairs with the
 
 | Name | Version |
 |------|---------|
-| <a name="provider_incus"></a> [incus](#provider\_incus) | 1.1.0 |
+| <a name="provider_incus"></a> [incus](#provider\_incus) | 1.1.1 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules

--- a/terraform/workstation/incus/README.md
+++ b/terraform/workstation/incus/README.md
@@ -15,14 +15,14 @@ Local-host runtime backing `windsor apply` when `compute.driver` is
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.12.0 |
-| <a name="requirement_incus"></a> [incus](#requirement\_incus) | 1.1.0 |
+| <a name="requirement_incus"></a> [incus](#requirement\_incus) | 1.1.1 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | 2.9.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_incus"></a> [incus](#provider\_incus) | 1.1.0 |
+| <a name="provider_incus"></a> [incus](#provider\_incus) | 1.1.1 |
 | <a name="provider_local"></a> [local](#provider\_local) | 2.9.0 |
 
 ## Modules
@@ -33,10 +33,10 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [incus_instance.dns](https://registry.terraform.io/providers/lxc/incus/1.1.0/docs/resources/instance) | resource |
-| [incus_instance.git](https://registry.terraform.io/providers/lxc/incus/1.1.0/docs/resources/instance) | resource |
-| [incus_instance.registry](https://registry.terraform.io/providers/lxc/incus/1.1.0/docs/resources/instance) | resource |
-| [incus_network.main](https://registry.terraform.io/providers/lxc/incus/1.1.0/docs/resources/network) | resource |
+| [incus_instance.dns](https://registry.terraform.io/providers/lxc/incus/1.1.1/docs/resources/instance) | resource |
+| [incus_instance.git](https://registry.terraform.io/providers/lxc/incus/1.1.1/docs/resources/instance) | resource |
+| [incus_instance.registry](https://registry.terraform.io/providers/lxc/incus/1.1.1/docs/resources/instance) | resource |
+| [incus_network.main](https://registry.terraform.io/providers/lxc/incus/1.1.1/docs/resources/network) | resource |
 | [local_file.corefile](https://registry.terraform.io/providers/hashicorp/local/2.9.0/docs/resources/file) | resource |
 | [local_file.registry_cache_dir](https://registry.terraform.io/providers/hashicorp/local/2.9.0/docs/resources/file) | resource |
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> Isolated policy edits to an opt-in module introduced one commit ago — no impact on existing deployments.
>
> **Overview**
>
> This PR carries four policy corrections to the Karpenter substrate from #2018, aligning the controller IAM policy and interruption queue with the upstream Karpenter v1 getting-started baseline. It adds EC2 capacity reservation access (resource ARN + describe action), permits the `eks:eks-cluster-name` tag key on launched nodes, and enforces TLS on the SQS queue via an explicit Deny statement.
>
> The node role's ECR managed policy is also swapped from `AmazonEC2ContainerRegistryReadOnly` to `AmazonEC2ContainerRegistryPullOnly`, narrowing to pull-only access. Because `enable_karpenter` defaults to false and the substrate was just introduced in #2018, there are no existing node roles to migrate and the change takes effect only on fresh applies.
>
> Reviewed by Claude for commit `e798ea9`.
<!-- /claude-code-review:summary -->
