### PR TITLE
fix(ci): widen resolve-threads tool allowlist to prevent turn exhaustion

### DIFF
--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -334,5 +334,5 @@ jobs:
           claude_args: |
             --model claude-sonnet-4-6
             --max-turns 15
-            --allowedTools "Read,Bash(gh api:*),Bash(cat:*),Bash(jq:*)"
+            --allowedTools "Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Bash(gh api:*),Bash(cat:*),Bash(jq:*)"
             --disallowedTools WebSearch,WebFetch


### PR DESCRIPTION
- widen resolve-threads job allowedTools in .github/workflows/claude-code-review.yaml to add Grep, Glob, Bash(git diff:*), Bash(git log:*)
- matches the read-only toolset Full Review already uses, minus Write

<!-- claude-code-review:summary -->

> [!WARNING]
>
> **Review did not complete**
>
> The automated review produced no summary. See the [run](https://github.com/windsorcli/core/actions/runs/29166922118).

<!-- /claude-code-review:summary -->
