### PR TITLE
fix(ci): fetch publish-review.sh from main, not the PR's own tree

### DIFF
--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -115,7 +115,14 @@ jobs:
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: bash .github/scripts/publish-review.sh
+        run: |
+          # The publish script is CI infrastructure that lives on main, not in the
+          # PR's own tree — a PR branch opened or last pushed before this script was
+          # added won't have it. Always run main's copy regardless of what commit
+          # the checkout step left in the working directory.
+          git fetch --depth=1 origin main
+          git show origin/main:.github/scripts/publish-review.sh > /tmp/publish-review.sh
+          bash /tmp/publish-review.sh
 
   review-on-comment:
     name: Full Review (on-demand)
@@ -227,7 +234,14 @@ jobs:
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}
           PR_HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
-        run: bash .github/scripts/publish-review.sh
+        run: |
+          # The publish script is CI infrastructure that lives on main, not in the
+          # PR's own tree — a PR branch opened or last pushed before this script was
+          # added won't have it. Always run main's copy regardless of what commit
+          # the checkout step left in the working directory.
+          git fetch --depth=1 origin main
+          git show origin/main:.github/scripts/publish-review.sh > /tmp/publish-review.sh
+          bash /tmp/publish-review.sh
 
   resolve-threads:
     name: Resolve Threads


### PR DESCRIPTION
## Same bug found and fixed in cli

While porting the review-publish fix to cli, re-dispatching onto an existing PR (windsorcli/cli#2917) surfaced a real crash: the on-demand review job checks out the PR's own commit (\`ref: inputs.head_sha\` in cli; \`ref: steps.pr.outputs.head_ref\` here in core's \`review-on-comment\`), not \`main\`. Any PR branch opened or last pushed before \`.github/scripts/publish-review.sh\` was added (#2131) doesn't have the script in its tree:

\`\`\`
bash: .github/scripts/publish-review.sh: No such file or directory
##[error]Process completed with exit code 127.
\`\`\`

Nothing gets posted — not even the fail-loud stub, since the script that posts the stub is the thing missing. This hits every currently-open PR here until it rebases past #2131, in both the \`review\` and \`review-on-comment\` jobs.

## Status: fixed here, unconfirmed live

I haven't observed this actually happen in core yet — no \`/review\` comment has landed on a PR predating #2131. The mechanism is identical to the confirmed cli failure ([cli#2919](https://github.com/windsorcli/cli/pull/2919), verified end-to-end via re-dispatch onto windsorcli/cli#2917), so this ports the same fix preemptively rather than waiting to reproduce it here.

## Fix

Both \`Publish review\` steps now fetch and run main's copy of the script explicitly instead of relying on whatever commit the checkout step left in the working directory:

\`\`\`bash
git fetch --depth=1 origin main
git show origin/main:.github/scripts/publish-review.sh > /tmp/publish-review.sh
bash /tmp/publish-review.sh
\`\`\`

## Validation

\`yamllint\` (repo config) and \`actionlint\` clean — the one remaining actionlint note is a pre-existing style nit in the untouched \`Get PR details\` step, not part of this change.

<!-- claude-code-review:summary -->

> [!WARNING]
>
> **Review did not complete**
>
> The automated review produced no summary. See the [run](https://github.com/windsorcli/core/actions/runs/28751616083).

<!-- /claude-code-review:summary -->
