### PR TITLE
chore(test): correct flux install/resources tier assertions for object-store and lb

### DIFF
--- a/contexts/_template/tests/addon-object-store.test.yaml
+++ b/contexts/_template/tests/addon-object-store.test.yaml
@@ -44,7 +44,7 @@ cases:
       flux:
         - name: object-store
           dependsOn:
-            - csi
+            - csi-install
           install:
             components:
               - minio
@@ -82,7 +82,7 @@ cases:
       flux:
         - name: object-store
           dependsOn:
-            - csi
+            - csi-install
           install:
             components:
               - minio

--- a/contexts/_template/tests/platform-hyperv.test.yaml
+++ b/contexts/_template/tests/platform-hyperv.test.yaml
@@ -143,7 +143,6 @@ cases:
               - metallb
           resources:
             - components:
-                - metallb
                 - metallb/arp
               substitutions:
                 loadbalancer_ip_range: 10.20.0.100-10.20.0.110

--- a/contexts/_template/tests/platform-incus.test.yaml
+++ b/contexts/_template/tests/platform-incus.test.yaml
@@ -192,7 +192,6 @@ cases:
             interval: 5m
           resources:
             - components:
-                - metallb
                 - metallb/arp
               substitutions:
                 loadbalancer_ip_range: 10.10.1.10-10.10.1.100
@@ -293,8 +292,6 @@ cases:
         - name: cni
       flux:
         - name: cni
-      kustomize:
-        - name: lb-install
 
   # Edge case: Schedulable controlplanes use controlplane volume path
   - name: schedulable controlplanes use controlplane volume path for CSI

--- a/contexts/_template/tests/platform-metal.test.yaml
+++ b/contexts/_template/tests/platform-metal.test.yaml
@@ -230,7 +230,6 @@ cases:
             interval: 5m
           resources:
             - components:
-                - metallb
                 - metallb/arp
               substitutions:
                 loadbalancer_ip_range: 192.168.1.100-192.168.1.200


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> Test-only corrections to assertion fixtures — no production code is touched, and the changes are straightforwardly reversible.
>
> **Overview**
>
> This PR fixes inaccurate tier assertions across four blueprint test files. The `object-store` addon's `dependsOn` field is corrected from `csi` to `csi-install` in two cases, aligning the test expectation with the actual Flux kustomization name. Across the `hyperv`, `incus`, and `metal` platform tests, the `metallb` base component is removed from `resources.components` lists, leaving only the `metallb/arp` subcomponent — matching what the lb resources tier actually installs.
>
> A `kustomize: lb-install` assertion block is also removed from the incus "no lb addon" edge-case test, which is consistent with the resources-tier cleanup.
>
> Reviewed by Claude for commit `e896f54b`.

<!-- /claude-code-review:summary -->
