### PR TITLE
Revert trust-manager helm release bump to v0.24.0

### DIFF
--- a/kustomize/pki/base/trust-manager/helm-release.yaml
+++ b/kustomize/pki/base/trust-manager/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       chart: trust-manager
       # renovate: datasource=helm depName=trust-manager package=trust-manager helmRepo=https://charts.jetstack.io
-      version: 0.24.0
+      version: 0.22.1
       sourceRef: 
         kind: HelmRepository
         name: jetstack


### PR DESCRIPTION
## Summary
- Reverts #2074, which bumped the trust-manager helm chart from 0.22.1 to 0.24.0
- That PR merged with zero human review and while the `Integration (fresh)` CI check was failing, because the Renovate app's bypass permissions on the main ruleset skip required status checks in addition to required reviews
- v0.24.0 also carries a possibly-breaking Helm values change (`app.securityContext.seccompProfileEnabled` removed/replaced)

## Test plan
- [ ] CI passes, including `Integration (fresh)` and `Integration (upgrade)`
- [ ] Human review confirms the revert is clean

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This PR reverts a single Helm chart version pin for trust-manager, walking the dependency back from 0.24.0 to 0.22.1 — an isolated, easily reversible change to the PKI stack.
>
> **Overview**
>
> The PR undoes the trust-manager upgrade that was merged in #2074, restoring the `version` field in `kustomize/pki/base/trust-manager/helm-release.yaml` to 0.22.1. No other files are touched; all chart configuration, source references, and Renovate annotations remain unchanged.
>
> The revert implies 0.24.0 introduced a regression or incompatibility in the target environment. The Renovate comment is still in place, so the bot will propose the upgrade again unless it is ignored or the underlying issue is resolved first.
>
> Reviewed by Claude for commit `5ff97441`.

<!-- /claude-code-review:summary -->
