### PR TITLE
chore(ci): update concurrency settings to use SHA for group identification

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,8 +41,8 @@ env:
   HELM_VERSION: v4.2.3
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change touches only the CI concurrency block in `.github/workflows/ci.yaml` and has no effect on production code or deployment logic.
>
> **Overview**
>
> The PR makes two related adjustments to the workflow's `concurrency` settings. First, it switches the fallback group key from `github.ref` to `github.sha`, so non-PR triggers (e.g. push to main) each get a unique concurrency group per commit rather than sharing one group across the entire ref. Second, it gates `cancel-in-progress` on `github.event_name == 'pull_request'`, so only PR runs cancel each other; push-to-main runs are now allowed to complete even when a newer commit has landed.
>
> Together these changes prevent main-branch CI results from being silently dropped when commits land in quick succession, while preserving the existing fast-feedback behaviour for pull requests.
>
> Reviewed by Claude for commit `5160a55d`.

<!-- /claude-code-review:summary -->
