### PR TITLE
chorew(facets): cover gitops/demo resources-only flux systems and no-install guards

### DIFF
--- a/contexts/_template/tests/option-demo.test.yaml
+++ b/contexts/_template/tests/option-demo.test.yaml
@@ -47,6 +47,33 @@ cases:
             - components:
                 - database
 
+  # static + bookinfo apps carry no database dependency, and demo is a
+  # resources-only system, so no demo-install tier is emitted.
+  - name: demo static and bookinfo apps compose as resources tier without install
+    values:
+      platform: metal
+      dev: true
+      demo:
+        enabled: true
+        resources:
+          static: true
+          bookinfo: true
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster: *default-cluster
+    expect:
+      flux:
+        - name: demo
+          path: demo
+          resources:
+            - components:
+                - static
+                - bookinfo
+    exclude:
+      kustomize:
+        - name: demo-install
+
   # Edge case: Demo disabled excludes demo database
   - name: excludes demo database when demo disabled
     values:

--- a/contexts/_template/tests/option-gateway.test.yaml
+++ b/contexts/_template/tests/option-gateway.test.yaml
@@ -357,6 +357,29 @@ cases:
         # renovate: datasource=github-releases depName=envoyproxy/gateway package=envoyproxy/gateway
         - envoy-gateway-1.8.2
 
+  # Gateway disabled: gitops is a resources-only system, so it composes to a
+  # gitops-resources kustomization with the plain webhook (no webhook/gateway,
+  # no gateway-install dep) and emits neither an install tier nor a flat
+  # gitops kustomization.
+  - name: gitops without gateway is webhook-only resources tier with no install tier
+    values:
+      platform: metal
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster: *default-cluster
+    expect:
+      flux:
+        - name: gitops
+          path: gitops
+          resources:
+            - components:
+                - webhook
+    exclude:
+      kustomize:
+        - name: gitops-install
+        - name: gitops
+
   # Flux webhook receiver includes webhook/gateway for Gateway API drivers
   # (push mode is the default, so no explicit gitops.mode needed)
   - name: envoy driver includes webhook/gateway in gitops component
@@ -456,6 +479,10 @@ cases:
                 - gateway-install
               components:
                 - ui
+    exclude:
+      kustomize:
+        - name: flux-ui-install
+        - name: flux-ui
 
   - name: web_ui enabled on cilium adds ui/cilium to flux-ui
     values:


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This PR adds test coverage only — no production code, kustomizations, or facet logic is modified.
>
> **Overview**
>
> Three new test assertions are added across `option-demo.test.yaml` and `option-gateway.test.yaml`. They exercise the resources-only tier behavior of the `demo` and `gitops` flux systems: verifying that when no database-backed app is selected (demo with static/bookinfo only) or when the gateway is disabled (gitops with plain webhook), no install-tier kustomization is emitted. A fourth change adds an `exclude` block to an existing `web_ui` test, asserting that `flux-ui-install` and `flux-ui` kustomizations are absent in that scenario.
>
> All additions follow the established `expect`/`exclude` pattern and are read-only from the perspective of deployed infrastructure.
>
> Reviewed by Claude for commit `6cf893f1`.

<!-- /claude-code-review:summary -->
