### PR TITLE
chore(docs): regenerate terraform module READMEs

### DIFF
--- a/terraform/backend/azurerm/README.md
+++ b/terraform/backend/azurerm/README.md
@@ -15,13 +15,13 @@ locking — no separate lock table.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 4.74.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 4.78.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.74.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.78.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | 2.6.1 |
 
 ## Modules
@@ -32,10 +32,10 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/4.74.0/docs/resources/resource_group) | resource |
-| [azurerm_storage_account.this](https://registry.terraform.io/providers/hashicorp/azurerm/4.74.0/docs/resources/storage_account) | resource |
-| [azurerm_storage_container.this](https://registry.terraform.io/providers/hashicorp/azurerm/4.74.0/docs/resources/storage_container) | resource |
-| [azurerm_user_assigned_identity.storage](https://registry.terraform.io/providers/hashicorp/azurerm/4.74.0/docs/resources/user_assigned_identity) | resource |
+| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/4.78.0/docs/resources/resource_group) | resource |
+| [azurerm_storage_account.this](https://registry.terraform.io/providers/hashicorp/azurerm/4.78.0/docs/resources/storage_account) | resource |
+| [azurerm_storage_container.this](https://registry.terraform.io/providers/hashicorp/azurerm/4.78.0/docs/resources/storage_container) | resource |
+| [azurerm_user_assigned_identity.storage](https://registry.terraform.io/providers/hashicorp/azurerm/4.78.0/docs/resources/user_assigned_identity) | resource |
 | [local_file.backend_config](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 
 ## Inputs

--- a/terraform/backend/s3/README.md
+++ b/terraform/backend/s3/README.md
@@ -17,13 +17,13 @@ acquires the lock.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 6.47.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 6.51.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.47.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | 2.8.0 |
 
 ## Modules
@@ -34,18 +34,18 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_kms_alias.terraform_state_alias](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/kms_alias) | resource |
-| [aws_kms_key.terraform_state](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/kms_key) | resource |
-| [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket_lifecycle_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/s3_bucket_lifecycle_configuration) | resource |
-| [aws_s3_bucket_logging.this](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/s3_bucket_logging) | resource |
-| [aws_s3_bucket_policy.this](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/s3_bucket_policy) | resource |
-| [aws_s3_bucket_public_access_block.this](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/s3_bucket_public_access_block) | resource |
-| [aws_s3_bucket_server_side_encryption_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
-| [aws_s3_bucket_versioning.this](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/s3_bucket_versioning) | resource |
+| [aws_kms_alias.terraform_state_alias](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/kms_alias) | resource |
+| [aws_kms_key.terraform_state](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/kms_key) | resource |
+| [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_lifecycle_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/s3_bucket_lifecycle_configuration) | resource |
+| [aws_s3_bucket_logging.this](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/s3_bucket_logging) | resource |
+| [aws_s3_bucket_policy.this](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_bucket_public_access_block.this](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| [aws_s3_bucket_versioning.this](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/s3_bucket_versioning) | resource |
 | [local_file.backend_config](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/data-sources/caller_identity) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/data-sources/region) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/data-sources/caller_identity) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/data-sources/region) | data source |
 
 ## Inputs
 

--- a/terraform/cluster/aws-eks/README.md
+++ b/terraform/cluster/aws-eks/README.md
@@ -20,13 +20,13 @@ and EBS CSI driver helpers that EKS expects out-of-band.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 6.47.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 6.51.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.47.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | 2.6.1 |
 | <a name="provider_null"></a> [null](#provider\_null) | 3.2.4 |
 
@@ -38,71 +38,71 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_autoscaling_group_tag.cluster_autoscaler_enabled](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/autoscaling_group_tag) | resource |
-| [aws_autoscaling_group_tag.cluster_autoscaler_owned](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/autoscaling_group_tag) | resource |
-| [aws_cloudwatch_event_rule.karpenter](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/cloudwatch_event_rule) | resource |
-| [aws_cloudwatch_event_target.karpenter](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/cloudwatch_event_target) | resource |
-| [aws_cloudwatch_log_group.eks_cluster](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/cloudwatch_log_group) | resource |
-| [aws_ec2_tag.karpenter_discovery_sg](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/ec2_tag) | resource |
-| [aws_ec2_tag.karpenter_discovery_subnet](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/ec2_tag) | resource |
-| [aws_eks_addon.main](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/eks_addon) | resource |
-| [aws_eks_cluster.main](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/eks_cluster) | resource |
-| [aws_eks_fargate_profile.main](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/eks_fargate_profile) | resource |
-| [aws_eks_node_group.main](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/eks_node_group) | resource |
-| [aws_eks_pod_identity_association.aws_lb_controller](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/eks_pod_identity_association) | resource |
-| [aws_eks_pod_identity_association.cert_manager](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/eks_pod_identity_association) | resource |
-| [aws_eks_pod_identity_association.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/eks_pod_identity_association) | resource |
-| [aws_eks_pod_identity_association.external_dns](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/eks_pod_identity_association) | resource |
-| [aws_eks_pod_identity_association.karpenter](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/eks_pod_identity_association) | resource |
-| [aws_iam_instance_profile.karpenter_node](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_instance_profile) | resource |
-| [aws_iam_policy.aws_lb_controller](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.cert_manager](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.external_dns](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.karpenter_controller](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.pod_identity_agent](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_policy) | resource |
-| [aws_iam_role.aws_lb_controller](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.cert_manager](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.cluster](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.ebs_csi](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.efs_csi](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.external_dns](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.fargate](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.karpenter_controller](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.karpenter_node](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.node_group](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.pod_identity_agent](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.vpc_cni](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy_attachment.aws_lb_controller](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.cert_manager](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.cluster_AmazonEKSClusterPolicy](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.cluster_AmazonEKSVPCResourceController](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.ebs_csi](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.efs_csi](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.external_dns](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.fargate_pod_execution_role_policy](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.karpenter_controller](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.karpenter_node](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.node_group_AmazonEC2ContainerRegistryReadOnly](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.node_group_AmazonEKSWorkerNodePolicy](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.node_group_AmazonEKS_CNI_Policy](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.pod_identity_agent](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.vpc_cni](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_kms_alias.ebs_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/kms_alias) | resource |
-| [aws_kms_alias.eks_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/kms_alias) | resource |
-| [aws_kms_key.ebs_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/kms_key) | resource |
-| [aws_kms_key.eks_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/kms_key) | resource |
-| [aws_launch_template.node_group](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/launch_template) | resource |
-| [aws_security_group.cluster_api_access](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/security_group) | resource |
-| [aws_sqs_queue.karpenter](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/sqs_queue) | resource |
-| [aws_sqs_queue_policy.karpenter](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/sqs_queue_policy) | resource |
+| [aws_autoscaling_group_tag.cluster_autoscaler_enabled](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/autoscaling_group_tag) | resource |
+| [aws_autoscaling_group_tag.cluster_autoscaler_owned](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/autoscaling_group_tag) | resource |
+| [aws_cloudwatch_event_rule.karpenter](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_target.karpenter](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/cloudwatch_event_target) | resource |
+| [aws_cloudwatch_log_group.eks_cluster](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/cloudwatch_log_group) | resource |
+| [aws_ec2_tag.karpenter_discovery_sg](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/ec2_tag) | resource |
+| [aws_ec2_tag.karpenter_discovery_subnet](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/ec2_tag) | resource |
+| [aws_eks_addon.main](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/eks_addon) | resource |
+| [aws_eks_cluster.main](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/eks_cluster) | resource |
+| [aws_eks_fargate_profile.main](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/eks_fargate_profile) | resource |
+| [aws_eks_node_group.main](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/eks_node_group) | resource |
+| [aws_eks_pod_identity_association.aws_lb_controller](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/eks_pod_identity_association) | resource |
+| [aws_eks_pod_identity_association.cert_manager](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/eks_pod_identity_association) | resource |
+| [aws_eks_pod_identity_association.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/eks_pod_identity_association) | resource |
+| [aws_eks_pod_identity_association.external_dns](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/eks_pod_identity_association) | resource |
+| [aws_eks_pod_identity_association.karpenter](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/eks_pod_identity_association) | resource |
+| [aws_iam_instance_profile.karpenter_node](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_instance_profile) | resource |
+| [aws_iam_policy.aws_lb_controller](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.cert_manager](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.external_dns](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.karpenter_controller](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.pod_identity_agent](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_policy) | resource |
+| [aws_iam_role.aws_lb_controller](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role) | resource |
+| [aws_iam_role.cert_manager](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role) | resource |
+| [aws_iam_role.cluster](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role) | resource |
+| [aws_iam_role.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role) | resource |
+| [aws_iam_role.ebs_csi](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role) | resource |
+| [aws_iam_role.efs_csi](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role) | resource |
+| [aws_iam_role.external_dns](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role) | resource |
+| [aws_iam_role.fargate](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role) | resource |
+| [aws_iam_role.karpenter_controller](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role) | resource |
+| [aws_iam_role.karpenter_node](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role) | resource |
+| [aws_iam_role.node_group](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role) | resource |
+| [aws_iam_role.pod_identity_agent](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role) | resource |
+| [aws_iam_role.vpc_cni](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.aws_lb_controller](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.cert_manager](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.cluster_AmazonEKSClusterPolicy](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.cluster_AmazonEKSVPCResourceController](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.ebs_csi](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.efs_csi](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.external_dns](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.fargate_pod_execution_role_policy](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.karpenter_controller](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.karpenter_node](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.node_group_AmazonEC2ContainerRegistryReadOnly](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.node_group_AmazonEKSWorkerNodePolicy](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.node_group_AmazonEKS_CNI_Policy](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.pod_identity_agent](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.vpc_cni](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_kms_alias.ebs_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/kms_alias) | resource |
+| [aws_kms_alias.eks_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/kms_alias) | resource |
+| [aws_kms_key.ebs_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/kms_key) | resource |
+| [aws_kms_key.eks_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/kms_key) | resource |
+| [aws_launch_template.node_group](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/launch_template) | resource |
+| [aws_security_group.cluster_api_access](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/security_group) | resource |
+| [aws_sqs_queue.karpenter](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/sqs_queue) | resource |
+| [aws_sqs_queue_policy.karpenter](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/sqs_queue_policy) | resource |
 | [local_sensitive_file.kubeconfig](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/sensitive_file) | resource |
 | [null_resource.create_kubeconfig_dir](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/data-sources/caller_identity) | data source |
-| [aws_eks_addon_version.default](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/data-sources/eks_addon_version) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/data-sources/region) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/data-sources/caller_identity) | data source |
+| [aws_eks_addon_version.default](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/data-sources/eks_addon_version) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/data-sources/region) | data source |
 
 ## Inputs
 

--- a/terraform/cluster/aws-eks/additions/README.md
+++ b/terraform/cluster/aws-eks/additions/README.md
@@ -16,14 +16,14 @@ Kubernetes API once the control plane is reachable.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 6.47.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 6.51.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 3.1.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.47.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 3.1.0 |
 
 ## Modules
@@ -36,7 +36,7 @@ No modules.
 |------|------|
 | [kubernetes_config_map_v1.external_dns](https://registry.terraform.io/providers/hashicorp/kubernetes/3.1.0/docs/resources/config_map_v1) | resource |
 | [kubernetes_namespace_v1.system_dns](https://registry.terraform.io/providers/hashicorp/kubernetes/3.1.0/docs/resources/namespace_v1) | resource |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/data-sources/region) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/data-sources/region) | data source |
 
 ## Inputs
 

--- a/terraform/cluster/azure-aks/README.md
+++ b/terraform/cluster/azure-aks/README.md
@@ -65,14 +65,14 @@ The next apply will then only show creates.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.74.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.78.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.74.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.78.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | 3.3.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.8.1 |
 | <a name="provider_time"></a> [time](#provider\_time) | 0.13.1 |

--- a/terraform/cni/cilium/README.md
+++ b/terraform/cni/cilium/README.md
@@ -38,7 +38,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cgroup_auto_mount"></a> [cgroup\_auto\_mount](#input\_cgroup\_auto\_mount) | Let Cilium mount the cgroup2 fs at startup (chart default). Set to false on systems that mount cgroups during init (Talos, most systemd-based distros on recent kernels) so Cilium uses the pre-mounted path instead of racing to mount its own. | `bool` | `true` | no |
-| <a name="input_cilium_version"></a> [cilium\_version](#input\_cilium\_version) | Version of the Cilium Helm chart to install. | `string` | `"1.19.4"` | no |
+| <a name="input_cilium_version"></a> [cilium\_version](#input\_cilium\_version) | Version of the Cilium Helm chart to install. | `string` | `"1.19.5"` | no |
 | <a name="input_cluster_endpoint"></a> [cluster\_endpoint](#input\_cluster\_endpoint) | Kubernetes API server endpoint (https://host:port). Required when kube\_proxy\_replacement is true so Cilium can reach the API server before eBPF service rules are active. | `string` | `""` | no |
 | <a name="input_ipam_mode"></a> [ipam\_mode](#input\_ipam\_mode) | Cilium IPAM mode. 'kubernetes' uses node CIDR ranges (default, works for Talos and standard EKS). 'eni' uses AWS ENI-based allocation for EKS native networking. | `string` | `"kubernetes"` | no |
 | <a name="input_kube_proxy_replacement"></a> [kube\_proxy\_replacement](#input\_kube\_proxy\_replacement) | Replace kube-proxy with Cilium's eBPF implementation. Requires cluster\_endpoint to be set. Recommended for Talos and EKS. | `bool` | `true` | no |

--- a/terraform/dns/zone/azure-dns/README.md
+++ b/terraform/dns/zone/azure-dns/README.md
@@ -16,13 +16,13 @@ resources.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.74.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.78.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.74.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.78.0 |
 
 ## Modules
 

--- a/terraform/dns/zone/route53/README.md
+++ b/terraform/dns/zone/route53/README.md
@@ -48,14 +48,14 @@ plus storage cost scales with query volume.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 6.47.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 6.51.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.47.0 |
-| <a name="provider_aws.us_east_1"></a> [aws.us\_east\_1](#provider\_aws.us\_east\_1) | 6.47.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_aws.us_east_1"></a> [aws.us\_east\_1](#provider\_aws.us\_east\_1) | 6.51.0 |
 
 ## Modules
 
@@ -65,14 +65,14 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_cloudwatch_log_group.query_log](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/cloudwatch_log_group) | resource |
-| [aws_cloudwatch_log_resource_policy.query_log](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/cloudwatch_log_resource_policy) | resource |
-| [aws_kms_key.dnssec](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/kms_key) | resource |
-| [aws_route53_hosted_zone_dnssec.main](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/route53_hosted_zone_dnssec) | resource |
-| [aws_route53_key_signing_key.dnssec](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/route53_key_signing_key) | resource |
-| [aws_route53_query_log.main](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/route53_query_log) | resource |
-| [aws_route53_zone.main](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/route53_zone) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/data-sources/caller_identity) | data source |
+| [aws_cloudwatch_log_group.query_log](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_log_resource_policy.query_log](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/cloudwatch_log_resource_policy) | resource |
+| [aws_kms_key.dnssec](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/kms_key) | resource |
+| [aws_route53_hosted_zone_dnssec.main](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/route53_hosted_zone_dnssec) | resource |
+| [aws_route53_key_signing_key.dnssec](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/route53_key_signing_key) | resource |
+| [aws_route53_query_log.main](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/route53_query_log) | resource |
+| [aws_route53_zone.main](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/route53_zone) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/data-sources/caller_identity) | data source |
 
 ## Inputs
 

--- a/terraform/network/aws-vpc/README.md
+++ b/terraform/network/aws-vpc/README.md
@@ -17,13 +17,13 @@ lists describe the same AZ. Outputs feed the `cluster/aws-eks` module.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 6.47.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 6.51.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.47.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 
 ## Modules
 
@@ -33,30 +33,30 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_cloudwatch_log_group.vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/cloudwatch_log_group) | resource |
-| [aws_default_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/default_security_group) | resource |
-| [aws_eip.nat](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/eip) | resource |
-| [aws_flow_log.main](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/flow_log) | resource |
-| [aws_iam_role.vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy.vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/iam_role_policy) | resource |
-| [aws_internet_gateway.main](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/internet_gateway) | resource |
-| [aws_kms_alias.vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/kms_alias) | resource |
-| [aws_kms_key.vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/kms_key) | resource |
-| [aws_nat_gateway.main](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/nat_gateway) | resource |
-| [aws_route53_zone.main](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/route53_zone) | resource |
-| [aws_route_table.isolated](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/route_table) | resource |
-| [aws_route_table.private](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/route_table) | resource |
-| [aws_route_table.public](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/route_table) | resource |
-| [aws_route_table_association.isolated](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/route_table_association) | resource |
-| [aws_route_table_association.private](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/route_table_association) | resource |
-| [aws_route_table_association.public](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/route_table_association) | resource |
-| [aws_subnet.isolated](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/subnet) | resource |
-| [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/subnet) | resource |
-| [aws_subnet.public](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/subnet) | resource |
-| [aws_vpc.main](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/resources/vpc) | resource |
-| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/data-sources/availability_zones) | data source |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/data-sources/caller_identity) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/6.47.0/docs/data-sources/region) | data source |
+| [aws_cloudwatch_log_group.vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/cloudwatch_log_group) | resource |
+| [aws_default_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/default_security_group) | resource |
+| [aws_eip.nat](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/eip) | resource |
+| [aws_flow_log.main](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/flow_log) | resource |
+| [aws_iam_role.vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/iam_role_policy) | resource |
+| [aws_internet_gateway.main](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/internet_gateway) | resource |
+| [aws_kms_alias.vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/kms_alias) | resource |
+| [aws_kms_key.vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/kms_key) | resource |
+| [aws_nat_gateway.main](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/nat_gateway) | resource |
+| [aws_route53_zone.main](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/route53_zone) | resource |
+| [aws_route_table.isolated](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/route_table) | resource |
+| [aws_route_table.private](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/route_table) | resource |
+| [aws_route_table.public](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/route_table) | resource |
+| [aws_route_table_association.isolated](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/route_table_association) | resource |
+| [aws_route_table_association.private](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/route_table_association) | resource |
+| [aws_route_table_association.public](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/route_table_association) | resource |
+| [aws_subnet.isolated](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/subnet) | resource |
+| [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/subnet) | resource |
+| [aws_subnet.public](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/subnet) | resource |
+| [aws_vpc.main](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/resources/vpc) | resource |
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/data-sources/availability_zones) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/data-sources/caller_identity) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/6.51.0/docs/data-sources/region) | data source |
 
 ## Inputs
 

--- a/terraform/network/azure-vnet/README.md
+++ b/terraform/network/azure-vnet/README.md
@@ -16,13 +16,13 @@ Outputs feed the `cluster/azure-aks` module.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.74.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.78.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.74.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.78.0 |
 
 ## Modules
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> Documentation-only change: regenerates Terraform module READMEs with no edits to module code, so it cannot affect plan or apply behavior.
>
> **Overview**
>
> Refreshes the terraform-docs output across the backend, cluster, CNI, DNS, and network modules so the generated Requirements, Providers, and Resources tables match the provider and chart bumps that landed earlier via renovate (notably aws 6.51.0 and cilium 1.19.5) without a docs regeneration.
>
> Brings the tree back in sync with `task docs:terraform`, clearing the `docs:terraform:check` drift that was failing Code Quality across open PRs rather than anything specific to this change.
>
> Reviewed by Claude for commit `02fe2f15`.

<!-- /claude-code-review:summary -->
