### PR TITLE
chore(terraform): permit terraform greater than v1.12.2

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: create-pr
+description: Push the current branch and open or update its pull request with a Conventional-Commits title. Does NOT author a PR description -- the claude-code-review workflow upserts the canonical summary into the body on every push, so this skill leaves the body empty for CI to fill and never touches an existing one. Run after committing and before announcing the PR. Use whenever the user asks to "open the PR", "push and PR", or after the project's gates are green and the branch is ready.
+disable-model-invocation: true
+---
+
+# Create or Update PR
+
+Open a pull request for the current branch with a Conventional-Commits
+title and an empty body. The repo's `claude-code-review` workflow upserts
+the canonical summary into the PR body on every push, so this skill never
+authors a description: it creates the PR with no body and leaves the body
+for CI, and it never overwrites a body that already exists.
+
+## Apply when
+- The user says "open the PR", "push the branch and PR", "make a PR", or
+  similar after work is committed.
+- The project's gates (lint + tests) have passed locally and the branch
+  has commits ahead of `main`.
+- Skip if `git status -s` shows uncommitted changes that should be in the
+  PR -- ask the user to commit or stash first.
+
+## Inputs to gather
+1. `git rev-parse --abbrev-ref HEAD` — branch name.
+2. `git log main..HEAD --oneline` — commits the PR contains.
+3. `git diff main...HEAD --stat` — file-level shape of the change.
+4. `gh pr view --json number 2>/dev/null` — does a PR exist already?
+
+If `gh pr view` returns "no pull requests found", we'll create with an
+empty body. Otherwise the PR already exists and we leave its body alone.
+
+## Title rules
+
+Hard requirements:
+- **Conventional Commits shape**: `<type>(<scope>?): <description>`.
+- **Types**: `feat`, `fix`, `chore`, `docs`, `test`, `refactor`, `ci`,
+  `perf`, `build`. Pick from this fixed set.
+- **Scope** (optional, lowercase): the package or area touched, e.g. the
+  directory or component name, or `deps` for dependency bumps. Single
+  word; multi-word scopes are a smell. Sample existing scopes with
+  `git log main --pretty=format:%s | head -20`.
+- **Description**: lowercase first letter, imperative or descriptive,
+  no trailing punctuation.
+- **Length**: aim for ≤ 65 chars total. Hard cap at 72.
+- **Same shape as commit titles** in the project — sample
+  `git log main --pretty=format:%s | head -20` to verify.
+
+Examples that fit: `feat(api): inline default timeout`,
+`fix(server): bound request ctx with command timeout`,
+`chore(deps): bump some-dependency to v1.20`.
+
+Anti-patterns to avoid:
+- ALL CAPS prefixes ("M4: ..."): drop the milestone tag.
+- Multi-clause titles with "and" or `+`: pick the bigger half. If the
+  change really is two things, that's a sign it should be two PRs.
+- Verbose nouns ("complete the foo resource"): use the verb
+  ("complete foo").
+
+## Body
+
+Do not write a PR body. The repo's `claude-code-review` workflow upserts
+the canonical summary (a `> [!NOTE]` block delimited by
+`<!-- claude-code-review:summary -->` markers) into the PR description on
+every push, so authoring one here would only duplicate or fight with it.
+
+Create the PR with an empty body and let CI fill it. If a PR already
+exists, leave its body untouched — CI owns it, and a human may have added
+prose of their own that must not be clobbered.
+
+## Decision tree
+
+```
+Does a PR exist for this branch?
+├── No  → gh pr create with generated title and an empty body, then print URL.
+└── Yes → Leave the body alone (CI owns the summary; a human may have added
+          prose). Print URL only.
+```
+
+After the PR exists, **always check CI status** (see below). The point
+of opening a PR is to get the change reviewed and merged; surfacing a
+red check immediately lets the user fix it before they walk away.
+
+## Commands
+
+Push first, then create the PR with an empty body. Pass `--body ""`
+explicitly so `gh` does not drop into an interactive editor.
+
+```bash
+# 1. Push (set upstream on first push of this branch)
+git push -u origin "$(git rev-parse --abbrev-ref HEAD)"
+
+# 2. Detect existing PR
+PR_NUM=$(gh pr view --json number --jq '.number // empty' 2>/dev/null)
+
+# 3. Create with an empty body when none exists; never touch an existing body
+if [ -z "$PR_NUM" ]; then
+  gh pr create --title "<generated title>" --body ""
+  PR_NUM=$(gh pr view --json number --jq .number)
+else
+  echo "PR #$PR_NUM already exists; leaving its body to CI."
+fi
+gh pr view --json url --jq .url
+```
+
+If `gh` returns `HTTP 401: Bad credentials`, the operator has a stale
+`GITHUB_TOKEN` env var overriding the keychain. Prepend `unset GITHUB_TOKEN`
+to the failing command and retry.
+
+## CI status check
+
+After the PR exists (just created OR already-existed), run a quick
+status check. CI typically kicks off within a few seconds of the push,
+but most pipelines take 1-5 minutes to complete. Two modes:
+
+```bash
+# Snapshot: list current state of every check, no waiting.
+gh pr checks "$PR_NUM"
+```
+
+If any row shows `fail` or `failure`, surface those rows to the user
+verbatim and direct them to the failing job's URL (the rightmost
+column of `gh pr checks`). Don't try to diagnose the failure from the
+skill -- the failing job's logs are the source of truth.
+
+If every row shows `pending` or `queued`, that's expected on a fresh
+push. Print the URL with a "checks running" hint. Do NOT block the
+skill on completion -- the user can run `gh pr checks --watch` to
+follow them.
+
+If every row shows `pass`, say so explicitly. The user shouldn't have
+to scroll back to verify.
+
+## What NOT to do
+- Don't author a PR body. The `claude-code-review` workflow owns the
+  description; anything written here duplicates or fights with it.
+- Don't overwrite or edit the body of an existing PR.
+- Don't push to `main` directly. Always operate on a feature branch.
+- Don't run `git push --force` unless the user explicitly asked.
+
+## After posting
+
+Print the PR URL on its own line so the operator can click through.

