### PR TITLE
chore(tests): update CRD references and add renovate datasource annotations

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -223,7 +223,8 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/^contexts/_template/facets/.*\\.ya?ml$/"
+        "/^contexts/_template/facets/.*\\.ya?ml$/",
+        "/^contexts/_template/tests/.*\\.ya?ml$/"
       ],
       "description": "Parse helm renovate annotations on CRD layer refs (<name>-<version>)",
       "matchStrings": [
@@ -238,7 +239,8 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/^contexts/_template/facets/.*\\.ya?ml$/"
+        "/^contexts/_template/facets/.*\\.ya?ml$/",
+        "/^contexts/_template/tests/.*\\.ya?ml$/"
       ],
       "description": "Parse non-helm renovate annotations on CRD layer refs (<name>-<version>)",
       "matchStrings": [

--- a/contexts/_template/tests/option-gateway.test.yaml
+++ b/contexts/_template/tests/option-gateway.test.yaml
@@ -101,9 +101,11 @@ cases:
         - *gateway-base-cilium
         - *gateway-resources-cilium
       crds:
+        # renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api package=kubernetes-sigs/gateway-api
         - gateway-api-experimental-1.6.0
     exclude:
       crds:
+        # renovate: datasource=github-releases depName=envoyproxy/gateway package=envoyproxy/gateway
         - envoy-gateway-1.8.2
 
   # Docker Desktop: nodeport (docker-desktop defaults to envoy; no cilium bootstrap)
@@ -171,7 +173,9 @@ cases:
         - *gateway-base-envoy-lb
         - *gateway-resources-envoy
       crds:
+        # renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api package=kubernetes-sigs/gateway-api
         - gateway-api-experimental-1.6.0
+        # renovate: datasource=github-releases depName=envoyproxy/gateway package=envoyproxy/gateway
         - envoy-gateway-1.8.2
 
   # Envoy + Docker Desktop: nodeport variant
@@ -288,7 +292,9 @@ cases:
         - *gateway-base-envoy-lb
         - *gateway-resources-envoy
       crds:
+        # renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api package=kubernetes-sigs/gateway-api
         - gateway-api-experimental-1.6.0
+        # renovate: datasource=github-releases depName=envoyproxy/gateway package=envoyproxy/gateway
         - envoy-gateway-1.8.2
 
   - name: legacy ingress alias maps nginx to envoy
@@ -318,7 +324,9 @@ cases:
         - name: gateway-resources
         - name: gateway-base
       crds:
+        # renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api package=kubernetes-sigs/gateway-api
         - gateway-api-experimental-1.6.0
+        # renovate: datasource=github-releases depName=envoyproxy/gateway package=envoyproxy/gateway
         - envoy-gateway-1.8.2
 
   # Flux webhook receiver includes webhook/gateway for Gateway API drivers

--- a/contexts/_template/tests/platform-aws.test.yaml
+++ b/contexts/_template/tests/platform-aws.test.yaml
@@ -48,6 +48,7 @@ cases:
           timeout: 5m
           interval: 5m
       crds:
+        # renovate: datasource=helm depName=aws-load-balancer-controller package=aws-load-balancer-controller helmRepo=https://aws.github.io/eks-charts
         - aws-load-balancer-controller-3.4.0
 
   # Regression: workstation.runtime must not activate option-workstation on AWS.

--- a/contexts/_template/tests/platform-base.test.yaml
+++ b/contexts/_template/tests/platform-base.test.yaml
@@ -89,8 +89,11 @@ cases:
           timeout: 15m
           interval: 10m
       crds:
+        # renovate: datasource=github-releases depName=cert-manager/cert-manager package=cert-manager/cert-manager
         - cert-manager-1.20.2
+        # renovate: datasource=github-releases depName=prometheus-operator/prometheus-operator package=prometheus-operator/prometheus-operator
         - prometheus-operator-0.92.1
+        # renovate: datasource=helm depName=fluent-operator package=fluent-operator helmRepo=https://fluent.github.io/helm-charts
         - fluent-operator-4.1.0
 
   # Full: observability addon enabled; addon wins for same-name observability (grafana + fluentd/outputs/stdout)
@@ -380,6 +383,7 @@ cases:
           components:
             - cert-manager
       crds:
+        # renovate: datasource=github-releases depName=cert-manager/cert-manager package=cert-manager/cert-manager
         - cert-manager-1.20.2
     exclude:
       flux:
@@ -387,7 +391,9 @@ cases:
       kustomize:
         - name: observability
       crds:
+        # renovate: datasource=github-releases depName=prometheus-operator/prometheus-operator package=prometheus-operator/prometheus-operator
         - prometheus-operator-0.92.1
+        # renovate: datasource=helm depName=fluent-operator package=fluent-operator helmRepo=https://fluent.github.io/helm-charts
         - fluent-operator-4.1.0
 
   # Metrics on, logs off: Prometheus stack deploys, fluent-bit and fluentd are
@@ -470,10 +476,13 @@ cases:
             - fluentd
             - fluentd/filters/otel
       crds:
+        # renovate: datasource=github-releases depName=cert-manager/cert-manager package=cert-manager/cert-manager
         - cert-manager-1.20.2
+        # renovate: datasource=helm depName=fluent-operator package=fluent-operator helmRepo=https://fluent.github.io/helm-charts
         - fluent-operator-4.1.0
     exclude:
       crds:
+        # renovate: datasource=github-releases depName=prometheus-operator/prometheus-operator package=prometheus-operator/prometheus-operator
         - prometheus-operator-0.92.1
 
   # Observability addon force-overrides both telemetry toggles — Grafana needs


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change extends Renovate's automated dependency tracking to test files, where it previously only covered facet files — a pure tooling configuration change with no runtime impact.
>
> **Overview**
>
> The PR does two things in concert: it expands two Renovate regex custom managers to also scan `contexts/_template/tests/` YAML files (in addition to the existing `facets/` pattern), and it backfills the matching `# renovate:` datasource annotations onto the hardcoded CRD version strings already present in those test files. Together these changes let Renovate open automated bump PRs for CRD versions referenced in tests, just as it already does for facets.
>
> The annotations cover four datasources across three test files: `cert-manager`, `prometheus-operator`, `fluent-operator`, `gateway-api-experimental`, `envoy-gateway`, and `aws-load-balancer-controller`. No logic, defaults, or runtime behavior is affected.
>
> Reviewed by Claude for commit `95364318`.

<!-- /claude-code-review:summary -->
