### PR TITLE
chore(facets): adopt policy globalDependency

### DIFF
--- a/contexts/_template/facets/option-cni.yaml
+++ b/contexts/_template/facets/option-cni.yaml
@@ -73,12 +73,13 @@ flux:
   # Two variants — they differ in Talos-specific settings and how
   # k8s_service_host is derived:
   #
-  # The dep on policy-resources serves two purposes. Normally (policies on) it
-  # preserves ordering so Cilium pods are re-rolled after Kyverno's mutation
-  # policies are live. When the cilium/gateway component is active it also
-  # ships a ClusterPolicy (LBIPAM IP sharing); disabling policies in that
-  # combination would otherwise fail on "no matches for kind ClusterPolicy",
-  # so the dep is kept present to surface it as DependencyNotReady instead.
+  # Ordering against Kyverno's mutation policies is handled globally by policy's
+  # globalDependency barrier, so no explicit policy-resources dep is needed for
+  # the normal (policies on) case. The one exception is cilium/gateway: it ships
+  # a ClusterPolicy (LBIPAM IP sharing), so with policies disabled the apply
+  # would fail on "no matches for kind ClusterPolicy". The cilium-gated dep below
+  # keeps policy-resources present in that combination to surface it as
+  # DependencyNotReady instead.
   #
 
   # Talos: cilium/talos applies Talos-specific security context + cgroup
@@ -86,7 +87,7 @@ flux:
   - name: cni
     when: talos_enabled
     dependsOn:
-      - "${(policies.enabled ?? true) || (gateway.enabled == true && gateway.driver == 'cilium') ? 'policy-resources' : ''}"
+      - "${(gateway.enabled == true && gateway.driver == 'cilium') ? 'policy-resources' : ''}"
       - "${telemetry.metrics.enabled || telemetry.logs.enabled ? 'telemetry-install' : ''}"
     install:
       components:
@@ -110,7 +111,7 @@ flux:
   - name: cni
     when: eks_enabled
     dependsOn:
-      - "${(policies.enabled ?? true) || (gateway.enabled == true && gateway.driver == 'cilium') ? 'policy-resources' : ''}"
+      - "${(gateway.enabled == true && gateway.driver == 'cilium') ? 'policy-resources' : ''}"
       - "${telemetry.metrics.enabled || telemetry.logs.enabled ? 'telemetry-install' : ''}"
     install:
       components:

--- a/contexts/_template/facets/option-storage.yaml
+++ b/contexts/_template/facets/option-storage.yaml
@@ -72,8 +72,6 @@ flux:
   #
   - name: csi
     when: talos_common.storage_driver == 'openebs'
-    dependsOn:
-      - "${(policies.enabled ?? true) ? 'policy-resources' : ''}"
     install:
       components:
         - openebs
@@ -96,7 +94,6 @@ flux:
   - name: csi
     when: talos_common.storage_driver == 'longhorn'
     dependsOn:
-      - "${(policies.enabled ?? true) ? 'policy-resources' : ''}"
       - "${telemetry.metrics.enabled || telemetry.logs.enabled ? 'telemetry-install' : ''}"
     install:
       components:

--- a/contexts/_template/facets/platform-aws.yaml
+++ b/contexts/_template/facets/platform-aws.yaml
@@ -355,8 +355,6 @@ flux:
   # startup than fall back to a guess.
   #
   - name: lb
-    dependsOn:
-      - policy-resources
     install:
       components:
         - aws-lb-controller
@@ -378,8 +376,6 @@ flux:
   # cluster-autoscaler.
   #
   - name: compute
-    dependsOn:
-      - policy-resources
     install:
       components:
         - cluster-autoscaler
@@ -394,8 +390,6 @@ flux:
   # configures the StorageClass volumeType; gp3 is the current AWS recommendation.
   # ---------------------------------------------------------------------------
   - name: csi
-    dependsOn:
-      - policy-resources
     install:
       components:
         - aws-ebs
@@ -442,7 +436,6 @@ flux:
   - name: dns
     when: "(dns.public_domain ?? '') != '' || (gateway.access == 'private' && (dns.private_domain ?? '') != '')"
     dependsOn:
-      - policy-resources
       # gateway-install installs the Gateway API CRDs (HTTPRoute, Gateway). When
       # the gateway is on, external-dns is configured with the gateway-httproute
       # source below — without the CRDs present at startup it crash-loops on