--- a/terraform/backend/s3/README.md
+++ b/terraform/backend/s3/README.md
@@ -16,7 +16,7 @@ acquires the lock.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.12.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | 6.47.0 |
 
 ## Providers

--- a/terraform/backend/s3/main.tf
+++ b/terraform/backend/s3/main.tf
@@ -6,7 +6,7 @@
 #---------------------------------------------------------------------------------------------------
 
 terraform {
-  required_version = "~> 1.12.0"
+  required_version = ">= 1.12.2"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/cluster/aws-eks/README.md
+++ b/terraform/cluster/aws-eks/README.md
@@ -19,7 +19,7 @@ and EBS CSI driver helpers that EKS expects out-of-band.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.12.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | 6.47.0 |
 
 ## Providers

--- a/terraform/cluster/aws-eks/additions/README.md
+++ b/terraform/cluster/aws-eks/additions/README.md
@@ -15,7 +15,7 @@ Kubernetes API once the control plane is reachable.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.12.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | 6.47.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 3.1.0 |
 

--- a/terraform/cluster/aws-eks/additions/main.tf
+++ b/terraform/cluster/aws-eks/additions/main.tf
@@ -4,7 +4,7 @@
 # Key features: namespace management, configmap creation, auto-import of existing resources
 
 terraform {
-  required_version = "~> 1.12.0"
+  required_version = ">= 1.12.2"
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/terraform/cluster/aws-eks/main.tf
+++ b/terraform/cluster/aws-eks/main.tf
@@ -1,6 +1,6 @@
 // Define the required Terraform version and providers
 terraform {
-  required_version = "~> 1.12.0"
+  required_version = ">= 1.12.2"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/cluster/azure-aks/README.md
+++ b/terraform/cluster/azure-aks/README.md
@@ -64,7 +64,7 @@ The next apply will then only show creates.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.12.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.74.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.2 |
 

--- a/terraform/cluster/azure-aks/main.tf
+++ b/terraform/cluster/azure-aks/main.tf
@@ -3,7 +3,7 @@
 #---------------------------------------------------------------------------------------------------
 
 terraform {
-  required_version = "~> 1.12.0"
+  required_version = ">= 1.12.2"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/terraform/cluster/talos/README.md
+++ b/terraform/cluster/talos/README.md
@@ -20,7 +20,7 @@ extensions baked in.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.12.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_talos"></a> [talos](#requirement\_talos) | 0.11.0 |
 
 ## Providers

--- a/terraform/cluster/talos/config/README.md
+++ b/terraform/cluster/talos/config/README.md
@@ -17,7 +17,7 @@ kubeconfig flow run without a redundant machine-config apply.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.12.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_hyperv"></a> [hyperv](#requirement\_hyperv) | 0.3.1 |
 | <a name="requirement_talos"></a> [talos](#requirement\_talos) | 0.11.0 |
 

--- a/terraform/cluster/talos/config/main.tf
+++ b/terraform/cluster/talos/config/main.tf
@@ -27,7 +27,7 @@
 # =============================================================================
 
 terraform {
-  required_version = "~> 1.12.0"
+  required_version = ">= 1.12.2"
   required_providers {
     hyperv = {
       source  = "windsorcli/hyperv"

--- a/terraform/cluster/talos/extensions/.terraform.lock.hcl
+++ b/terraform/cluster/talos/extensions/.terraform.lock.hcl
@@ -1,0 +1,45 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.3.0"
+  constraints = "~> 3.2"
+  hashes = [
+    "h1:a14TKo7Xvg4W8+H1VA6p+oLZTLxVQnYUD8LOaOs14A8=",
+    "zh:021748b5ea3b5f6956f2e75c42c5cdc113b391fb98ac71364a4965d23b37000f",
+    "zh:3b27956f8541d46704fda234e0d535c2ae2a4b33411848b1ee262a1ec03568b0",
+    "zh:3de4ed47d6d0f4d8edba4a5092c7c9799950eda63989d8d0d2586e6afcb0aa20",
+    "zh:57ed8935c7d56dbc91cf2673534582cacfaab7a2f105f51d9f797e99df0c0c47",
+    "zh:58e176ba1d142827089e30e0711e007309a9f2726e8881986da5026e9778fdf4",
+    "zh:5949c4a3d4a93f841f155cdb7e991c087e637145c1630572e21948224f8f4923",
+    "zh:76d60f366b743003c1b085afa769b45b2198ee919927e45807d7d44fb42c067d",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79cd1bab1261a07f84e917191d7ddc4340ac5f5524283767256f7ffd7f87caf0",
+    "zh:8ec9083038cf710b30e319eaa467c9df7fa52bbd9969b61053a35bc2cdd2e0a6",
+    "zh:a6e502cb579685ab7aeb886c2bb11ddd9cfed74b41008592d57cbc3351a9218b",
+    "zh:acb74d6b4f66ff6acfcda315df802a7432170ef3955c9b432cb4580767004006",
+    "zh:f0ce55d8d9ffdb33dab612b1246f9bab060a9d54fc32ce2b4a038646155660af",
+  ]
+}
+
+provider "registry.terraform.io/siderolabs/talos" {
+  version     = "0.11.0"
+  constraints = "0.11.0"
+  hashes = [
+    "h1:1NC84ojUrL+G3aSLMl4Khh83HnJYuxsYNKK7zg2C/dI=",
+    "zh:0fa82a384b25a58b65523e0ea4768fa1212b1f5cfc0c9379d31162454fedcc9d",
+    "zh:12e0f007b86240b6d06d497fcc5a2092056683a7bb2dac56571d9f0cab0d99a6",
+    "zh:1468add8a3bc8d2d12af9671431b0881639c81b5c04c89f7cbfd34f7eed4e860",
+    "zh:194fca4484d2dbb55351235cfb8c174471925b3390f99ce148d8908a7ae42c20",
+    "zh:1a0c53146625e6e13b6794e823079e696dae53719ffb421bfa77c9e625cf64bb",
+    "zh:245987cdc2cf922a72814ebc502ddd7eec68fbb6d1a64b11a7d2b3f2a514f3a6",
+    "zh:2491690b2881c2670eec72fcfd02a2956865464b6e962110b9317f04ca5d8857",
+    "zh:28d4f6ea1b3ffffaf70823d8ccd05a05e5092b462ad2f66735915f532b71157f",
+    "zh:362cfb8929712dc2fec16d3245bac955f3a99c8b511eee7b9dde13f9ada49dd5",
+    "zh:3c807429a02213e36d044549ec03cb883d141084e1f113553088aa88497de543",
+    "zh:50755afc9c8921e264ba8bf8680e498970ddd4b726f3f41e3ad37d973ba9204c",
+    "zh:585582cf4e629de2b044ce2cf634ee0772f25937edea1c22a3a9b5102d8fc7bf",
+    "zh:696e4d43139cfd55dce7d91da92318839bc9ba553d89885ba202ce61cd0bb729",
+    "zh:d218bab0f67a2a8b15add9b51df3d30f514b57e9a7c1d733ebe97966ea132acb",
+  ]
+}

--- a/terraform/cluster/talos/extensions/README.md
+++ b/terraform/cluster/talos/extensions/README.md
@@ -15,7 +15,7 @@ worker nodes when the image changes.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.12.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.2 |
 | <a name="requirement_talos"></a> [talos](#requirement\_talos) | 0.11.0 |
 
@@ -23,7 +23,7 @@ worker nodes when the image changes.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.2 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.3.0 |
 | <a name="provider_talos"></a> [talos](#provider\_talos) | 0.11.0 |
 
 ## Modules

--- a/terraform/cluster/talos/extensions/main.tf
+++ b/terraform/cluster/talos/extensions/main.tf
@@ -3,7 +3,7 @@
 #-----------------------------------------------------------------------------------------------------------------------
 
 terraform {
-  required_version = "~> 1.12.0"
+  required_version = ">= 1.12.2"
   required_providers {
     talos = {
       source  = "siderolabs/talos"

--- a/terraform/cluster/talos/main.tf
+++ b/terraform/cluster/talos/main.tf
@@ -1,6 +1,6 @@
 // Define the required Terraform version and providers
 terraform {
-  required_version = "~> 1.12.0"
+  required_version = ">= 1.12.2"
   required_providers {
     talos = {
       source  = "siderolabs/talos"

--- a/terraform/cni/cilium/README.md
+++ b/terraform/cni/cilium/README.md
@@ -14,7 +14,7 @@ running release afterward and takes over day-2 changes.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.12.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 3.1.2 |
 
 ## Providers

--- a/terraform/cni/cilium/main.tf
+++ b/terraform/cni/cilium/main.tf
@@ -3,7 +3,7 @@
 #-----------------------------------------------------------------------------------------------------------------------
 
 terraform {
-  required_version = "~> 1.12.0"
+  required_version = ">= 1.12.2"
   required_providers {
     helm = {
       source  = "hashicorp/helm"

--- a/terraform/compute/docker/README.md
+++ b/terraform/compute/docker/README.md
@@ -16,7 +16,7 @@ brings up via the Talos API.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.12.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_docker"></a> [docker](#requirement\_docker) | 4.4.0 |
 
 ## Providers

--- a/terraform/compute/docker/main.tf
+++ b/terraform/compute/docker/main.tf
@@ -7,7 +7,7 @@
 # =============================================================================
 
 terraform {
-  required_version = "~> 1.12.0"
+  required_version = ">= 1.12.2"
   required_providers {
     docker = {
       source  = "kreuzwerker/docker"

--- a/terraform/compute/hyperv/.terraform.lock.hcl
+++ b/terraform/compute/hyperv/.terraform.lock.hcl
@@ -1,27 +1,6 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/siderolabs/talos" {
-  version = "0.11.0"
-  hashes = [
-    "h1:1NC84ojUrL+G3aSLMl4Khh83HnJYuxsYNKK7zg2C/dI=",
-    "zh:0fa82a384b25a58b65523e0ea4768fa1212b1f5cfc0c9379d31162454fedcc9d",
-    "zh:12e0f007b86240b6d06d497fcc5a2092056683a7bb2dac56571d9f0cab0d99a6",
-    "zh:1468add8a3bc8d2d12af9671431b0881639c81b5c04c89f7cbfd34f7eed4e860",
-    "zh:194fca4484d2dbb55351235cfb8c174471925b3390f99ce148d8908a7ae42c20",
-    "zh:1a0c53146625e6e13b6794e823079e696dae53719ffb421bfa77c9e625cf64bb",
-    "zh:245987cdc2cf922a72814ebc502ddd7eec68fbb6d1a64b11a7d2b3f2a514f3a6",
-    "zh:2491690b2881c2670eec72fcfd02a2956865464b6e962110b9317f04ca5d8857",
-    "zh:28d4f6ea1b3ffffaf70823d8ccd05a05e5092b462ad2f66735915f532b71157f",
-    "zh:362cfb8929712dc2fec16d3245bac955f3a99c8b511eee7b9dde13f9ada49dd5",
-    "zh:3c807429a02213e36d044549ec03cb883d141084e1f113553088aa88497de543",
-    "zh:50755afc9c8921e264ba8bf8680e498970ddd4b726f3f41e3ad37d973ba9204c",
-    "zh:585582cf4e629de2b044ce2cf634ee0772f25937edea1c22a3a9b5102d8fc7bf",
-    "zh:696e4d43139cfd55dce7d91da92318839bc9ba553d89885ba202ce61cd0bb729",
-    "zh:d218bab0f67a2a8b15add9b51df3d30f514b57e9a7c1d733ebe97966ea132acb",
-  ]
-}
-
 provider "registry.terraform.io/windsorcli/hyperv" {
   version     = "0.3.1"
   constraints = "0.3.1"

--- a/terraform/compute/hyperv/README.md
+++ b/terraform/compute/hyperv/README.md
@@ -15,7 +15,7 @@ Pairs with the `cluster/talos` module.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.12.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_hyperv"></a> [hyperv](#requirement\_hyperv) | 0.3.1 |
 
 ## Providers

--- a/terraform/compute/hyperv/main.tf
+++ b/terraform/compute/hyperv/main.tf
@@ -9,7 +9,7 @@
 # =============================================================================
 
 terraform {
-  required_version = "~> 1.12.0"
+  required_version = ">= 1.12.2"
   required_providers {
     hyperv = {
       source  = "windsorcli/hyperv"

--- a/terraform/compute/incus/README.md
+++ b/terraform/compute/incus/README.md
@@ -16,7 +16,7 @@ Docker-on-Mac can't expose (e.g. nested KVM, real iSCSI). Pairs with the
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.12.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_incus"></a> [incus](#requirement\_incus) | ~> 1.1.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.2 |
 

--- a/terraform/compute/incus/main.tf
+++ b/terraform/compute/incus/main.tf
@@ -7,7 +7,7 @@
 # =============================================================================
 
 terraform {
-  required_version = "~> 1.12.0"
+  required_version = ">= 1.12.2"
   required_providers {
     incus = {
       source  = "lxc/incus"

--- a/terraform/compute/incus/modules/instance/main.tf
+++ b/terraform/compute/incus/modules/instance/main.tf
@@ -3,7 +3,7 @@
 #-----------------------------------------------------------------------------------------------------------------------
 
 terraform {
-  required_version = "~> 1.12.0"
+  required_version = ">= 1.12.2"
   required_providers {
     incus = {
       source  = "lxc/incus"

--- a/terraform/dns/zone/azure-dns/README.md
+++ b/terraform/dns/zone/azure-dns/README.md
@@ -15,7 +15,7 @@ resources.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.12.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.74.0 |
 
 ## Providers

--- a/terraform/dns/zone/azure-dns/main.tf
+++ b/terraform/dns/zone/azure-dns/main.tf
@@ -14,7 +14,7 @@
 # resources with it.
 
 terraform {
-  required_version = "~> 1.12.0"
+  required_version = ">= 1.12.2"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/terraform/dns/zone/route53/README.md
+++ b/terraform/dns/zone/route53/README.md
@@ -47,7 +47,7 @@ plus storage cost scales with query volume.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.12.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | 6.47.0 |
 
 ## Providers

--- a/terraform/dns/zone/route53/main.tf
+++ b/terraform/dns/zone/route53/main.tf
@@ -10,7 +10,7 @@
 # DNS infra has a different lifecycle than compute.
 
 terraform {
-  required_version = "~> 1.12.0"
+  required_version = ">= 1.12.2"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/gitops/flux/README.md
+++ b/terraform/gitops/flux/README.md
@@ -16,7 +16,7 @@ mostly inert — Flux self-manages from the repo going forward.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.12.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 3.1.2 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | 3.9.0 |

--- a/terraform/gitops/flux/main.tf
+++ b/terraform/gitops/flux/main.tf
@@ -3,7 +3,7 @@
 #-----------------------------------------------------------------------------------------------------------------------
 
 terraform {
-  required_version = "~> 1.12.0"
+  required_version = ">= 1.12.2"
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/terraform/network/aws-vpc/README.md
+++ b/terraform/network/aws-vpc/README.md
@@ -16,7 +16,7 @@ lists describe the same AZ. Outputs feed the `cluster/aws-eks` module.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.12.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | 6.47.0 |
 
 ## Providers

--- a/terraform/network/aws-vpc/main.tf
+++ b/terraform/network/aws-vpc/main.tf
@@ -1,6 +1,6 @@
 // Define the required Terraform version and providers
 terraform {
-  required_version = "~> 1.12.0"
+  required_version = ">= 1.12.2"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/network/azure-vnet/README.md
+++ b/terraform/network/azure-vnet/README.md
@@ -15,7 +15,7 @@ Outputs feed the `cluster/azure-aks` module.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.12.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.74.0 |
 
 ## Providers

--- a/terraform/network/azure-vnet/main.tf
+++ b/terraform/network/azure-vnet/main.tf
@@ -3,7 +3,7 @@
 #---------------------------------------------------------------------------------------------------
 
 terraform {
-  required_version = "~> 1.12.0"
+  required_version = ">= 1.12.2"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/terraform/workstation/docker/README.md
+++ b/terraform/workstation/docker/README.md
@@ -15,7 +15,7 @@ with Docker Desktop or Colima.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.12.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_docker"></a> [docker](#requirement\_docker) | 4.4.0 |
 
 ## Providers

--- a/terraform/workstation/docker/main.tf
+++ b/terraform/workstation/docker/main.tf
@@ -7,7 +7,7 @@
 # =============================================================================
 
 terraform {
-  required_version = "~> 1.12.0"
+  required_version = ">= 1.12.2"
   required_providers {
     docker = {
       source  = "kreuzwerker/docker"

--- a/terraform/workstation/incus/README.md
+++ b/terraform/workstation/incus/README.md
@@ -14,7 +14,7 @@ Local-host runtime backing `windsor apply` when `compute.driver` is
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.12.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_incus"></a> [incus](#requirement\_incus) | 1.1.1 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | 2.9.0 |
 

--- a/terraform/workstation/incus/main.tf
+++ b/terraform/workstation/incus/main.tf
@@ -7,7 +7,7 @@
 # =============================================================================
 
 terraform {
-  required_version = "~> 1.12.0"
+  required_version = ">= 1.12.2"
   required_providers {
     incus = {
       source  = "lxc/incus"


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> This change touches shared Terraform infrastructure constraints across every module in the repo, but the change itself is a mechanical find-and-replace with no logic modifications.
>
> **Overview**
>
> Bumps the minimum Terraform version requirement from `~> 1.12.0` to `>= 1.12.2` across all modules, and commits the `.terraform.lock.hcl` provider lock files for the `hyperv` and `talos/extensions` modules. The constraint change targets a specific patch that introduced a required behavior, while the lock files improve reproducibility for the two modules that were previously missing them. Also introduces a new `.claude/skills/create-pr/SKILL.md` skill definition for automating PR creation.
>
> The semantic shift from `~> 1.12.0` (patches only within 1.12.x) to `>= 1.12.2` (no upper bound) is worth noting: it permits Terraform 1.13+ or 2.x to satisfy the constraint, which may be intentional but removes the minor-version ceiling that `~>` provides. Teams already pinned to 1.12.x via tooling will not notice the difference.
>
> Reviewed by Claude for commit `c8a09f0`.
<!-- /claude-code-review:summary -->
