### PR TITLE
ci(review): write PR summary via gh api PATCH instead of gh pr edit

### DIFF
--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -210,7 +210,7 @@ jobs:
               pathlib.Path("/tmp/pr-body.new.md").write_text(new)
               PY
 
-              gh pr edit "$PR_NUMBER" --body-file /tmp/pr-body.new.md
+              gh api --method PATCH "repos/$GH_REPO/pulls/$PR_NUMBER" --field body=@/tmp/pr-body.new.md
 
             Clean up any legacy sticky comment posted as a standalone
             conversation comment by earlier runs (one-time migration):
@@ -450,7 +450,7 @@ jobs:
               pathlib.Path("/tmp/pr-body.new.md").write_text(new)
               PY
 
-              gh pr edit "$PR_NUMBER" --body-file /tmp/pr-body.new.md
+              gh api --method PATCH "repos/$GH_REPO/pulls/$PR_NUMBER" --field body=@/tmp/pr-body.new.md
 
             Clean up any legacy sticky comment posted as a standalone
             conversation comment by earlier runs (one-time migration):


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> Edits the Claude review workflow that runs on every pull request, so the blast radius is the review automation itself rather than product code.
>
> **Overview**
>
> Switches the review bot's sticky-summary step from `gh pr edit --body-file` to the REST `gh api --method PATCH` endpoint in both the PR-review and `/review`-comment jobs, so the bot can write a PR description again.
>
> `gh pr edit` had been silently failing because it still requests the deprecated Projects (classic) `projectCards` GraphQL field, which now hard-errors since the sunset; the REST path never touches that field and is independent of the runner's `gh` version.
>
> This PR's own review run is the smoke test — a populated description here confirms the fix works end to end.
>
> Reviewed by Claude for commit `33ec560`.

<!-- /claude-code-review:summary -->