--- a/contexts/_template/facets/platform-azure.yaml
+++ b/contexts/_template/facets/platform-azure.yaml
@@ -269,8 +269,6 @@ flux:
   # component only adds a custom `single` StorageClass tuned to our defaults.
   # StandardSSD_LRS is the recommended balance of cost and performance.
   - name: csi
-    dependsOn:
-      - policy-resources
     install:
       components:
         - azure-disk
@@ -307,7 +305,6 @@ flux:
   - name: dns
     when: "(dns.public_domain ?? '') != '' || (gateway.access == 'private' && (dns.private_domain ?? '') != '')"
     dependsOn:
-      - policy-resources
       # gateway-install installs the Gateway API CRDs (HTTPRoute, Gateway). When
       # the gateway is on, external-dns is configured with the gateway-httproute
       # source below — without the CRDs present at startup it crash-loops on

--- a/contexts/_template/facets/platform-base.yaml
+++ b/contexts/_template/facets/platform-base.yaml
@@ -418,6 +418,7 @@ terraform:
 flux:
   - name: policy
     when: (policies.enabled ?? true) == true
+    globalDependency: true
     install:
       components:
         - kyverno
@@ -462,7 +463,6 @@ flux:
   # working Prometheus target from the moment it's created.
   - name: pki
     dependsOn:
-      - "${(policies.enabled ?? true) ? 'policy-resources' : ''}"
       - "${telemetry.metrics.enabled || telemetry.logs.enabled ? 'telemetry-install' : ''}"
     install:
       components:

--- a/contexts/_template/facets/platform-docker.yaml
+++ b/contexts/_template/facets/platform-docker.yaml
@@ -161,8 +161,6 @@ flux:
 
   - name: lb
     when: workstation.runtime != 'docker-desktop' && lb_effective.enabled
-    dependsOn:
-      - policy-resources
     install:
       components:
         - ${lb_effective.driver}

--- a/contexts/_template/facets/platform-hyperv.yaml
+++ b/contexts/_template/facets/platform-hyperv.yaml
@@ -602,8 +602,6 @@ flux:
   #
   - name: lb
     when: lb_effective.enabled
-    dependsOn:
-      - policy-resources
     install:
       components:
         - ${lb_effective.driver}

--- a/contexts/_template/facets/platform-incus.yaml
+++ b/contexts/_template/facets/platform-incus.yaml
@@ -192,8 +192,6 @@ flux:
 
   - name: lb
     when: lb_effective.enabled
-    dependsOn:
-      - policy-resources
     install:
       components:
         - ${lb_effective.driver}

--- a/contexts/_template/facets/platform-metal.yaml
+++ b/contexts/_template/facets/platform-metal.yaml
@@ -104,8 +104,6 @@ flux:
 
   - name: lb
     when: lb_effective.enabled
-    dependsOn:
-      - policy-resources
     install:
       components:
         - ${lb_effective.driver}


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This change reshapes policy-ordering guarantees across every platform — a correctness-sensitive, cross-cutting refactor that warrants careful verification that the new `globalDependency` barrier is semantically equivalent to the explicit `policy-resources` deps it replaces.
>
> **Overview**
>
> The PR centralises the "wait for Kyverno before applying" ordering requirement by adding `globalDependency: true` to the `policy` kustomization in `platform-base.yaml`, then strips the now-redundant explicit `dependsOn: policy-resources` entries from every other facet (AWS, Azure, Docker, HyperV, Incus, Metal, storage, PKI, and the two CNI variants). The one exception is the `cilium/gateway` combination, which retains an explicit `policy-resources` dep to surface a missing-CRD failure as `DependencyNotReady` rather than a cryptic apply error.
>
> The prior explicit deps all pointed at `policy-resources` (the ClusterPolicy layer), while the new `globalDependency` is declared on `policy` (the Kyverno install kustomization itself). Whether these are equivalent depends on Windsor's `globalDependency` implementation: if it synthesises a barrier that covers `policy-resources` as well, the refactor is safe; if it only adds an implicit `dependsOn: policy`, components that previously waited for mutation policies to be live may now race with `policy-resources` reconciliation.
>
> Reviewed by Claude for commit `7f950c73`.

<!-- /claude-code-review:summary -->
