### PR TITLE
fix(ci): investigate integration failures once per PR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,10 @@ env:
   # renovate: datasource=github-releases depName=helm package=helm/helm
   HELM_VERSION: v4.2.2
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   # ===========================================================================
@@ -546,8 +550,25 @@ jobs:
       # Runs on any non-none phase. Inspects the still-running cluster and
       # publishes a diagnosis to the PR conversation (upsert), step summary,
       # and uploaded artifact. No cluster mutation — strictly read-only tools.
+      - name: Check for existing diagnosis
+        id: diag_check
+        if: always() && steps.phase.outputs.phase != 'none' && github.event_name == 'pull_request' && steps.phase.outputs.phase != 'baseline'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          MARKER: "<!-- claude-integration-${{ matrix.mode }}-diagnosis -->"
+        run: |
+          if COUNT=$(gh api --paginate "repos/$GH_REPO/issues/$PR_NUMBER/comments" \
+                --jq "[.[] | select(.body | contains(\"$MARKER\"))] | length"); then
+            echo "existing=$COUNT" >> "$GITHUB_OUTPUT"
+            [ "$COUNT" -gt 0 ] && echo "Already diagnosed mode '${{ matrix.mode }}' — skipping." || true
+          else
+            echo "existing=0" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Investigate failure with Claude
-        if: always() && steps.phase.outputs.phase != 'none' && github.event_name == 'pull_request'
+        if: always() && steps.phase.outputs.phase != 'none' && github.event_name == 'pull_request' && steps.diag_check.outputs.existing == '0' && steps.phase.outputs.phase != 'baseline'
         uses: anthropics/claude-code-action@80b31826338489861333dc17217865dfe8085cdc # v1.0.155
         env:
           GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
## What

Stops the `Investigate failure with Claude` step in `.github/workflows/ci.yaml` from re-running an expensive (`--max-turns 100`, full CI logs + live cluster inspection) investigation on every failing push across the `fresh`+`upgrade` matrix.

## Changes (one file: `.github/workflows/ci.yaml`)

1. **Top-level `concurrency` block** — cancels superseded runs per PR/ref (`cancel-in-progress: true`).
2. **`Check for existing diagnosis` gate step** — before the investigation, counts PR comments containing the per-mode marker `<!-- claude-integration-<mode>-diagnosis -->` (the diagnosis the investigation already posts) and exposes the count as `existing`. Fails open: if the `gh api` lookup errors, `existing=0` so the investigation still runs and the first diagnosis is never lost.
3. **Extended `if:` on the investigation step** — adds `steps.diag_check.outputs.existing == '0'` and `steps.phase.outputs.phase != 'baseline'`.

## Behavior

- Investigates the **first** failure per PR per mode (`install`/`upgrade`).
- Skips every later failing push once a diagnosis exists.
- Skips `baseline` failures entirely (that means `main` is broken, not the PR).
- Cancels superseded runs.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yaml'))"` → OK
- `actionlint` → exit 0