### PR TITLE
chore(facets): drop explicit policy-resources deps and trim verbose comments

### DIFF
--- a/contexts/_template/facets/addon-database.yaml
+++ b/contexts/_template/facets/addon-database.yaml
@@ -9,13 +9,10 @@ when: addons.database.postgres.enabled == true
 # =============================================================================
 # Flux systems — CloudNativePG operator
 # =============================================================================
-#
 flux:
 
-  # CloudNativePG operator. Depends on csi because CNPG needs PVCs for WAL
-  # archives and data volumes as soon as the first Cluster is applied. The
-  # `ha` topology adds anti-affinity and PDBs for the operator's own pods.
-  # Install-only: the operator manages Cluster CRs but creates none itself.
+  # CloudNativePG operator. Depends on csi for WAL/data PVCs; `ha` topology
+  # adds anti-affinity and PDBs. Install-only — manages Cluster CRs, creates none.
   - name: database
     when: addons.database.postgres.driver == 'cloudnativepg'
     dependsOn:

--- a/contexts/_template/facets/addon-object-store.yaml
+++ b/contexts/_template/facets/addon-object-store.yaml
@@ -9,13 +9,8 @@ when: addons.object_store.enabled == true
 # =============================================================================
 # Flux systems — object storage driver (MinIO)
 # =============================================================================
-#
-# `addons.object_store.driver` selects the backend. Currently only MinIO is
-# wired up; other drivers (Ceph, cloud-provider managed) can be added as
-# additional `- name: object-store` entries gated on their own driver value.
-# No resources tier: the operator manages Tenant CRs but doesn't create one
-# automatically (see kustomize/object-store/README.md for the manual recipe).
-#
+# `addons.object_store.driver` selects the backend; only MinIO is wired up.
+# Operator manages Tenant CRs but creates none (see kustomize/object-store/README.md).
 flux:
 
   # MinIO depends on csi for PVC-backed storage.

--- a/contexts/_template/facets/addon-observability.yaml
+++ b/contexts/_template/facets/addon-observability.yaml
@@ -9,16 +9,9 @@ when: addons.observability.enabled == true
 # =============================================================================
 # Config — dashboard backend default
 # =============================================================================
-#
-# Land `addons.observability.dashboards` so other facets (option-cni /
-# option-storage patch dashboards into the observability-resources kustomization
-# when dashboards == 'grafana') can read it directly without re-applying the
-# fallback.
-#
-# logs_driver intentionally has no default — an unset driver means "no
-# external log storage, fluentd aggregator only" — so callers read
-# `addons.observability.logs_driver` straight through.
-#
+# Land `addons.observability.dashboards` so other facets can read it without
+# re-applying the fallback. logs_driver has no default — unset means "no external
+# log storage, fluentd aggregator only".
 config:
 
   - name: addons
@@ -29,28 +22,13 @@ config:
 # =============================================================================
 # Flux systems — observability install entries, telemetry override
 # =============================================================================
-#
-# Every observability entry below merges into a single `observability`
-# system. HelmReleases and their HR patches land in the install tier
-# (`observability-install`); dashboards, gateway routes, and fluentd
-# config land in the resources tier (`observability-resources`). The
-# layering strategy is:
-#
-#   1. Base Grafana + standard dashboards (this facet, dashboards=grafana).
-#   2. Gateway route for Grafana (when gateway is up).
-#   3. Log-storage driver pick: stdout / quickwit / elasticsearch.
-#   4. Elasticsearch: also replaces the telemetry flux: system so
-#      fluent-bit ships to filebeat instead of fluentd.
-#
-# Other facets (option-cni, option-storage, addon-database) patch in their
-# own dashboards under `- name: observability` entries.
-#
+# Every entry merges into one `observability` system: HelmReleases land in the
+# install tier, dashboards/routes/fluentd config in the resources tier. Other
+# facets patch in their own dashboards under `- name: observability` entries.
 flux:
 
-  # When Elasticsearch is the log store, replace platform-base's telemetry
-  # system entirely: swap fluent-bit for filebeat (native ES shipper) and drop
-  # the fluentbit/* component stack. `strategy: replace` on the system
-  # descriptor overrides both tiers as one unit.
+  # When Elasticsearch is the log store, replace platform-base's telemetry system:
+  # swap fluent-bit for filebeat (native ES shipper) and drop the fluentbit stack.
   - name: telemetry
     when: addons.observability.logs_driver == 'elasticsearch' && gateway.enabled == true
     strategy: replace
@@ -69,13 +47,8 @@ flux:
         timeout: 10m
         interval: 5m
 
-  # ---------------------------------------------------------------------------
-  # Base: Grafana + standard dashboards
-  # ---------------------------------------------------------------------------
-  #
-  # Substitutions propagate timezone / time format to dashboard panel defs so
-  # timestamps match operator locale. 12h/24h flips all date format strings.
-  #
+  # Base Grafana + standard dashboards. Substitutions propagate timezone/time
+  # format to panel defs so timestamps match operator locale.
   - name: observability
     when: addons.observability.dashboards == 'grafana'
     dependsOn:
@@ -105,14 +78,8 @@ flux:
           date_interval_hour: "${time_format == '12h' ? 'MMM DD hh:mm a' : 'MM/DD HH:mm'}"
           date_interval_day: "${time_format == '12h' ? 'MMM DD' : 'MM/DD'}"
 
-  # ---------------------------------------------------------------------------
-  # Grafana HTTPRoute (Gateway API)
-  # ---------------------------------------------------------------------------
-  #
-  # Adds the Gateway route + Envoy-specific dashboards when the cluster has a
-  # Gateway. All resources tier — waits for gateway-resources so the Gateway
-  # object exists before the HTTPRoute is applied.
-  #
+  # Gateway route + Envoy-specific dashboards when the cluster has a Gateway.
+  # Waits for gateway-resources so the Gateway exists before the HTTPRoute applies.
   - name: observability
     when: addons.observability.dashboards == 'grafana' && gateway.enabled == true
     resources:
@@ -124,16 +91,11 @@ flux:
         substitutions:
           external_domain: "${(dns.public_domain ?? '') == '' ? (dns.private_domain ?? '') : dns.public_domain}"
 
-  # ---------------------------------------------------------------------------
-  # Log storage drivers
-  # ---------------------------------------------------------------------------
-  #
-  # Exactly one driver block fires per logs_driver value. Each wires up the
-  # fluentd output plus any storage backend infrastructure.
-  #
+  # =============================================================================
+  # Log storage drivers — one block fires per logs_driver value
+  # =============================================================================
 
   # stdout: write logs to container stdout (no external store). Dev default.
-  # All resources tier — the output config waits for telemetry-resources.
   - name: observability
     when: addons.observability.logs_driver == 'stdout'
     resources:
@@ -142,9 +104,8 @@ flux:
         components:
           - fluentd/outputs/stdout
 
-  # Quickwit: lightweight search-optimized log store backed by object storage
-  # (with a PVC for staging). Install waits for csi (staging PVC); the fluentd
-  # output config waits for telemetry-resources.
+  # Quickwit: search-optimized log store on object storage (PVC for staging).
+  # Install waits for csi (staging PVC).
   - name: observability
     when: addons.observability.logs_driver == 'quickwit'
     dependsOn:
@@ -162,9 +123,8 @@ flux:
           - fluentd/outputs/quickwit
           - "${addons.observability.dashboards == 'grafana' ? 'grafana/dashboards/logs/quickwit' : ''}"
 
-  # Elasticsearch + Kibana. Gated on gateway.enabled because Kibana
-  # needs an HTTPRoute to be externally reachable. Install waits for csi (ES
-  # data PVCs); the Kibana route waits for gateway-resources.
+  # Elasticsearch + Kibana. Gated on gateway.enabled (Kibana needs an HTTPRoute
+  # to be reachable). Install waits for csi (ES data PVCs).
   - name: observability
     when: addons.observability.logs_driver == 'elasticsearch' && gateway.enabled == true
     dependsOn:

--- a/contexts/_template/facets/addon-private-ca.yaml
+++ b/contexts/_template/facets/addon-private-ca.yaml
@@ -10,17 +10,9 @@ when: addons.private_ca.enabled == true
 # Flux systems — pki (trust-manager + private CA issuer)
 # =============================================================================
 #
-# Layers onto the pki install/resources tiers created by platform-base:
-#   - install adds trust-manager so Bundle CRDs distribute CA certs to
-#     workload namespaces (ConfigMap/Secret fan-out).
-#   - resources installs the private-issuer/ca ClusterIssuer, which becomes
-#     the default issuer for workload certificates.
-#
-# Requires Kyverno (policy-resources): the private-issuer/ca component ships
-# a ClusterPolicy that mutates pods labeled use-custom-ca=true to mount the
-# CA bundle. Without Kyverno's CRDs the apply fails on "no matches for kind
-# ClusterPolicy"; the hard dep below surfaces the incompatibility as
-# DependencyNotReady instead.
+# Layers trust-manager (install) and the private-issuer/ca ClusterIssuer
+# (resources) onto the pki tiers from platform-base. The issuer becomes the
+# default for workload certificates.
 #
 flux:
 
@@ -31,9 +23,7 @@ flux:
       timeout: 10m
       interval: 5m
     resources:
-      - dependsOn:
-          - policy-resources
-        timeout: 5m
+      - timeout: 5m
         interval: 5m
         components:
           - private-issuer/ca

--- a/contexts/_template/facets/addon-private-dns.yaml
+++ b/contexts/_template/facets/addon-private-dns.yaml
@@ -36,19 +36,12 @@ requires:
 #   - external-dns/localhost: docker-desktop override — advertise 127.0.0.1
 #                             instead of the unreachable LB IP.
 #
-# Requires Kyverno (policy-resources) on docker-desktop: external-dns/localhost
-# ships a ClusterPolicy that rewrites ingress DNS targets to 127.0.0.1. Without
-# Kyverno's CRDs the apply fails on "no matches for kind ClusterPolicy"; the
-# docker-desktop-gated dep below surfaces the incompatibility as
-# DependencyNotReady instead.
-#
 flux:
 
   - name: dns
     dependsOn:
       - pki-install
       - "${gateway.driver == 'cilium' ? 'cni' : (gateway.enabled == true ? 'gateway-install' : '')}"
-      - "${workstation.runtime == 'docker-desktop' ? 'policy-resources' : ''}"
     install:
       components:
         - coredns

--- a/contexts/_template/facets/config-talos.yaml
+++ b/contexts/_template/facets/config-talos.yaml
@@ -11,59 +11,44 @@ when: cluster.driver == 'talos'
 # =============================================================================
 # Config — Talos machine patch + extension catalog
 # =============================================================================
-#
-# Everything here funnels into `talos_common`, which is the single object the
-# cluster/talos terraform module consumes. Platform facets (platform-incus,
-# platform-docker, platform-metal) contribute their own overrides before this
-# file is evaluated, and this file layers in the common defaults.
-#
+# Everything funnels into talos_common, the single object the cluster/talos
+# terraform module consumes. Platform facets set overrides first; this file
+# layers in the common defaults.
 config:
 
-  # ---------------------------------------------------------------------------
-  # talos_common defaults
-  # ---------------------------------------------------------------------------
-  #
-  # Values resolved here are the "last line of defense" — platform facets set
-  # platform-specific values first, then this block fills in anything left.
-  #
+  # talos_common defaults: platform facets set platform-specific values first,
+  # then this block fills in anything left.
   - name: talos_common
     value:
 
-      # Storage driver default. Most platforms get 'openebs' (hostPath); incus
-      # overrides to 'longhorn' since its VMs have dedicated block devices.
+      # Storage driver; incus overrides to 'longhorn' (dedicated block devices).
       storage_driver: "${cluster.storage.driver ?? 'openebs'}"
 
-      # Default data disk for Longhorn installations; per-platform facets
-      # override size/name if they need different.
+      # Default Longhorn data disk; platform facets override size/name.
       longhorn_default_disk:
         - name: longhorn
           size: 30
 
-      # topology=single-node implies the control plane must schedule workloads,
-      # so flip this on automatically even if the user didn't set schedulable.
+      # single-node forces the control plane to schedule workloads.
       allowSchedulingOnControlPlanes: "${(cluster.controlplanes.schedulable ?? false) || topology == 'single-node'}"
       controlplane_volumes: "${cluster.controlplanes.volumes ?? []}"
       worker_volumes: "${cluster.workers.volumes ?? []}"
       csi_local_volume_path: "${cluster.storage.local_base_path ?? \"/var/mnt/local\"}"
 
-      # If the user didn't specify disks, use the longhorn default when
-      # longhorn is the driver; otherwise no disks.
+      # Default to the longhorn disk when longhorn is the driver, else no disks.
       controlplane_disks: "${cluster.controlplanes.disks ?? (talos_common.storage_driver == 'longhorn' ? talos_common.longhorn_default_disk : [])}"
       worker_disks: "${cluster.workers.disks ?? (talos_common.storage_driver == 'longhorn' ? talos_common.longhorn_default_disk : [])}"
 
-      # Kubelet serving-cert rotation. The external approver runs as a
-      # static manifest (pre-Flux) so kubelet certs rotate even during
-      # cluster bootstrap. Required because the Talos default is opaque
-      # self-signed certs that don't match node IPs.
+      # Kubelet serving-cert rotation via a static (pre-Flux) manifest so certs
+      # rotate during bootstrap; the Talos default self-signed certs don't match node IPs.
       cert_rotation:
         extra_manifests:
           - "https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml"
         kubelet_extra_args:
           rotate-server-certificates: "true"
 
-      # The actual machine patch that gets stringified into
-      # common_config_patches. Platform facets can merge additional keys into
-      # common_patch; the merged object is serialized below.
+      # Machine patch stringified into common_config_patches; platform facets
+      # can merge additional keys into common_patch.
       common_patch:
         cluster:
           allowSchedulingOnControlPlanes: ${talos_common.allowSchedulingOnControlPlanes}
@@ -73,15 +58,8 @@ config:
             extraArgs: ${talos_common.cert_rotation.kubelet_extra_args}
       common_config_patches: "${string(talos_common.common_patch)}"
 
-      # -----------------------------------------------------------------------
-      # Extension catalog
-      # -----------------------------------------------------------------------
-      #
-      # Map of driver/feature → Talos Image Factory extensions that driver
-      # needs. Add a new key here when introducing a driver with kernel or
-      # tool requirements — no conditional branches elsewhere needed; the
-      # aggregated `extensions` list below picks up the new entry.
-      #
+      # Extension catalog: driver/feature → required Talos Image Factory
+      # extensions. Add a key for a new driver; the aggregated extensions list picks it up.
       csi_extensions:
         longhorn:
           - siderolabs/iscsi-tools
@@ -89,26 +67,12 @@ config:
 
       extensions: "${get(talos_common.csi_extensions, talos_common.storage_driver) ?? []}"
 
-      # First controlplane IP, used as `k8sServiceHost` for Cilium's
-      # kube-proxy replacement. Metal: read from user-provided nodes. Incus
-      # and docker override this with cidrhost(cidr, 10). Colima/docker still
-      # require cluster.controlplanes.nodes in values.yaml. The len() guard
-      # keeps this expression safe to evaluate while platform-metal's
-      # requires is deferring metal-without-nodes — without it, this crashes
-      # before the requires error reaches the user.
+      # First controlplane IP, used as k8sServiceHost for Cilium's kube-proxy
+      # replacement (incus/docker override with cidrhost). The len() guard keeps
+      # this safe to evaluate while platform-metal defers metal-without-nodes.
       k8s_service_host: "${len(cluster.controlplanes.nodes ?? {}) > 0 ? split(values(cluster.controlplanes.nodes)[0].endpoint, ':')[0] : ''}"
 
-  # ---------------------------------------------------------------------------
-  # Cilium-specific machine patch
-  # ---------------------------------------------------------------------------
-  #
-  # When Cilium is active, patch the Talos machine config to:
-  #   - disable the built-in flannel CNI (cluster.network.cni.name: none)
-  #   - disable kube-proxy (cluster.proxy.disabled: true)
-  #
-  # These both go through common_patch → common_config_patches, so no new
-  # terraform variable is needed.
-  #
+  # Cilium machine patch: disable the built-in flannel CNI and kube-proxy.
   - name: talos_common
     when: cluster.cni.driver == 'cilium'
     value:
@@ -120,15 +84,8 @@ config:
           proxy:
             disabled: true
 
-  # ---------------------------------------------------------------------------
-  # Single-node topology: shrink control-plane footprint
-  # ---------------------------------------------------------------------------
-  #
-  # With one control plane there are no peers to coordinate with, so leader
-  # election is pure overhead — KCM and scheduler otherwise hit etcd with a
-  # lease write every ~2s. We also enable etcd auto-compaction (upstream
-  # default is off, which lets the DB grow unboundedly).
-  #
+  # Single-node topology: no peers, so disable leader election (avoids a ~2s etcd
+  # lease write) and enable etcd auto-compaction (upstream default is off).
   - name: talos_common
     when: topology == 'single-node'
     value:
@@ -144,20 +101,11 @@ config:
             extraArgs:
               auto-compaction-mode: "revision"
               auto-compaction-retention: "1000"
-              # Retain fewer historical snapshots and WAL segments on disk.
-              # Defaults are 5/5; on a single-node cluster there are no peers
-              # that need to catch up from older snapshots, so 3/3 is safe
-              # and shaves ~128 MiB off the etcd data directory.
+              # 3/3 (default 5/5): no peers to catch up, saves ~128 MiB on disk.
               max-snapshots: "3"
               max-wals: "3"
 
-  # ---------------------------------------------------------------------------
-  # Pinned Talos version
-  # ---------------------------------------------------------------------------
-  #
-  # Renovate watches this string and opens an update PR for new Talos
-  # releases — keep the renovate comment intact when bumping manually.
-  #
+  # Pinned Talos version; Renovate watches the string below.
   - name: talos
     value:
       # renovate: datasource=github-releases depName=talos package=siderolabs/talos

--- a/contexts/_template/facets/option-cni.yaml
+++ b/contexts/_template/facets/option-cni.yaml
@@ -4,26 +4,17 @@ metadata:
   name: cni
   description: Kubernetes CNI driver configuration (Cilium)
 
-# Only active when Cilium is the resolved CNI and the cluster is enabled.
-# Other CNIs (flannel on docker-desktop, managed CNIs on EKS/AKS) skip this
-# facet entirely. The cluster.enabled guard prevents dangling csi→cni
-# dependencies when someone stands up just the workstation services.
+# Active only when Cilium is the resolved CNI and the cluster is enabled; the
+# cluster.enabled guard avoids dangling csi→cni deps for workstation-only stacks.
 when: cluster.cni.driver == 'cilium' && (cluster.enabled ?? true)
 
 # =============================================================================
 # Terraform — Cilium pre-flight bootstrap
 # =============================================================================
-#
-# Cilium has a chicken-and-egg problem on Talos: Flux needs pod networking to
-# reconcile anything, but Flux is what normally installs the CNI HelmRelease.
-# We resolve this by bootstrapping Cilium directly via Terraform (using the
-# Talos API), then letting Flux adopt the release later via the `cni`
-# kustomization below.
-#
+# Talos chicken-and-egg: Flux needs pod networking, but Flux installs the CNI.
+# Bootstrap Cilium via Terraform (Talos API), then Flux adopts it below.
 terraform:
 
-  # Bootstrap Cilium before Flux so pod networking exists when GitOps controllers
-  # start. Skipped on docker without workstation (no cluster is provisioned).
   - name: cni
     when: "talos_provisioned"
     path: cni/cilium
@@ -31,13 +22,11 @@ terraform:
       - cluster
     inputs:
       cluster_endpoint: "${cluster.endpoint ?? cluster_endpoint_fallback.endpoint}"
-      # Talos forbids privileged pods and mounts cgroups at init; both settings
-      # are required for Cilium to start and stay up on Talos.
+      # Talos forbids privileged pods and mounts cgroups at init — both required
+      # for Cilium on Talos.
       privileged: false
       cgroup_auto_mount: false
-      # Match the Flux-managed HelmRelease's operator.replicas so `windsor up`
-      # re-runs don't flap the deployment between Flux reconciles. Same
-      # single-node → 1, else → 2 rule applied by the Flux substitution.
+      # Match the Flux HelmRelease's replicas so `windsor up` re-runs don't flap.
       operator_replicas: "${topology == 'single-node' ? 1 : 2}"
   
   - name: gitops
@@ -47,14 +36,10 @@ terraform:
       - cni
 
 # =============================================================================
-# Flux systems — gateway resources dep merge
+# Flux systems
 # =============================================================================
-#
-# gateway-resources must wait for cni when Cilium is the gateway driver.
-# Otherwise the Kyverno LBIPAM sharing policy (in cilium/gateway) may not be
-# in place when the Cilium gateway controller creates the
-# cilium-gateway-external Service, and the LB IP won't be shared.
-#
+# The cilium gateway waits for cni so Cilium is up before the gateway controller
+# creates its LoadBalancer Service (and the LBIPAM sharing policy is in place).
 flux:
 
   - name: gateway
@@ -67,19 +52,9 @@ flux:
   # cni — Flux adoption of the HelmRelease
   # ---------------------------------------------------------------------------
   #
-  # The bootstrap was done in Terraform; these kustomizations reconcile the
-  # same HelmRelease through Flux so day-2 config changes flow via GitOps.
-  #
-  # Two variants — they differ in Talos-specific settings and how
-  # k8s_service_host is derived:
-  #
-  # Ordering against Kyverno's mutation policies is handled globally by policy's
-  # globalDependency barrier, so no explicit policy-resources dep is needed for
-  # the normal (policies on) case. The one exception is cilium/gateway: it ships
-  # a ClusterPolicy (LBIPAM IP sharing), so with policies disabled the apply
-  # would fail on "no matches for kind ClusterPolicy". The cilium-gated dep below
-  # keeps policy-resources present in that combination to surface it as
-  # DependencyNotReady instead.
+  # Terraform bootstraps Cilium; these kustomizations reconcile the same
+  # HelmRelease through Flux for day-2 changes. Two variants (Talos / EKS)
+  # differ in Talos-specific settings and how k8s_service_host is derived.
   #
 
   # Talos: cilium/talos applies Talos-specific security context + cgroup
@@ -87,7 +62,6 @@ flux:
   - name: cni
     when: talos_enabled
     dependsOn:
-      - "${(gateway.enabled == true && gateway.driver == 'cilium') ? 'policy-resources' : ''}"
       - "${telemetry.metrics.enabled || telemetry.logs.enabled ? 'telemetry-install' : ''}"
     install:
       components:
@@ -111,7 +85,6 @@ flux:
   - name: cni
     when: eks_enabled
     dependsOn:
-      - "${(gateway.enabled == true && gateway.driver == 'cilium') ? 'policy-resources' : ''}"
       - "${telemetry.metrics.enabled || telemetry.logs.enabled ? 'telemetry-install' : ''}"
     install:
       components:

--- a/contexts/_template/facets/option-dev.yaml
+++ b/contexts/_template/facets/option-dev.yaml
@@ -4,19 +4,15 @@ metadata:
   name: dev
   description: "Development mode configurations including selfsigned certificates and dev-specific resources"
 
-# Dev mode is a policy flag: turn on conveniences that make local iteration
-# fast but are unsuitable for production (selfsigned certs, default Grafana
-# password, auto-enabled addons).
+# Dev mode: enable local-iteration conveniences unsuitable for production
+# (selfsigned certs, default Grafana password, auto-enabled addons).
 when: dev == true
 
 # =============================================================================
 # Config — auto-enable common addons
 # =============================================================================
-#
-# Flip common addons on *unless the user explicitly set them to false*.
-# The `!= false` form preserves user overrides — setting `enabled: false`
-# keeps them off, while leaving the field unset defaults them on.
-#
+# Enable common addons unless explicitly set to false; `!= false` preserves
+# user overrides while defaulting unset fields on.
 config:
   - name: addons
     value:
@@ -34,11 +30,8 @@ config:
 # =============================================================================
 # Flux systems — pki resources overlay
 # =============================================================================
-#
-# PKI for local dev: a selfsigned ClusterIssuer so every certificate works
-# without an external trust anchor. Production uses letsencrypt / a private
-# CA wired up by addon-private-ca.
-#
+# Local-dev PKI: a selfsigned ClusterIssuer so certificates work without an
+# external trust anchor. Production uses letsencrypt or addon-private-ca.
 flux:
 
   - name: pki

--- a/contexts/_template/facets/option-gateway.yaml
+++ b/contexts/_template/facets/option-gateway.yaml
@@ -7,7 +7,6 @@ metadata:
 # =============================================================================
 # Requires
 # =============================================================================
-#
 requires:
   - when: gateway.access == 'private'
     paths:
@@ -17,24 +16,16 @@ requires:
 # =============================================================================
 # Config — derived values consumed by this facet
 # =============================================================================
-#
-# cert_effective.public_issuer: which public ClusterIssuer is currently
-# deployed. The selfsigned and ACME public issuers are deployed as distinct
-# ClusterIssuers (`public-selfsigned`, `public-acme`) rather than one
-# `public` resource mutated in place — flipping the name flips a Certificate's
-# spec.issuerRef.name and forces cert-manager to reissue. See platform-aws.yaml
-# and kustomize/pki/resources/public-issuer/.
-#
+# cert_effective.public_issuer: selfsigned and ACME public issuers are distinct
+# ClusterIssuers — flipping the name forces cert-manager to reissue.
 config:
 
   - name: cert_effective
     value:
       public_issuer: "${(dns.public_domain ?? '') != '' ? 'public-acme' : 'public-selfsigned'}"
 
-  # gateway_effective.external_domain — cert SAN, resolved as an ordered
-  # fallback (last matching entry wins). Floor is '<id>.local' so the
-  # no-domain selfsigned path still renders a valid SAN, never "null".
-  # Private access pins the private domain even when a public one is set.
+  # gateway_effective.external_domain — cert SAN; ordered fallback, last match
+  # wins. Floor '<id>.local' keeps a valid SAN on the no-domain selfsigned path.
   - name: gateway_effective
     value:
       external_domain: "${(id ?? 'windsor') + '.local'}"
@@ -55,11 +46,8 @@ config:
     value:
       external_domain: "${dns.private_domain}"
 
-  # gateway_effective.cert_issuer — ClusterIssuer for the gateway TLS cert
-  # (last match wins). Floor is 'private' selfsigned; clouds and any
-  # public_domain get the public issuer; private access with a private
-  # domain forces 'private' because ACME DNS-01 can't validate a VPC-only
-  # zone.
+  # gateway_effective.cert_issuer — gateway TLS ClusterIssuer; last match wins.
+  # Private access forces 'private': ACME DNS-01 can't validate a VPC-only zone.
   - name: gateway_effective
     value:
       cert_issuer: private
@@ -75,13 +63,8 @@ config:
 # =============================================================================
 # CRDs — vendored, applied ahead of the controller
 # =============================================================================
-#
-# Gateway API CRDs are shared by both drivers (Envoy installs the controller;
-# Cilium provides the implementation), so they ship whenever the gateway is
-# enabled. Envoy Gateway's own CRDs ship only on the envoy path. Both are
-# version-pinned under kustomize/crds/; every kustomization in this facet
-# auto-depends on them.
-#
+# Gateway API CRDs ship whenever the gateway is enabled (both drivers use them);
+# Envoy Gateway's own CRDs ship only on the envoy path.
 crds:
   # renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api package=kubernetes-sigs/gateway-api
   - "${gateway.enabled == true ? 'gateway-api-experimental-1.6.0' : ''}"
@@ -91,27 +74,12 @@ crds:
 # =============================================================================
 # Flux systems — Gateway API controller + shared Gateway resource
 # =============================================================================
-#
-# gateway (resolved in platform-base) selects the driver: 'envoy' or
-# 'cilium'. All downstream facets dependsOn the canonical names
-# `gateway-install` and `gateway-resources` regardless of driver — we emit
-# one variant of each (compiled from a single `gateway` system entry per
-# driver, merged with the additive install patches in platform-aws.yaml /
-# platform-azure.yaml and the additive resources patches in option-cni.yaml /
-# option-workstation.yaml).
-#
+# gateway.driver selects 'envoy' or 'cilium'. Downstream facets dependsOn the
+# canonical names gateway-install / gateway-resources regardless of driver.
 flux:
 
-  # ---------------------------------------------------------------------------
-  # install — CRDs, namespace, controller
-  # ---------------------------------------------------------------------------
-  #
-  # Envoy path: install Envoy Gateway + its service variant (loadbalancer or
-  # nodeport, chosen by lb_effective.mode) + prometheus scraping.
-  #
-  # Depends on pki-install so cert-manager is available for the Gateway TLS
-  # certificate created in resources.
-  #
+  # Envoy path: install Envoy Gateway + service variant (lb_effective.mode) +
+  # prometheus. Depends on pki-install for the Gateway TLS cert made in resources.
   - name: gateway
     when: gateway.enabled == true && gateway.driver != 'cilium'
     dependsOn:
@@ -127,9 +95,7 @@ flux:
       timeout: 10m
       interval: 5m
 
-  # Cilium path: Cilium itself provides the Gateway API implementation, so this
-  # variant only needs to install the Gateway API CRDs (via the `cilium`
-  # component). The Cilium HelmRelease is owned by option-cni.
+  # Cilium path: only installs the Gateway API CRDs; the Cilium HelmRelease is owned by option-cni.
   - name: gateway
     when: gateway.enabled == true && gateway.driver == 'cilium'
     dependsOn:
@@ -141,40 +107,16 @@ flux:
       timeout: 10m
       interval: 5m
 
-  # ---------------------------------------------------------------------------
-  # cni dep merge (cilium gateway only)
-  # ---------------------------------------------------------------------------
-  #
-  # When Cilium is the gateway driver, the Gateway API CRDs (installed by
-  # gateway-install) must exist before the Cilium HelmRelease is applied.
-  # Otherwise cilium-operator starts with gatewayAPI.enabled but finds no CRDs
-  # and never initializes the Gateway controller. Merged into the cni system's
-  # install tier (compiled name cni-install) as an additive dependsOn edge.
-  #
+  # cni dep merge (cilium gateway only): Gateway API CRDs must exist before the
+  # Cilium HelmRelease, or cilium-operator finds no CRDs and never starts the controller.
   - name: cni
     when: gateway.enabled == true && gateway.driver == 'cilium'
     dependsOn:
       - gateway-install
 
-  # ---------------------------------------------------------------------------
-  # resources — shared Gateway CR + TLS certificate
-  # ---------------------------------------------------------------------------
-  #
-  # Conditional components:
-  #   - cilium:       patches Gateway spec.infrastructure.annotations so the
-  #                   Cilium gateway LB IP is shared with CoreDNS (LBIPAM).
-  #   - dns:          UDP/TCP port-53 listeners for CoreDNS. Envoy only —
-  #                   Cilium shares the LB IP instead, no extra listeners
-  #                   needed.
-  #   - lb-address:   pins the Gateway to the start of the LB IP range when an
-  #                   in-cluster LB is active.
-  #   - flux-webhook: adds a dedicated port-9292 listener for the Flux
-  #                   notification receiver (gated on gitops.mode == 'push').
-  #
-  # `gateway_class_name` drives the Gateway spec.gatewayClassName (envoy,
-  # cilium, etc.). `gateway_dns_target` is the IP external-dns advertises for
-  # Gateway-attached hostnames.
-  #
+  # resources — shared Gateway CR + TLS certificate. gateway_class_name drives
+  # spec.gatewayClassName; gateway_dns_target is the IP external-dns advertises
+  # for Gateway-attached hostnames.
   - name: gateway
     when: gateway.enabled == true
     resources:
@@ -182,19 +124,12 @@ flux:
           - "${dns.enabled ? 'dns-install' : ''}"
         components:
           - "${gateway.driver == 'cilium' ? 'cilium' : ''}"
-          # Points the Gateway at its EnvoyProxy (per-gateway data-plane Service
-          # config). Envoy-only: cilium gateways don't use the EnvoyProxy resource.
+          # Points the Gateway at its EnvoyProxy (envoy-only data-plane Service config).
           - "${gateway.driver != 'cilium' ? 'envoy/parameters' : ''}"
-          # Catch-all 404 served by Envoy's directResponse — covers any
-          # request that doesn't match a real app's HTTPRoute. Envoy-only:
-          # uses the gateway.envoyproxy.io HTTPRouteFilter CRD, which
-          # cilium clusters don't ship.
+          # Catch-all 404 (Envoy directResponse) for unmatched HTTPRoutes; envoy-only.
           - "${gateway.driver != 'cilium' ? 'envoy/default-404' : ''}"
-          # external-dns hostname annotation on the 404 route. Fires whenever a
-          # gateway-managed DNS zone exists — the public zone (dns.public_domain)
-          # for the default public path, or the private zone (dns.private_domain)
-          # when gateway.access=private. Skipped when neither applies so the
-          # substitution doesn't render a malformed ",*." value.
+          # external-dns hostname annotation on the 404 route; fires when a
+          # gateway-managed DNS zone exists (public, or private when access=private).
           - "${gateway.driver != 'cilium' && ((dns.public_domain ?? '') != '' || (gateway.access == 'private' && (dns.private_domain ?? '') != '')) ? 'envoy/default-404/external-dns' : ''}"
           - "${gateway.driver != 'cilium' && (addons.private_dns.enabled ?? (dev == true)) == true ? 'dns' : ''}"
           - "${lb_effective.enabled == true ? 'lb-address' : ''}"
@@ -202,13 +137,11 @@ flux:
         substitutions:
           gateway_class_name: ${gateway.driver}
           gateway_dns_target: "${lb_effective.enabled == true ? network.loadbalancer_ips.start : ''}"
-          # Cert SAN domain and TLS ClusterIssuer — both resolved as ordered
-          # fallback ladders in the config section above.
+          # Cert SAN domain and TLS issuer — resolved in the config section above.
           external_domain: "${gateway_effective.external_domain}"
           gateway_cert_issuer: "${gateway_effective.cert_issuer}"
-          # Only emitted when a consumer is active: the lb-address patch (in-cluster
-          # LB) or the cilium gateway component. NodePort/cloud-managed-LB paths
-          # have no consumer, so leave it empty and the harness drops it.
+          # Only emitted when a consumer is active (in-cluster LB or cilium gateway);
+          # empty otherwise and the harness drops it.
           loadbalancer_start_ip: "${(lb_effective.enabled == true || gateway.driver == 'cilium') ? network.loadbalancer_ips.start : ''}"
         timeout: 10m
         interval: 5m

--- a/contexts/_template/facets/option-single-node.yaml
+++ b/contexts/_template/facets/option-single-node.yaml
@@ -9,41 +9,15 @@ when: topology == 'single-node'
 # =============================================================================
 # Single-node control-plane hardening
 # =============================================================================
-#
-# On a single-node cluster every leader-electing controller is electing
-# against itself — each held lease is a PUT to etcd every ~2s, producing the
-# bulk of apiserver/etcd write load on an otherwise idle cluster. The
-# kube-controller-manager and scheduler leases are already disabled in
-# config-talos.yaml (via --leader-elect=false on the static manifests); this
-# facet layers the same hardening onto the workload controllers whose charts
-# expose a clean toggle.
-#
-# Charts covered here:
-#   - cert-manager (controller + cainjector)   --leader-elect=false via extraArgs
-#   - trust-manager                            app.leaderElection.enabled=false
-#   - openebs localpv-provisioner              localpv.enableLeaderElection=false
-#   - cloudnative-pg operator                  --leader-elect=false via additionalArgs
-#
-# Kyverno's reports-controller and cleanup-controller are handled at the
-# platform-base layer via the top-level `policies.reporting` and
-# `policies.cleanup` flags (both default to disabled across all topologies
-# since Windsor ships no CleanupPolicy resources and no dashboards consume
-# PolicyReports). Leader election on the remaining kyverno controllers is
-# hard-coded in the v1.16 binary and can't be disabled without a fork.
-#
-# Charts deliberately not covered (no supported disable mechanism at their
-# pinned versions):
-#   - kube-prometheus-stack operator (chart does not wire a flag through)
-#
-# Flux's six controllers are handled via the terraform/gitops/flux module's
-# leader_election input below rather than a kustomize component.
-#
+# On single-node clusters every leader-electing controller elects against
+# itself, each lease a PUT to etcd every ~2s. This disables leader election on
+# the workload controllers whose charts expose a toggle (cert-manager,
+# trust-manager, openebs, cloudnative-pg); kube-controller-manager/scheduler are
+# already handled in config-talos.yaml and Flux via the gitops input below.
 terraform:
 
-  # Layers onto the `gitops` terraform entry declared by each platform facet
-  # (platform-metal, platform-docker, platform-incus, platform-aws,
-  # platform-azure). Flipping this input to false appends
-  # --enable-leader-election=false to every Flux controller's additionalArgs.
+  # Layers onto each platform facet's `gitops` entry; false appends
+  # --enable-leader-election=false to every Flux controller.
   - name: gitops
     path: gitops/flux
     inputs:
@@ -52,10 +26,8 @@ terraform:
 # =============================================================================
 # Flux systems — pki install overlay
 # =============================================================================
-#
-# cert-manager is always present, trust-manager only when the private-ca
-# addon is enabled.
-#
+# Single-node leader-election toggles per chart; trust-manager only with the
+# private-ca addon, openebs only on that driver, database only when enabled.
 flux:
 
   - name: pki
@@ -64,25 +36,15 @@ flux:
         - cert-manager/single-node
         - "${addons.private_ca.enabled == true ? 'trust-manager/single-node' : ''}"
 
-  # ---------------------------------------------------------------------------
-  # csi overlay — only the openebs path; longhorn has its own single-node
-  # component wired from option-storage.yaml and does not leader-elect for
-  # the same reason we target here.
-  # ---------------------------------------------------------------------------
+  # openebs only; longhorn has its own single-node component in option-storage.
   - name: csi
     when: talos_common.storage_driver == 'openebs'
     install:
       components:
         - openebs/single-node
 
-  # ---------------------------------------------------------------------------
-  # database overlay — only when the cloudnative-pg addon is actually enabled
-  # AND cloudnative-pg is the chosen driver. Guarding on `enabled` matters
-  # because the single-node entry is a kustomize *component* (patch-only); if
-  # the database base HelmRelease isn't also being applied by addon-database,
-  # the patch has nothing to target and flux errors out on "no matches for Id
-  # HelmRelease.v2.helm.toolkit.fluxcd.io/cloudnativepg.system-database".
-  # ---------------------------------------------------------------------------
+  # Guard on `enabled`: this is a patch-only component, so without the base
+  # HelmRelease from addon-database flux errors on "no matches for Id".
   - name: database
     when: addons.database.postgres.enabled == true && addons.database.postgres.driver == 'cloudnativepg'
     install:

--- a/contexts/_template/facets/option-storage.yaml
+++ b/contexts/_template/facets/option-storage.yaml
@@ -12,26 +12,14 @@ when: cluster.driver == 'talos'
 # =============================================================================
 # Terraform — Talos extensions for CSI
 # =============================================================================
-#
-# Many CSI drivers need kernel/system tools that aren't in the stock Talos
-# image (e.g. Longhorn needs iscsi-tools + util-linux-tools). We install them
-# via the cluster/talos/extensions module, and make Flux wait so pods don't
-# start before the extensions are live.
-#
+# Some CSI drivers need kernel/system tools missing from the stock Talos image
+# (Longhorn needs iscsi-tools + util-linux-tools). Installed via the
+# cluster/talos/extensions module, with Flux waiting until they're live.
 terraform:
 
-  # ---------------------------------------------------------------------------
-  # cluster-extensions — apply Talos system extensions
-  # ---------------------------------------------------------------------------
-  #
-  # Only runs when extensions are needed for the chosen storage driver
-  # (currently: longhorn → iscsi-tools + util-linux-tools).
-  #
-  # When Cilium is the CNI, the cni terraform step bootstraps Cilium directly
-  # against the Talos API. Extensions also touches Talos, so it must wait for
-  # cni to finish to avoid concurrent machine-config writes — hence the
-  # conditional dependsOn entry below.
-  #
+  # cluster-extensions — apply Talos system extensions when the storage driver
+  # needs them (longhorn). Waits for cni when Cilium is the CNI, since both
+  # write Talos machine config and must not run concurrently.
   - name: cluster-extensions
     when: "(cluster.storage.driver ?? 'openebs') == 'longhorn' && cluster_provisioned"
     path: cluster/talos/extensions
@@ -45,8 +33,7 @@ terraform:
       workers: ${talos_node_targets.workers ?? []}
       extensions: ${talos_common.extensions ?? []}
 
-  # Dependency merge: Flux waits for extensions before reconciling, so CSI
-  # DaemonSets find the kernel modules they expect.
+  # Dependency merge: Flux waits for extensions so CSI DaemonSets find their kernel modules.
   - name: gitops
     when: "(cluster.storage.driver ?? 'openebs') == 'longhorn' && cluster_provisioned"
     path: gitops/flux
@@ -56,20 +43,11 @@ terraform:
 # =============================================================================
 # Kustomize — CSI driver Helm releases
 # =============================================================================
-#
 # One kustomization per storage driver; exactly one fires based on
-# talos_common.storage_driver (set per platform: openebs on metal/docker,
-# longhorn on incus).
-#
+# talos_common.storage_driver (openebs on metal/docker, longhorn on incus).
 flux:
 
-  # ---------------------------------------------------------------------------
-  # OpenEBS — hostPath-style local volumes
-  # ---------------------------------------------------------------------------
-  #
-  # Simple and dependency-light: uses a local directory on each node. Good
-  # default for dev and for platforms without dedicated block devices.
-  #
+  # OpenEBS — hostPath local volumes; the default for platforms without dedicated block devices.
   - name: csi
     when: talos_common.storage_driver == 'openebs'
     install:
@@ -81,16 +59,7 @@ flux:
       timeout: 20m
       interval: 5m
 
-  # ---------------------------------------------------------------------------
-  # Longhorn — distributed block storage
-  # ---------------------------------------------------------------------------
-  #
-  # Conditional components:
-  #   - longhorn/single-node: relaxed replica placement when scheduling on
-  #     control planes (dev/incus workloads).
-  #   - longhorn/ha:          replica anti-affinity for multi-node prod.
-  #   - longhorn/prometheus:  ServiceMonitor; only when observability addon is on.
-  #
+  # Longhorn — distributed block storage.
   - name: csi
     when: talos_common.storage_driver == 'longhorn'
     dependsOn:
@@ -104,15 +73,9 @@ flux:
       timeout: 20m
       interval: 5m
 
-  # ---------------------------------------------------------------------------
-  # Grafana dashboard patch
-  # ---------------------------------------------------------------------------
-  #
-  # Inject the Longhorn dashboard into the observability-resources kustomization
-  # when Longhorn is the active storage driver AND observability is on (or dev
-  # mode is on, which auto-enables observability). The longhorn driver gate is
-  # required — the dashboard is meaningless without longhorn metrics to render.
-  #
+  # Grafana dashboard patch: inject the Longhorn dashboard into observability-resources
+  # when Longhorn is active and observability is on; the driver gate is required
+  # since the dashboard is meaningless without longhorn metrics.
   - name: observability
     when: talos_common.storage_driver == 'longhorn' && (addons.observability.enabled == true || dev == true)
     resources:

--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -4,52 +4,30 @@ metadata:
   name: workstation
   description: Workstation stack for local development and cluster infrastructure.
 
-# Active only on workstation-capable platforms (docker, incus) with a runtime
-# explicitly set. `workstation.runtime` is the single switch that turns on all
-# workstation services (DNS forwarder, registry mirrors, git livereload).
+# Active on workstation platforms (docker, incus) when workstation.runtime is
+# set — the single switch enabling DNS, registry mirrors, and git livereload.
 when: "(platform == 'docker' || platform == 'incus') && workstation.runtime != null && workstation.runtime != ''"
 
 # =============================================================================
 # Config — workstation + Talos patch values
 # =============================================================================
-#
 config:
 
-  # ---------------------------------------------------------------------------
-  # Workstation identity
-  # ---------------------------------------------------------------------------
-  #
-  # Normalize runtime/arch so downstream expressions have safe defaults.
-  # Architecture is used to pick the correct Talos Incus image below.
-  #
+  # Normalize runtime/arch defaults; arch picks the Talos Incus image below.
   - name: workstation
     value:
       runtime: "${workstation.runtime ?? ''}"
       arch: "${workstation.arch ?? 'amd64'}"
 
-  # ---------------------------------------------------------------------------
-  # Talos image references
-  # ---------------------------------------------------------------------------
-  #
-  # Only relevant when the workstation stack runs; non-workstation platforms
-  # use a talos_version fallback built elsewhere.
-  #
+  # Talos image references; only used when the workstation stack runs.
   - name: talos
     value:
       docker_image: "ghcr.io/siderolabs/talos:v${talos.talos_version}"
       incus_image: "windsor:talos/v${talos.talos_version}/${workstation.arch ?? 'amd64'}"
 
-  # ---------------------------------------------------------------------------
-  # Registry mirrors (pull-through cache)
-  # ---------------------------------------------------------------------------
-  #
-  # `workstation_registries.registries` is the map of upstream → mirror used
-  # both by the workstation Terraform (to run the mirror containers) and by
-  # the Talos registry config (to redirect pulls).
-  #
-  # Empty when workstation.services.registries == false. Otherwise uses
-  # user-supplied docker.registries or falls back to a sensible default set.
-  #
+  # Registry pull-through cache: upstream → mirror map used by workstation
+  # Terraform (runs the containers) and Talos registry config (redirects pulls).
+  # Empty when services.registries is false; else docker.registries or defaults.
   - name: workstation_registries
     value:
       registries: |
@@ -62,14 +40,9 @@ config:
           "registry.k8s.io": { "remote": "https://registry.k8s.io" }
         })}
 
-  # Transform workstation TF output into the Talos machine.registries.mirrors
-  # shape. Only entries with both `remote` and `hostname` set are included;
-  # `local` (when present) is used as the mirror key so users can override the
-  # upstream name (e.g. "registry-1.docker.io" → "docker.io").
-  #
-  # config: {} — intentionally empty. Talos errors
-  # "TLS config specified for non-HTTPS registry" if tls is set for http://
-  # endpoints, and our mirrors are always plain HTTP.
+  # Map workstation TF output to Talos machine.registries.mirrors. Only entries
+  # with both `remote` and `hostname` are kept; `local` overrides the mirror key.
+  # config: {} stays empty — Talos rejects TLS config on our plain-HTTP mirrors.
   - name: talos_registry_mirrors
     when: cluster.driver == 'talos' && (cluster.enabled ?? true)
     value:
@@ -85,14 +58,8 @@ config:
         ))}
       config: {}
 
-  # ---------------------------------------------------------------------------
-  # talos_common overrides
-  # ---------------------------------------------------------------------------
-  #
-  # Each block merges additional settings into talos_common, which config-talos
-  # stringifies into the Talos machine patch. Blocks are additive — they don't
-  # replace talos_common, they extend it.
-  #
+  # talos_common overrides — each block additively merges settings that
+  # config-talos stringifies into the Talos machine patch.
 
   # Inject registry mirrors (always, for any workstation runtime).
   - name: talos_common
@@ -104,15 +71,13 @@ config:
             mirrors: ${talos_registry_mirrors.mirrors}
             config: ${talos_registry_mirrors.config}
 
-  # Docker only: when there are no workers, schedule workloads on control planes.
-  # Otherwise honor the user's cluster.controlplanes.schedulable setting.
+  # Docker only: schedule on control planes when no workers, else honor schedulable.
   - name: talos_common
     when: cluster.driver == 'talos' && (cluster.enabled ?? true) && platform == 'docker'
     value:
       allowSchedulingOnControlPlanes: "${(cluster.workers.count ?? 0) == 0 ? true : (cluster.controlplanes.schedulable ?? false)}"
 
-  # Docker Desktop only: ignore eth0 so Talos doesn't fight the docker-desktop
-  # managed interface config.
+  # Docker Desktop only: ignore eth0 to avoid fighting its managed interface.
   - name: talos_common
     when: cluster.driver == 'talos' && (cluster.enabled ?? true) && workstation.runtime == 'docker-desktop'
     value:
@@ -123,23 +88,15 @@ config:
               - ignore: true
                 interface: eth0
 
-  # Expose empty per-role patch slots for platform-docker to populate.
-  # config-talos stringifies these after merging.
+  # Empty per-role patch slots for platform-docker to populate.
   - name: talos_common_docker
     when: cluster.driver == 'talos' && (cluster.enabled ?? true)
     value:
       controlplane_config_patches: ""
       worker_config_patches: ""
 
-  # ---------------------------------------------------------------------------
-  # Colima-on-Incus CNI/LB overrides
-  # ---------------------------------------------------------------------------
-  #
-  # Colima running an Incus VM is primarily a storage-driver test rig —
-  # Cilium's eBPF adds overhead that confuses those tests. Force flannel here
-  # and pair it with kube-vip so LoadBalancer services still get an IP
-  # (flannel has no built-in L2 announcer like Cilium does).
-  #
+  # Colima-on-Incus is a storage-driver test rig; force flannel (Cilium's eBPF
+  # skews tests) and pair with kube-vip so LoadBalancer services still get an IP.
   - name: cluster
     when: platform == 'incus' && workstation.runtime == 'colima'
     value:
@@ -156,23 +113,12 @@ config:
 # =============================================================================
 # Terraform — workstation services, compute, cluster
 # =============================================================================
-#
-# Dependency chain: workstation → compute → cluster → gitops
-#
-# The `workstation` step creates DNS, registries, and git-livereload services.
-# `compute` provisions the Talos nodes (containers on docker, VMs on incus).
-# `cluster` runs Talos bootstrap/apply. `gitops` deploys Flux with credentials.
-#
+# Dependency chain: workstation (DNS/registries/git) → compute (Talos nodes) →
+# cluster (Talos bootstrap) → gitops (Flux + credentials).
 terraform:
 
-  # ---------------------------------------------------------------------------
-  # gitops — Flux with workstation credentials
-  # ---------------------------------------------------------------------------
-  #
-  # Runs only when the cluster is enabled. The cni / cluster-extensions deps
-  # are merged in by option-cni and option-storage respectively; we don't
-  # reference them here directly.
-  #
+  # gitops — Flux with workstation credentials. cni/cluster-extensions deps are
+  # merged in by option-cni and option-storage, not referenced here.
   - name: gitops
     when: (cluster.enabled ?? true)
     path: gitops/flux
@@ -180,11 +126,8 @@ terraform:
     dependsOn:
       - cluster
     inputs:
-      # On incus-backed workstations (bare incus, or colima with the incus
-      # runtime) the cluster runs in a nested VM whose vCPUs are less
-      # performant than the host's, so the CPU-derived formula overshoots
-      # and the boot reconcile storm saturates apiserver → cert-manager/
-      # scheduler probes flap. Clamp to 2 there; docker stays CPU-derived.
+      # Incus runs the cluster in a nested VM with slower vCPUs, so the
+      # CPU-derived formula overshoots and floods apiserver. Clamp to 2 there.
       concurrency: >-
         ${platform == 'incus' ? 2 : max(2, min(
           floor(cluster.controlplanes.cpu / 2),
@@ -195,17 +138,10 @@ terraform:
       git_password: ${workstation.git.password ?? "local"}
       webhook_token: ${gitops.webhook.token ?? "abcdef123456"}
 
-  # ---------------------------------------------------------------------------
-  # workstation — DNS, registries, git-livereload
-  # ---------------------------------------------------------------------------
-  #
-  # Three variants, one per runtime family:
-  #
+  # workstation — DNS, registries, git-livereload. Three variants by runtime.
 
-  # Docker Desktop: no in-cluster loadbalancer. DNS forwards to the first node
-  # via container port 30053 (not host 8053) so the DNS container can reach
-  # the node on the shared docker network. 30053 is the NodePort for CoreDNS;
-  # cluster.*.hostports must map that same port (e.g. "8053:30053/udp").
+  # Docker Desktop: no in-cluster LB. DNS forwards to the first node via
+  # container port 30053 (CoreDNS NodePort) on the shared docker network.
   - name: workstation
     when: "platform == 'docker' && workstation.runtime == 'docker-desktop'"
     path: workstation/docker
@@ -224,10 +160,9 @@ terraform:
       enable_git: ${workstation.services.git ?? true}
       registries: ${workstation_registries.registries ?? {}}
 
-  # Colima / docker / linux: loadbalancer exists, so DNS and webhook target
-  # the LB IP. Webhook port is 80 when Gateway is active (routed through the
-  # standard HTTP listener), otherwise the dedicated NodePort 9292.
-  # Terraform module expects "linux" (not "docker") as the runtime string.
+  # Colima/docker/linux: LB exists, so DNS and webhook target the LB IP.
+  # Webhook port 80 when Gateway is active, else NodePort 9292. Module runtime
+  # string is "linux", not "docker".
   - name: workstation
     when: "platform == 'docker' && workstation.runtime != \"docker-desktop\""
     path: workstation/docker
@@ -270,10 +205,7 @@ terraform:
       git_username: ${workstation.git.username ?? "local"}
       git_password: ${workstation.git.password ?? "local"}
 
-  # ---------------------------------------------------------------------------
   # compute — Talos nodes
-  # ---------------------------------------------------------------------------
-  #
 
   # Incus: provision Talos VMs on the workstation network. Under colima, use
   # the local `dir` storage driver; otherwise use incus `default`.
@@ -357,15 +289,10 @@ terraform:
           hostports: "${workstation.runtime == \"docker-desktop\" ? (cluster.workers.hostports ?? [\"8080:30080/tcp\", \"8443:30443/tcp\"]) : []}"
           volumes: ${cluster.workers.volumes ?? []}
 
-  # ---------------------------------------------------------------------------
   # cluster — Talos bootstrap/apply
-  # ---------------------------------------------------------------------------
-  #
 
-  # Incus: nodes come from compute output (Incus provisioned VMs) or from
-  # cluster.*.nodes if compute hasn't run yet. Hostname flows through as a
-  # passthrough field — Talos 1.12+ reads it from the VM runtime (Incus
-  # user.hostname), not from Talos config.
+  # Incus: nodes come from compute output, or cluster.*.nodes if compute hasn't
+  # run. Hostname is passthrough — Talos 1.12+ reads it from the VM runtime.
   - name: cluster
     when: "platform == 'incus' && (cluster.enabled ?? true)"
     path: cluster/talos
@@ -396,9 +323,8 @@ terraform:
       controlplane_volumes: ${talos_common.controlplane_volumes ?? []}
       worker_volumes: ${talos_common.worker_volumes ?? []}
 
-  # Docker: just inject the `compute` dependency. The full cluster inputs are
-  # defined in platform-docker (which owns the per-node endpoint rewriting
-  # logic for localhost-tunneled docker-desktop clusters).
+  # Docker: inject the `compute` dependency; full cluster inputs live in
+  # platform-docker (owns per-node endpoint rewriting for docker-desktop).
   - name: cluster
     when: "cluster.enabled == true && platform == 'docker'"
     dependsOn:
@@ -407,11 +333,8 @@ terraform:
 # =============================================================================
 # Flux systems — docker-desktop DNS override
 # =============================================================================
-#
-# Docker Desktop's LB IP is cluster-internal and unreachable from the host.
-# Override gateway_dns_target so external-dns advertises 127.0.0.1 — reached
-# via the host-port mapping on the Talos container.
-#
+# Docker Desktop's LB IP is unreachable from the host, so advertise 127.0.0.1
+# via gateway_dns_target — reached through the Talos container's host-port map.
 flux:
 
   - name: gateway

--- a/contexts/_template/facets/platform-aws.yaml
+++ b/contexts/_template/facets/platform-aws.yaml
@@ -6,20 +6,15 @@ metadata:
 
 when: platform == 'aws'
 
-# Terraform remote state lives in the S3 bucket provisioned by the `backend`
-# component below. Downstream components configure their backend pointed at
-# that bucket; the `backend` component itself uses local state.
+# Remote state lives in the S3 bucket the `backend` component provisions;
+# `backend` itself uses local state, downstream components point at the bucket.
 backend: backend
 
 # =============================================================================
 # Requires
 # =============================================================================
-#
-# aws.region has no derivable default — the aws-lb-controller, external-dns,
-# and the ACME Route53 issuer all need it, and the inline comment in this
-# facet calls out that propagating empty causes controller crashes rather
-# than falling back to a guess.
-#
+# aws.region has no default; lb-controller, external-dns, and the ACME issuer
+# all need it. Public DNS also requires an operator email for TLS registration.
 requires:
   - paths:
       - aws.region
@@ -32,14 +27,10 @@ requires:
 # =============================================================================
 # Config
 # =============================================================================
-#
 config:
 
-  # pki_effective.issuer_component — public ClusterIssuer variant rendered by
-  # pki-resources, resolved as an ordered selection (last match wins):
-  # selfsigned floor → ACME (route53) when a public domain is set → private
-  # selfsigned when access is private (creates the `private` ClusterIssuer the
-  # gateway cert references; the public path only ever creates `public`).
+  # issuer_component selects the ClusterIssuer variant (last match wins):
+  # selfsigned floor → ACME/route53 with a public domain → private selfsigned.
   - name: pki_effective
     value:
       issuer_component: public-issuer/selfsigned
@@ -55,11 +46,8 @@ config:
 # =============================================================================
 # CRDs — vendored, applied ahead of the controller
 # =============================================================================
-#
-# The AWS Load Balancer Controller chart ships its CRDs in the chart's crds/
-# directory, which Helm/Flux install once and never upgrade. Vendoring them
-# into the crds: layer keeps them current; the chart's CRD install is skipped.
-#
+# LB Controller CRDs vendored here (chart-installed CRDs never upgrade); the
+# chart's own CRD install is skipped.
 crds:
   # renovate: datasource=helm depName=aws-load-balancer-controller package=aws-load-balancer-controller helmRepo=https://aws.github.io/eks-charts
   - aws-load-balancer-controller-3.4.1
@@ -67,35 +55,19 @@ crds:
 # =============================================================================
 # Terraform — S3 state backend, VPC, EKS, optional Cilium bootstrap
 # =============================================================================
-#
 # Dependency chain:
 #   backend (S3) → network (VPC) → cluster (EKS) → cluster-additions → cni? → gitops
-#
-# The backend stack provisions the S3 bucket (and optional DynamoDB lock
-# table) that every downstream stack uses for remote state. It runs first on
-# apply and — because of the reverse-order teardown — last on destroy, so
-# dependent stacks finish writing their final (empty) state before the
-# bucket itself is removed.
-#
-# Cilium is optional on EKS; when used it's a full bring-your-own-CNI
-# replacement for VPC-CNI and is bootstrapped before Flux so pod networking
-# is up when the first reconciliation runs.
-#
+# Reverse-order teardown lets dependent stacks empty their state before the
+# backend bucket is removed. Cilium (optional) bootstraps before Flux.
 terraform:
 
-  # S3 + (optional) DynamoDB remote state backend. context_id/context_path and
-  # TF_VAR_operation are auto-injected by the CLI; the module's force_destroy
-  # flips on when operation == "destroy" so the bucket can be torn down with
-  # its contents on windsor destroy.
+  # S3 + optional DynamoDB remote state; force_destroy flips on for destroy so
+  # the bucket tears down with its contents.
   - name: backend
     path: backend/s3
 
-  # VPC with the requested CIDR. domain_name feeds the private (VPC-scoped)
-  # Route53 zone created inside this module — internal DNS for VPC
-  # resources. Sourced from dns.private_domain (the in-cluster / private
-  # name) rather than dns.public_domain, since the VPC zone is by
-  # definition private. The public zone for ACME / external-dns lives in
-  # the standalone dns-zone stack below.
+  # VPC with the requested CIDR. domain_name feeds the private VPC-scoped
+  # Route53 zone (from dns.private_domain); the public zone lives in dns-zone.
   - name: network
     path: network/aws-vpc
     dependsOn:
@@ -107,12 +79,8 @@ terraform:
       # one NAT per AZ. The subnet footprint stays multi-AZ either way.
       single_nat_gateway: "${topology != 'ha'}"
 
-  # Public Route53 zone — provisioned when the operator sets dns.public_domain.
-  # Lives in its own stack so it can be provisioned independently of the
-  # cluster (zone-only setups, different lifecycle than compute) and so
-  # tearing the cluster down doesn't drag the DNS zone (and its NS
-  # delegation effort) with it unless the operator explicitly destroys
-  # this stack.
+  # Public Route53 zone when dns.public_domain is set. Own stack so its
+  # lifecycle (and NS delegation) is independent of the cluster's.
   - name: dns-zone
     path: dns/zone/route53
     when: "(dns.public_domain ?? '') != ''"
@@ -121,23 +89,16 @@ terraform:
     inputs:
       domain_name: ${dns.public_domain}
 
-  # EKS cluster itself. The cert-manager IAM role + Pod Identity association
-  # is provisioned only when ACME is in play (the operator supplied a
-  # public_domain). Default deployments don't need Route53 access.
-  #
-  # cert_manager_hosted_zone_ids scopes the role's Route53 record-write
-  # actions to just the dns-zone we provisioned, so the credential can't
-  # write records to unrelated zones in the same account. Empty list when
-  # ACME is off (role isn't created either).
+  # EKS cluster. cert-manager IAM role + Pod Identity only when ACME is on
+  # (public_domain set); cert_manager_hosted_zone_ids scopes Route53 writes to
+  # just the dns-zone, empty when ACME is off.
   - name: cluster
     path: cluster/aws-eks
     dependsOn:
       - network
     inputs:
-      # vpc_id and private_subnet_ids come straight from the network module's
-      # outputs. The cluster module used to discover them via tag-filtered
-      # data sources; the facet now passes them explicitly so the dependency
-      # is visible in the input contract instead of an AWS-side lookup.
+      # vpc_id and private_subnet_ids come from the network module's outputs,
+      # passed explicitly so the dependency is visible in the input contract.
       vpc_id: ${terraform_output('network', 'vpc_id')}
       private_subnet_ids: ${terraform_output('network', 'private_subnet_ids')}
       # Cheap default places node groups in a single AZ (first private subnet);
@@ -147,64 +108,41 @@ terraform:
       manage_log_group: ${!(ephemeral ?? false)}
       create_cert_manager_role: "${(dns.public_domain ?? '') != ''}"
       cert_manager_hosted_zone_ids: "${(dns.public_domain ?? '') != '' ? [terraform_output('dns-zone', 'zone_id')] : []}"
-      # cluster.pools is the portable node-pool input (class + count, optional
-      # autoscaling + lifecycle). When unset, default to a small fixed system
-      # pool plus an autoscaling general pool — the same arrangement AKS gets
-      # (inline system pool + general). The defaults carry only class + count;
-      # the aws-eks module's class-conditional defaulting fixes class=system,
-      # autoscales the rest at min 1 / max 3, and taints class=system with
-      # CriticalAddonsOnly=true:NoSchedule to match AKS (see pools_autoscaling
-      # and pools_node_groups in terraform/cluster/aws-eks/main.tf). Declaring
-      # cluster.pools replaces this.
+      # Portable node-pool input. Default: fixed system pool + autoscaling
+      # general pool (matches AKS); the aws-eks module fills in class-conditional
+      # autoscaling and the system taint. Declaring cluster.pools replaces this.
       pools: >-
         ${cluster.pools ?? {"system": {"class": "system", "count": 1}, "general": {"class": "general", "count": 1}}}
 
-  # Path-less dependency-edge injector: when ACME is on, cluster must wait for
-  # dns-zone so terraform_output('dns-zone', 'zone_id') is resolved before the
-  # cert-manager IAM policy is rendered. Without this, Windsor can schedule
-  # cluster and dns-zone concurrently, the guard expression evaluates false,
-  # and the policy falls back to the wildcard hostedzone/* scope.
+  # Dependency-edge only: with ACME on, cluster must wait for dns-zone so
+  # zone_id resolves before the cert-manager policy renders — else it falls
+  # back to the wildcard hostedzone/* scope.
   - name: cluster
     when: "(dns.public_domain ?? '') != ''"
     dependsOn:
       - dns-zone
 
-  # destroy: false — "additions" are IAM / IRSA / aws-auth entries that are
-  # idempotent from EKS's perspective; leave them on teardown, the cluster
-  # delete takes them.
+  # destroy: false — IAM/IRSA/aws-auth entries; the cluster delete takes them.
   - name: cluster-additions
     path: cluster/aws-eks/additions
     dependsOn:
       - cluster
     destroy: false
 
-  # ---------------------------------------------------------------------------
-  # Optional Cilium bootstrap
-  # ---------------------------------------------------------------------------
-  #
-  # Only runs when the user explicitly opts into Cilium on EKS. EKS runs the
-  # Cilium agent privileged with chart-default cgroup auto-mount (Amazon Linux
-  # AMIs don't mount cgroups during init the way Talos does), so this step
-  # omits the privileged/cgroup_auto_mount overrides the Talos path uses.
-  #
+  # Optional Cilium bootstrap (full BYO-CNI). EKS uses chart-default cgroup
+  # auto-mount, unlike the Talos path, so no privileged/cgroup overrides here.
   - name: cni
     when: "cluster.cni.driver == 'cilium'"
     path: cni/cilium
     dependsOn:
       - cluster
     inputs:
-      # EKS endpoint only exists after the cluster module applies, so pull it
-      # from the terraform output by default. An explicit `cluster.endpoint` in
-      # values.yaml still wins — useful for proxied or air-gapped scenarios.
+      # Endpoint exists only after cluster applies; pull from output by default.
+      # Explicit cluster.endpoint still wins (proxied / air-gapped).
       cluster_endpoint: ${cluster.endpoint ?? terraform_output("cluster", "cluster_endpoint") ?? ""}
 
-  # ---------------------------------------------------------------------------
-  # GitOps (two variants)
-  # ---------------------------------------------------------------------------
-  #
-  # Without Cilium: Flux can start as soon as EKS is up (VPC-CNI is preinstalled).
+  # GitOps (two variants). Without Cilium: Flux starts as soon as EKS is up.
   # With Cilium: wait for the `cni` step so pod networking is healthy first.
-  #
   - name: gitops
     when: "cluster.cni.driver != 'cilium'"
     path: gitops/flux
@@ -227,133 +165,50 @@ terraform:
 # =============================================================================
 # Flux systems — pki resources overlay
 # =============================================================================
-#
-# public ClusterIssuer — selfsigned default, ACME when a real zone is set
-# -----------------------------------------------------------------------
-#
-# pki-resources is always rendered on AWS so the gateway cert always has
-# a working ClusterIssuer to issue against. Two modes:
-#
-#   1. Default (no public zone configured) → public-issuer/selfsigned,
-#      which deploys ClusterIssuer `public-selfsigned`. Cert issues
-#      immediately, browsers warn (untrusted CA), good for bringing up a
-#      cluster without DNS work. Flips to mode 2 below with no manual
-#      cert resource changes — the gateway_cert_issuer substitution in
-#      option-gateway switches to `public-acme`, which cert-manager sees
-#      as a Certificate spec change and reissues against the new issuer.
-#
-#   2. ACME (operator set dns.public_domain) → public-issuer/acme,
-#      which deploys ClusterIssuer `public-acme`. Windsor created a
-#      public Route53 zone via the dns-zone stack (so we have a place to
-#      write TXT records); cert-manager satisfies DNS-01 against it
-#      (using the IAM role + Pod Identity binding the cluster module
-#      provisioned). On switch, cert-manager re-issues into the same
-#      Secret name — gateway picks up the new cert with no restart.
-#
-# The trigger is "we have a Route53 zone we can write TXT records into",
-# not "an email is set" — email is required by Let's Encrypt for account
-# registration but isn't the capability gate. dns.public_domain is the
-# one knob the operator turns; everything else (zone, IAM, issuer) is
-# auto-provisioned.
-#
-# Server selection in ACME mode is implicit:
-#   - dev == true → Let's Encrypt staging (avoids prod rate limits)
-#   - otherwise   → Let's Encrypt production
-#
-# Required when ACME mode is active (schema enforces):
-#   - email      — operator address Let's Encrypt registers against
-#   - aws.region — Route53 API region (defaults to us-east-1)
-#
+# pki-resources always renders so the gateway cert has a ClusterIssuer. Two
+# modes, switchable with no manual cert changes: selfsigned default (browsers
+# warn), or ACME when dns.public_domain is set (DNS-01 against the Route53 zone,
+# using the cluster module's IAM role). dev == true uses staging, else prod.
 flux:
 
   - name: pki
     resources:
-      - dependsOn:
-          - policy-resources
-        # Component selection is gated only on dns.public_domain — the
-        # acme_hosted_zone_id substitution below threads the zone ID through
-        # via deferred evaluation, so it picks up the real value once the
-        # dns-zone stack has applied without needing an eager terraform_output
-        # call here. (Eager terraform_output in components: panics on first
-        # bootstrap because the dns-zone component isn't registered until
-        # composition completes.)
-        components:
-          # Issuer variant resolved in the config section above.
+      - components:
+          # acme_hosted_zone_id defers terraform_output until dns-zone applies;
+          # an eager lookup panics on first bootstrap.
           - "${pki_effective.issuer_component}"
         timeout: 5m
         interval: 5m
         substitutions:
-          # ACME-only substitutions; the selfsigned component doesn't reference
-          # them. acme_hosted_zone_id gates its terraform_output on public_domain
-          # because dns-zone isn't registered in private/selfsigned mode.
+          # ACME-only; selfsigned doesn't reference these. acme_hosted_zone_id
+          # gates on public_domain since dns-zone is absent in selfsigned mode.
           acme_server: "${dev == true ? 'https://acme-staging-v02.api.letsencrypt.org/directory' : 'https://acme-v02.api.letsencrypt.org/directory'}"
           acme_email: "${email ?? ''}"
           acme_dns_zone: "${dns.public_domain ?? ''}"
           acme_region: "${aws.region ?? 'us-east-1'}"
           acme_hosted_zone_id: "${(dns.public_domain ?? '') != '' ? (terraform_output('dns-zone', 'zone_id') ?? '') : ''}"
 
-  # ---------------------------------------------------------------------------
-  # Gateway install merge — AWS NLB annotations on the Envoy data-plane Service
-  # ---------------------------------------------------------------------------
-  #
-  # Additive block that merges into option-gateway's gateway install tier.
-  # When the gateway is on (envoy + loadbalancer mode), append the
-  # envoy/loadbalancer/aws-nlb component which strategic-merges NLB
-  # annotations onto the helm-release patch chain. Keeps AWS-specific
-  # knowledge in the AWS facet — option-gateway stays platform-agnostic.
-  #
-  # NLB (not ALB) is the right choice: Envoy is the L7 proxy and handles
-  # all routing / TLS / header logic. Putting an ALB in front would double-
-  # terminate L7 (cert sprawl, route-config sprawl, higher cost, no win).
-  # ALB remains available for direct-Service Ingress use cases — operators
-  # add `kubernetes.io/ingress.class: alb` on a per-Ingress basis.
-  #
+  # Gateway install merge — appends envoy/loadbalancer/aws-nlb (NLB annotations)
+  # when the Envoy gateway runs in loadbalancer mode, keeping AWS specifics out
+  # of option-gateway. NLB not ALB: Envoy already does L7, so an ALB would
+  # double-terminate. ALB stays available per-Ingress via the alb ingress class.
   - name: gateway
     when: "gateway.enabled == true && gateway.driver == 'envoy' && lb_effective.mode == 'loadbalancer'"
     install:
       components:
         - envoy/loadbalancer/aws-nlb
       substitutions:
-        # Map the platform-agnostic gateway.access to the AWS-specific
-        # aws-load-balancer-scheme annotation value. `internal` is the only
-        # case that needs an explicit override; otherwise we leave this empty
-        # and let the kustomize fallback (${lb_scheme:-internet-facing}) supply
-        # the default. Requires dns.private_domain — without a private zone
-        # the rest of the private-mode cascade no-ops, so the NLB scheme
-        # has to follow suit (an internal NLB with no private DNS published
-        # to it is a dead endpoint).
+        # Maps gateway.access to the aws-load-balancer-scheme annotation. Only
+        # `internal` overrides; else empty and the kustomize default applies.
+        # Gated on dns.private_domain to stay consistent with the private cascade.
         lb_scheme: "${gateway.access == 'private' && (dns.private_domain ?? '') != '' ? 'internal' : ''}"
 
-  # ---------------------------------------------------------------------------
-  # AWS Load Balancer Controller — NLB / ALB provisioner
-  # ---------------------------------------------------------------------------
-  #
-  # Watches Service: LoadBalancer and Ingress / Gateway resources and
-  # provisions modern AWS load balancers via the EKS API. Without it, the
-  # in-tree Cloud Controller Manager creates classic ELBs (no target-type=ip,
-  # no ALB ingress). Always rendered on AWS — every cluster wants this.
-  #
-  # IAM is wired by the cluster module: var.create_aws_lb_controller_role
-  # defaults to true, provisioning the role + the upstream IAM policy and a
-  # Pod Identity association binding the aws-load-balancer-controller SA in
-  # the system-lb namespace.
-  #
-  # The component lives at kustomize/lb/install/aws-lb-controller (sibling of
-  # lb/install/metallb which serves the same role on metal/incus). The install
-  # tier owns the system-lb namespace + whichever in-cluster LB implementation
-  # the platform needs.
-  #
-  # vpc_id + aws_region are passed explicitly so LBC doesn't fall back to
-  # IMDS for cluster discovery — worker launch templates set
-  # http_put_response_hop_limit=1, which blocks pod-network IMDS calls.
-  # cluster_name flows through via deferred terraform_output and is what
-  # LBC tags AWS resources with for ownership.
-  #
-  # aws_region has no default: a wrong region silently fails LBC (regional
-  # EC2/ELB API calls miss the cluster's VPC and emit confusing "not found"
-  # errors), so we'd rather propagate empty and let the controller crash on
-  # startup than fall back to a guess.
-  #
+  # AWS Load Balancer Controller — provisions NLB/ALB via the EKS API (else the
+  # in-tree CCM makes classic ELBs). Always rendered. IAM wired by the cluster
+  # module (create_aws_lb_controller_role, Pod Identity in system-lb). vpc_id +
+  # aws_region passed explicitly so LBC skips IMDS (worker hop-limit=1 blocks
+  # pod-network IMDS). aws_region has no default — a wrong region silently fails
+  # LBC, so propagate empty over guessing.
   - name: lb
     install:
       components:
@@ -365,16 +220,9 @@ flux:
         vpc_id: "${terraform_output('network', 'vpc_id') ?? ''}"
         aws_region: "${aws.region ?? ''}"
 
-  # ---------------------------------------------------------------------------
-  # Compute — cluster-autoscaler scales the EKS node-group ASGs on pending pods
-  # ---------------------------------------------------------------------------
-  #
-  # Node-group min/max only bounds the ASG; this controller does the scaling.
-  # It discovers groups by the k8s.io/cluster-autoscaler tags the aws-eks
-  # module applies to autoscaling-enabled pools, and authenticates via the
-  # Pod Identity association the module creates for system-compute/
-  # cluster-autoscaler.
-  #
+  # Compute — cluster-autoscaler scales the EKS node-group ASGs on pending pods.
+  # Discovers groups via the k8s.io/cluster-autoscaler tags the aws-eks module
+  # applies; authenticates through its Pod Identity association.
   - name: compute
     install:
       components:
@@ -385,10 +233,8 @@ flux:
         cluster_name: "${terraform_output('cluster', 'cluster_name') ?? ''}"
         aws_region: "${aws.region ?? ''}"
 
-  # ---------------------------------------------------------------------------
-  # CSI — AWS EBS, the default block storage on EKS. `single_storage_type`
-  # configures the StorageClass volumeType; gp3 is the current AWS recommendation.
-  # ---------------------------------------------------------------------------
+  # CSI — AWS EBS, default block storage on EKS. single_storage_type sets the
+  # StorageClass volumeType (gp3 recommended).
   - name: csi
     install:
       components:
@@ -398,81 +244,37 @@ flux:
       substitutions:
         single_storage_type: ${cluster.storage.single_storage_type ?? "gp3"}
 
-  # ---------------------------------------------------------------------------
-  # DNS — external-dns + Route53 record automation
-  # ---------------------------------------------------------------------------
-  #
-  # Anchored on the shared `dns` Kustomization (same canonical name that
-  # addon-private-dns uses) so the system-dns namespace and any sibling
-  # DNS components compose together at one path. The components below
-  # layer external-dns + the AWS-specific route53 patch; addon-private-dns
-  # would add coredns + its own components on top of the same Kustomization
-  # if both were active.
-  #
-  # external-dns watches Ingress and Gateway HTTPRoute resources annotated
-  # with external-dns.alpha.kubernetes.io/hostname=<host> and writes the
-  # matching A/CNAME records to a Route53 hosted zone. Two modes, both
-  # rendered by the same Kustomization:
-  #
-  #   - Public mode (default): targets the public zone provisioned by the
-  #     standalone dns-zone stack. Triggered by dns.public_domain.
-  #   - Private mode: targets the VPC-attached private zone created by the
-  #     network module from dns.private_domain. Triggered by
-  #     gateway.access=private (also requires dns.private_domain — there's
-  #     no zone to publish to without it, so the private cascade no-ops
-  #     and the gateway runs as public).
-  #
-  # The route53 component layers AWS-specific helm values onto the base
-  # external-dns release: Pod Identity auth, txtOwnerId from the cluster
-  # configmap (prevents two clusters in the same account from clobbering
-  # each other's records), and the zone_type / zone_id_filter pair below
-  # so the controller is locked to the right zone.
-  #
-  # IAM is already wired by the cluster module: var.create_external_dns_role
-  # defaults to true, which provisions the role + policy (wildcard-scoped on
-  # hostedzone/* — covers both public and private) and a Pod Identity
-  # association binding the external-dns ServiceAccount in system-dns to it.
-  #
+  # DNS — external-dns + Route53 record automation. Anchored on the shared `dns`
+  # Kustomization so it composes with addon-private-dns. external-dns writes
+  # A/CNAME records from annotated Ingress/HTTPRoute resources. Two modes: public
+  # (dns.public_domain → dns-zone stack) and private (gateway.access=private +
+  # dns.private_domain → the VPC zone). IAM wired by the cluster module
+  # (create_external_dns_role, Pod Identity in system-dns).
   - name: dns
     when: "(dns.public_domain ?? '') != '' || (gateway.access == 'private' && (dns.private_domain ?? '') != '')"
     dependsOn:
-      # gateway-install installs the Gateway API CRDs (HTTPRoute, Gateway). When
-      # the gateway is on, external-dns is configured with the gateway-httproute
-      # source below — without the CRDs present at startup it crash-loops on
-      # "no matches for kind HTTPRoute". Wait for gateway-install to finish.
+      # Wait for gateway-install's Gateway API CRDs; else the gateway-httproute
+      # source crash-loops on "no matches for kind HTTPRoute".
       - "${gateway.enabled == true ? 'gateway-install' : ''}"
     install:
       components:
         - external-dns
         - external-dns/providers/route53
-        # Gateway API HTTPRoute source — only when a Gateway controller is
-        # actually running. Without this guard, deployments that set
-        # dns.public_domain but disable the gateway would crash external-dns
-        # at startup (HTTPRoute CRDs aren't installed without gateway-install).
+        # HTTPRoute source only when the gateway runs; else external-dns crashes
+        # at startup without the HTTPRoute CRDs.
         - "${gateway.enabled == true ? 'external-dns/sources/gateway-httproute' : ''}"
       timeout: 5m
       interval: 5m
       substitutions:
-        # Private mode wins over public_domain for the gateway's DNS — even
-        # if both are set, a private gateway should publish to the private
-        # zone (its hostname is internal-only and unusable as an ALIAS target
-        # on the public zone). The same `access=private && private_domain set`
-        # gate fires here as everywhere else in the private-mode cascade,
-        # keeping the four substitutions and the `when:` self-consistent.
+        # Private mode wins over public_domain: a private gateway's hostname is
+        # internal-only, so it publishes to the private zone.
         external_domain: "${gateway.access == 'private' && (dns.private_domain ?? '') != '' ? dns.private_domain : (dns.public_domain ?? '')}"
         zone_type: "${gateway.access == 'private' && (dns.private_domain ?? '') != '' ? 'private' : 'public'}"
-        # Lock external-dns to the specific zone ID. Public zone comes from
-        # the standalone dns-zone stack; private zone comes from the network
-        # module (aws-vpc creates it when dns.private_domain is set).
-        # Deferred terraform_output handles first-bootstrap ordering.
+        # Lock external-dns to the zone ID: public from dns-zone, private from
+        # the network module. Deferred terraform_output handles bootstrap order.
         zone_id_filter: "${gateway.access == 'private' && (dns.private_domain ?? '') != '' ? (terraform_output('network', 'private_zone_id') ?? '') : (terraform_output('dns-zone', 'zone_id') ?? '')}"
-        # Region and owner-id were previously supposed to come through the
-        # external-dns ConfigMap via valuesFrom, but that ConfigMap was never
-        # created anywhere — fresh clusters silently failed at HelmRelease
-        # reconcile. Pass via Flux postBuild substitution instead.
+        # Region passed via Flux postBuild substitution.
         aws_region: "${aws.region ?? 'us-east-1'}"
-        # Owner ID stamped into TXT records so multiple external-dns instances
-        # in the same zone don't clobber each other. The context id (top-level
-        # `id` field in values.yaml) is unique per Windsor context so it doubles
-        # as a stable per-cluster identifier.
+        # Owner ID stamped into TXT records so external-dns instances sharing a
+        # zone don't clobber each other; the context id is unique per cluster.
         txt_owner_id: "${id}"

--- a/contexts/_template/facets/platform-azure.yaml
+++ b/contexts/_template/facets/platform-azure.yaml
@@ -6,15 +6,13 @@ metadata:
 
 when: platform == 'azure'
 
-# Terraform remote state lives in the Azure Storage account provisioned by
-# the `backend` component below. Downstream components configure their
-# backend pointed at it; the `backend` component itself uses local state.
+# Remote state lives in the Azure Storage account from the `backend` component
+# (which itself uses local state); downstream components point their backend at it.
 backend: backend
 
 # =============================================================================
 # Requires
 # =============================================================================
-#
 requires:
   - when: (dns.public_domain ?? '') != ''
     paths:
@@ -24,22 +22,16 @@ requires:
 # =============================================================================
 # Config — platform-specific overrides
 # =============================================================================
-#
-# AKS ships metrics-server as a built-in add-on, so we suppress the copy
-# platform-base would otherwise add to telemetry-resources (two instances
-# would fight on the same APIService).
-#
+# AKS ships metrics-server as a built-in add-on; suppress the platform-base copy
+# to avoid two instances fighting on the same APIService.
 config:
 
   - name: telemetry
     value:
       metrics_server_enabled: false
 
-  # pki_effective.issuer_component — public ClusterIssuer variant rendered by
-  # pki-resources, resolved as an ordered selection (last match wins):
-  # selfsigned floor → ACME (azuredns) when a public domain is set → private
-  # selfsigned when access is private (creates the `private` ClusterIssuer the
-  # gateway cert references; the public path only ever creates `public`).
+  # issuer_component selected in order (last match wins): selfsigned floor → ACME
+  # (azuredns) on public domain → private selfsigned on private access.
   - name: pki_effective
     value:
       issuer_component: public-issuer/selfsigned
@@ -55,41 +47,19 @@ config:
 # =============================================================================
 # Terraform — AzureRM state backend, VNet, AKS, optional public DNS zone
 # =============================================================================
-#
-# Dependency chain:
-#   backend (azurerm) → network (vnet) → cluster (aks) → gitops
-#                                     ↘  dns-zone (when ACME on)
-#
-# The backend stack provisions the storage account and container that every
-# downstream stack uses for remote state. It runs first on apply and — because
-# of the reverse-order teardown — last on destroy.
-#
-# AKS uses the cluster's built-in Cilium dataplane (network_data_plane: cilium
-# in the cluster module), so there's no optional Cilium bootstrap branch like
-# AWS — the dataplane comes up as part of the cluster itself.
-#
-# AKS doesn't need a "cluster-additions" sibling either: there's no aws-auth
-# ConfigMap to manage, and the cert-manager / external-dns Workload Identity
-# resources (UAMI + DNS Zone Contributor + Federated Credential) live inline
-# on the cluster module behind feature flags.
-#
+# Chain: backend (azurerm) → network (vnet) → cluster (aks) → gitops,
+# with dns-zone off backend when ACME is on. Cilium and the cert-manager/
+# external-dns Workload Identity resources are inline on the cluster module.
 terraform:
 
-  # AzureRM state backend (storage account + container). Per-context
-  # context_id keeps state isolated between contexts in the same subscription.
+  # State backend (storage account + container); per-context id isolates state
+  # across contexts in one subscription.
   - name: backend
     path: backend/azurerm
 
-  # VNet with the requested CIDR. AKS attaches to one of its private subnets
-  # (selected via the cluster module's data lookup on vnet_module_name).
-  # Depends on backend so the storage account holding remote state exists
-  # before this stack tries to write to it.
-  #
-  # domain_name feeds the VNet-linked private DNS zone created inside this
-  # module — internal DNS for VNet resources. Sourced from dns.private_domain
-  # (the in-cluster / private name) rather than dns.public_domain, since the
-  # VNet zone is by definition private. The public zone for ACME / external-dns
-  # lives in the standalone dns-zone stack below.
+  # VNet at the requested CIDR; AKS attaches to a private subnet. domain_name is
+  # the VNet-linked private DNS zone (dns.private_domain; the public zone lives
+  # in dns-zone below).
   - name: network
     path: network/azure-vnet
     dependsOn:
@@ -98,11 +68,9 @@ terraform:
       vnet_cidr: ${network.cidr_block}
       domain_name: ${dns.private_domain ?? ""}
 
-  # Public Azure DNS zone — provisioned when the operator sets dns.public_domain.
-  # Owns its own resource group so the zone has an independent lifecycle from
-  # the cluster: tearing the cluster down doesn't drag the DNS zone (and the
-  # registrar's NS delegation effort) with it unless the operator explicitly
-  # destroys this stack.
+  # Public Azure DNS zone, provisioned when dns.public_domain is set. Owns its
+  # own resource group so cluster teardown doesn't drag the zone (and NS
+  # delegation) with it.
   - name: dns-zone
     path: dns/zone/azure-dns
     when: "(dns.public_domain ?? '') != ''"
@@ -111,47 +79,29 @@ terraform:
     inputs:
       domain_name: ${dns.public_domain}
 
-  # AKS cluster. Workload Identity for cert-manager and external-dns is
-  # provisioned inline (UAMI + DNS Zone Contributor + Federated Credential).
-  # cert-manager identity is gated on dns.public_domain (no ACME → no
-  # cert-manager DNS-01 → no UAMI). external-dns identity is on by default,
-  # matching the AWS create_external_dns_role default.
-  #
-  # cert_manager_dns_zone_ids and external_dns_dns_zone_ids scope each role
-  # assignment to the specific Azure DNS zone resource ID we provisioned, so
-  # the credentials can't write records to unrelated zones in the same
-  # subscription.
+  # AKS cluster. Workload Identity (UAMI + DNS Zone Contributor + Federated
+  # Credential) for cert-manager and external-dns is inline; cert-manager's is
+  # gated on dns.public_domain, external-dns's is on by default. The
+  # *_dns_zone_ids inputs scope each role assignment to the provisioned zone.
   - name: cluster
     path: cluster/azure-aks
     dependsOn:
       - network
     inputs:
-      # private_subnet_ids comes straight from the network module's outputs.
-      # The cluster module used to discover the VNet/subnets via name-based
-      # data sources; the facet now passes them explicitly so the dependency
-      # is visible in the input contract instead of an Azure-side lookup.
       private_subnet_ids: ${terraform_output('network', 'private_subnet_ids')}
-      # Cheap default leaves node pools without a zone constraint (single-zone);
-      # topology: ha spreads them across zones 1-3.
+      # Single-zone by default; topology: ha spreads pools across zones 1-3.
       availability_zones: "${topology == 'ha' ? ['1','2','3'] : null}"
       create_cert_manager_identity: "${(dns.public_domain ?? '') != ''}"
       cert_manager_dns_zone_ids: "${(dns.public_domain ?? '') != '' && (terraform_output('dns-zone', 'zone_id') ?? '') != '' ? [terraform_output('dns-zone', 'zone_id')] : []}"
       external_dns_dns_zone_ids: "${gateway.access == 'private' && (dns.private_domain ?? '') != '' && (terraform_output('network', 'private_zone_id') ?? '') != '' ? [terraform_output('network', 'private_zone_id')] : ((dns.public_domain ?? '') != '' && (terraform_output('dns-zone', 'zone_id') ?? '') != '' ? [terraform_output('dns-zone', 'zone_id')] : [])}"
-      # Portable user pools (mirrors AWS-EKS). Render as additional
-      # azurerm_kubernetes_cluster_node_pool resources alongside the cluster's
-      # inline default (system) pool. When unset, default to one autoscaling
-      # general pool; the inline pool already covers the fixed system role, so
-      # AWS and AKS land on the same arrangement. Declaring cluster.pools
-      # replaces this.
+      # Portable user pools alongside the inline default (system) pool; defaults
+      # to one general pool. Declaring cluster.pools replaces this.
       pools: >-
         ${cluster.pools ?? {"general": {"class": "general", "count": 1}}}
 
-  # Path-less dependency-edge injector: when ACME is on, cluster must wait
-  # for dns-zone so terraform_output('dns-zone', 'zone_id') is resolved
-  # before the role assignment list is rendered. Without this, Windsor can
-  # schedule cluster and dns-zone concurrently, the guard expression
-  # evaluates false, and the role assignments fall through to the empty
-  # default (no zone access for cert-manager / external-dns).
+  # Dependency-edge injector: when ACME is on, cluster must wait for dns-zone so
+  # terraform_output('dns-zone', 'zone_id') resolves before the role assignment
+  # list is rendered (otherwise the guard evaluates false → no zone access).
   - name: cluster
     when: "(dns.public_domain ?? '') != ''"
     dependsOn:
@@ -167,43 +117,14 @@ terraform:
       concurrency: 5
 
 # =============================================================================
-# Kustomize — Azure Disk CSI + DNS / ACME / LB
-# =============================================================================
-#
-# AKS-specific telemetry trim (metrics-server suppression) is handled in the
-# config block above, so it composes via the shared platform-base entry
-# rather than a separate kustomize override here.
-#
-# =============================================================================
 # Flux systems — pki install/resources overlay
 # =============================================================================
-#
-# cert-manager Workload Identity (Azure DNS-01 only)
-# ---------------------------------------------------
-#
-# When ACME is on, the cert-manager pod itself needs Workload Identity wired
-# up so the azureDNS solver can mint Azure AD tokens via the projected SA
-# token. The webhook-injected env vars (AZURE_CLIENT_ID, AZURE_TENANT_ID,
-# AZURE_FEDERATED_TOKEN_FILE, AZURE_AUTHORITY_HOST) only fire when the pod
-# carries azure.workload.identity/use=true and the cert-manager SA has the
-# client-id annotation. This component patches the cert-manager HelmRelease
-# to add both. Lives under the install tier because that's where the
-# HelmRelease is composed.
-#
-# public ClusterIssuer — selfsigned default, ACME (azureDNS) when zone is set
-# -----------------------------------------------------------------------------
-#
-# Mirrors the AWS pki-resources logic exactly — same three branches, same
-# trigger (operator set dns.public_domain). The only difference is the ACME
-# branch picks public-issuer/acme/azuredns instead of the route53 sibling,
-# and the substitutions are Azure-specific (RG name, subscription, tenant,
-# cert-manager UAMI client_id) instead of (region, hostedZoneID).
-#
-# Required when ACME mode is active (schema enforces):
-#   - email — operator address Let's Encrypt registers against
-#
+# install: patches the cert-manager HelmRelease with Workload Identity so the
+# azureDNS solver can mint Azure AD tokens (ACME only). resources: renders the
+# public ClusterIssuer — selfsigned default, ACME (azuredns) when a zone is set.
 flux:
 
+  # Workload Identity for the cert-manager pod, gated on ACME.
   - name: pki
     when: "(dns.public_domain ?? '') != ''"
     install:
@@ -215,10 +136,7 @@ flux:
 
   - name: pki
     resources:
-      - dependsOn:
-          - policy-resources
-        components:
-          # Issuer variant resolved in the config section above.
+      - components:
           - "${pki_effective.issuer_component}"
         timeout: 5m
         interval: 5m
@@ -226,48 +144,28 @@ flux:
           acme_server: "${dev == true ? 'https://acme-staging-v02.api.letsencrypt.org/directory' : 'https://acme-v02.api.letsencrypt.org/directory'}"
           acme_email: "${email ?? ''}"
           acme_dns_zone: "${dns.public_domain ?? ''}"
-          # Deferred terraform_outputs from the dns-zone and cluster stacks.
-          # Gate the dns-zone reads on public_domain: the component isn't
-          # registered in private/selfsigned mode, and referencing an
-          # unregistered component is a hard error (?? '' only defaults an
-          # absent output, not an absent component). Selfsigned in private
-          # mode doesn't read these; empty values are inert there.
+          # Gate dns-zone reads on public_domain: the component isn't registered
+          # in private/selfsigned mode and referencing it is a hard error (?? ''
+          # only defaults an absent output, not an absent component).
           acme_dns_zone_resource_group: "${(dns.public_domain ?? '') != '' ? (terraform_output('dns-zone', 'resource_group_name') ?? '') : ''}"
           acme_dns_zone_subscription_id: "${(dns.public_domain ?? '') != '' ? (terraform_output('dns-zone', 'subscription_id') ?? '') : ''}"
           cert_manager_client_id: "${terraform_output('cluster', 'cert_manager_client_id') ?? ''}"
           cert_manager_tenant_id: "${terraform_output('cluster', 'tenant_id') ?? ''}"
 
-  # ---------------------------------------------------------------------------
-  # Gateway install merge — Azure LB annotations on the Envoy data-plane Service
-  # ---------------------------------------------------------------------------
-  #
-  # Additive block that merges into option-gateway's gateway install tier.
-  # AKS's CCM provisions a Standard SKU public LB for any Service:
-  # LoadBalancer with no annotations or controller add-on required, so
-  # the only platform-azure customization needed is flipping the LB to
-  # internal for private clusters. Done by conditionally including the
-  # azure-lb-internal component, which hardcodes the annotation to "true".
-  #
-  # This differs from platform-aws on purpose. AWS always includes
-  # aws-nlb and uses an lb_scheme substitution to toggle internal vs
-  # internet-facing. The Azure annotation values are "true" or "false",
-  # which YAML treats as bool tokens. They don't survive substitution
-  # through Flux postBuild and kustomize re-serialization, so we use
-  # conditional component inclusion as the equivalent toggle.
-  #
-  # Gated on dns.private_domain for the same reason as AWS: without a
-  # private zone the rest of the private-mode cascade no-ops, so an
-  # internal LB would have no zone to publish to.
-  #
+  # Merges into option-gateway's install tier. AKS's CCM gives any Service:
+  # LoadBalancer a public LB by default; the only customization is flipping it
+  # internal for private clusters by conditionally including azure-lb-internal
+  # (the annotation is a bool token that wouldn't survive substitution, so
+  # component inclusion is the toggle). Gated on dns.private_domain — no zone,
+  # no internal LB target.
   - name: gateway
     when: "gateway.enabled == true && gateway.driver == 'envoy' && lb_effective.mode == 'loadbalancer'"
     install:
       components:
         - "${gateway.access == 'private' && (dns.private_domain ?? '') != '' ? 'envoy/loadbalancer/azure-lb-internal' : ''}"
 
-  # Azure Disk CSI driver is preinstalled on AKS (since K8s 1.21) — this
-  # component only adds a custom `single` StorageClass tuned to our defaults.
-  # StandardSSD_LRS is the recommended balance of cost and performance.
+  # Azure Disk CSI is preinstalled on AKS; this only adds a `single`
+  # StorageClass. StandardSSD_LRS balances cost and performance.
   - name: csi
     install:
       components:
@@ -277,38 +175,15 @@ flux:
       substitutions:
         single_storage_type: ${cluster.storage.single_storage_type ?? "StandardSSD_LRS"}
 
-  # ---------------------------------------------------------------------------
-  # DNS — external-dns + Azure DNS record automation
-  # ---------------------------------------------------------------------------
-  #
-  # Anchored on the shared `dns` Kustomization (same canonical name that
-  # addon-private-dns and platform-aws use) so DNS components compose at one
-  # path. external-dns watches Ingress / Gateway HTTPRoute resources annotated
-  # with external-dns.alpha.kubernetes.io/hostname=<host> and writes A/CNAME
-  # records into a single Azure DNS zone. Two modes, both rendered by the
-  # same Kustomization:
-  #
-  #   - Public mode (default): targets the public zone provisioned by the
-  #     standalone dns-zone stack. Triggered by dns.public_domain.
-  #   - Private mode: targets the VNet-linked private zone created by the
-  #     network module from dns.private_domain. Triggered by
-  #     gateway.access=private (also requires dns.private_domain — there's
-  #     no zone to publish to without it, so the private cascade no-ops
-  #     and the gateway runs as public).
-  #
-  # Workload Identity is wired by the cluster module (external_dns UAMI +
-  # Federated Credential bound to system:serviceaccount:system-dns:external-dns).
-  # The provider patch annotates the SA with the UAMI's client_id and labels
-  # both the SA and the pod with azure.workload.identity/use=true so the
-  # webhook injects the projected token at runtime.
-  #
+  # external-dns writes A/CNAME records from annotated Ingress/HTTPRoute into an
+  # Azure DNS zone. Public mode (dns.public_domain) targets the dns-zone stack's
+  # zone; private mode (gateway.access=private + dns.private_domain) targets the
+  # VNet-linked zone. Workload Identity is wired by the cluster module.
   - name: dns
     when: "(dns.public_domain ?? '') != '' || (gateway.access == 'private' && (dns.private_domain ?? '') != '')"
     dependsOn:
-      # gateway-install installs the Gateway API CRDs (HTTPRoute, Gateway). When
-      # the gateway is on, external-dns is configured with the gateway-httproute
-      # source below — without the CRDs present at startup it crash-loops on
-      # "no matches for kind HTTPRoute". Wait for gateway-install to finish.
+      # Wait for the Gateway API CRDs, else the gateway-httproute source below
+      # crash-loops on "no matches for kind HTTPRoute".
       - "${gateway.enabled == true ? 'gateway-install' : ''}"
     install:
       components:
@@ -318,31 +193,21 @@ flux:
       timeout: 5m
       interval: 5m
       substitutions:
-        # Private mode wins over public_domain for the gateway's DNS — even if
-        # both are set, a private gateway should publish to the private zone (its
-        # hostname is internal-only and unusable as a record target on the public
-        # zone). Same access=private && private_domain gate fires here as in the
-        # rest of the private-mode cascade.
+        # Private mode wins: a private gateway's hostname is internal-only and
+        # unusable on the public zone.
         external_domain: "${gateway.access == 'private' && (dns.private_domain ?? '') != '' ? dns.private_domain : (dns.public_domain ?? '')}"
-        # Azure DNS resource ID — pins external-dns to a specific zone. Public
-        # zone comes from the standalone dns-zone stack; private zone comes from
-        # the network module (azure-vnet creates it when dns.private_domain is set).
+        # Pins external-dns to one zone: private from the network module, public
+        # from the dns-zone stack.
         zone_id_filter: "${gateway.access == 'private' && (dns.private_domain ?? '') != '' ? (terraform_output('network', 'private_zone_id') ?? '') : (terraform_output('dns-zone', 'zone_id') ?? '')}"
-        # Owner ID stamped into TXT records so multiple external-dns instances
-        # in the same zone don't clobber each other. The context id (top-level
-        # `id` field in values.yaml) is unique per Windsor context so it doubles
-        # as a stable per-cluster identifier.
+        # Context id in TXT records so multiple external-dns instances in a zone
+        # don't clobber each other.
         txt_owner_id: "${id}"
         external_dns_client_id: "${terraform_output('cluster', 'external_dns_client_id') ?? ''}"
         external_dns_tenant_id: "${terraform_output('cluster', 'tenant_id') ?? ''}"
-        # Subscription / RG of the target zone — feeds external-dns's azure.json.
-        # Private mode pulls from the network module (zone lives in the VNet's
-        # RG), public mode from the dns-zone stack.
+        # Subscription/RG of the target zone for azure.json: network module in
+        # private mode, dns-zone stack in public mode.
         external_dns_dns_zone_subscription_id: "${gateway.access == 'private' && (dns.private_domain ?? '') != '' ? (terraform_output('network', 'subscription_id') ?? '') : (terraform_output('dns-zone', 'subscription_id') ?? '')}"
         external_dns_dns_zone_resource_group: "${gateway.access == 'private' && (dns.private_domain ?? '') != '' ? (terraform_output('network', 'resource_group_name') ?? '') : (terraform_output('dns-zone', 'resource_group_name') ?? '')}"
-        # Public Azure DNS and Azure Private DNS Zones are served by different
-        # external-dns provider implementations (azure vs azure-private-dns) and
-        # different ARM resource types — without flipping this in private mode
-        # external-dns lists Microsoft.Network/dnszones and silently skips the
-        # privateDnsZones it should be writing to.
+        # Public and private zones use different provider implementations; without
+        # flipping this, private mode lists dnszones and skips privateDnsZones.
         external_dns_azure_provider: "${gateway.access == 'private' && (dns.private_domain ?? '') != '' ? 'azure-private-dns' : 'azure'}"

--- a/contexts/_template/facets/platform-base.yaml
+++ b/contexts/_template/facets/platform-base.yaml
@@ -4,86 +4,47 @@ metadata:
   name: platform-base
   description: "Base infrastructure components for all platforms"
 
-# Skip the entire facet when no platform is selected (the "none" context
-# used for bare blueprint scaffolding and schema validation).
+# Skip the facet when no platform is selected (the "none" scaffolding context).
 when: (platform ?? 'none') != 'none'
 
 # =============================================================================
 # Config — effective values
 # =============================================================================
-#
-# platform-base is the single source of truth for every `_effective` computed
-# value. Downstream facets (options, addons, platform-*) consume these values;
-# they do not re-derive or override them.
-#
-# Evaluation order matters: later entries may reference earlier ones. Keep
-# dependent values below their dependencies (e.g. the gateway block reads
-# cluster.cni.driver, so the cluster block must come first).
-#
+# Single source of truth for every `_effective` value; downstream facets
+# consume these without re-deriving. Order matters — dependent values sit
+# below their dependencies (gateway reads cluster.cni.driver).
 config:
 
-  # ---------------------------------------------------------------------------
-  # Platform identity
-  # ---------------------------------------------------------------------------
-  #
-  # Fall back to 'none' so expressions downstream can rely on a non-null
-  # string value.
-  #
+  # Platform identity — fall back to 'none' for a non-null downstream value.
   - name: platform
     value: "${platform ?? 'none'}"
 
-  # Normalize workstation.runtime so `workstation.runtime == '...'` checks are
-  # safe even when the user didn't supply a workstation block at all.
+  # Normalize workstation.runtime so equality checks are safe when unset.
   - name: workstation
     value:
       runtime: "${workstation.runtime ?? ''}"
 
-  # ---------------------------------------------------------------------------
-  # Cluster driver and CNI (platform-implied defaults)
-  # ---------------------------------------------------------------------------
-  #
-  # cluster.driver — managed clouds imply their managed driver (aws → eks,
-  # azure → aks); everything else defaults to talos. An explicit
-  # `cluster.driver` in values.yaml always wins.
-  #
-  # cluster.cni.driver — Talos defaults to Cilium (standard L2/BGP + Gateway
-  # API stack); managed clouds leave it empty so option-cni stays out unless
-  # Cilium is explicitly requested. cluster.driver is re-derived inline
-  # because sibling fields in the same block evaluate against user input,
-  # not the just-computed `driver` value.
-  #
+  # Cluster driver and CNI. Managed clouds imply their driver (aws→eks,
+  # azure→aks); else talos. Talos defaults CNI to cilium; managed clouds leave
+  # it empty. driver is re-derived inline since siblings see user input only.
   - name: cluster
     value:
       driver: "${cluster.driver ?? (platform == 'aws' ? 'eks' : (platform == 'azure' ? 'aks' : 'talos'))}"
       cni:
         driver: "${cluster.cni.driver ?? ((cluster.driver ?? (platform == 'aws' ? 'eks' : (platform == 'azure' ? 'aks' : 'talos'))) == 'talos' ? 'cilium' : '')}"
 
-  # Docker Desktop override: its API server is reachable only via a localhost
-  # tunnel, which Cilium's eBPF bootstrap can't use. Fall back to the built-in
-  # flannel CNI. Split into a `when:`-gated entry rather than an inline
-  # branch on workstation.runtime because option-workstation re-positions
-  # the `workstation` block to the end of evaluation order, leaving
-  # workstation.runtime as an unevaluated template at the time the cluster
-  # block evaluates.
+  # Docker Desktop: Cilium's eBPF bootstrap can't use its localhost-tunnel API
+  # server, so fall back to flannel. when:-gated (not inline) because
+  # option-workstation defers the workstation block past this one.
   - name: cluster
     when: workstation.runtime == 'docker-desktop'
     value:
       cni:
         driver: "${cluster.cni.driver ?? 'flannel'}"
 
-  # ---------------------------------------------------------------------------
-  # Gateway driver selection
-  # ---------------------------------------------------------------------------
-  #
-  # Resolution order (first non-null wins):
-  #   1. Explicit gateway.driver.
-  #   2. Legacy ingress.driver alias ('envoy-gateway' and 'nginx' both map to
-  #      'envoy'; anything else passes through unchanged).
-  #   3. Platform-based default:
-  #        - docker-desktop and AWS always use envoy (no cilium LB path).
-  #        - Otherwise, use cilium when it is the CNI (native Gateway API),
-  #          else envoy.
-  #
+  # Gateway driver. First non-null wins: explicit gateway.driver; legacy
+  # ingress.driver alias (envoy-gateway/nginx → envoy); else platform default
+  # — docker-desktop and AWS use envoy, otherwise cilium when it's the CNI.
   - name: gateway
     value:
       enabled: ${gateway.enabled ?? ingress.enabled ?? true}
@@ -96,41 +57,26 @@ config:
               ? 'envoy'
               : (cluster.cni.driver == 'cilium' ? 'cilium' : 'envoy'))}
 
-  # ---------------------------------------------------------------------------
-  # Load balancer selection
-  # ---------------------------------------------------------------------------
-  #
-  # An in-cluster LB is only needed when:
-  #   - The CNI doesn't provide one (Cilium has built-in L2/BGP LB), AND
-  #   - A loadbalancer_driver is explicitly configured.
-  #
-  # Cloud platforms (AWS, Azure) use cloud-managed LBs and leave
-  # loadbalancer_driver unset, so this evaluates to false there.
-  #
+  # Load balancer. In-cluster LB needed only when the CNI lacks one (Cilium has
+  # built-in L2/BGP) and loadbalancer_driver is set. Cloud platforms use managed
+  # LBs and leave it unset → false.
   - name: lb_effective
     value:
       enabled: "${cluster.cni.driver != 'cilium' && (network.loadbalancer_driver ?? '') != ''}"
       driver: "${network.loadbalancer_driver ?? 'kube-vip'}"
       mode: loadbalancer
 
-  # Docker Desktop has no routable node network, so Services of type
-  # LoadBalancer cannot be reached and an in-cluster LB controller (MetalLB)
-  # has nothing to advertise. Force enabled=false so lb-install is not pulled
-  # in via controller_required, and switch the gateway service to NodePort.
+  # Docker Desktop has no routable node network, so LoadBalancer Services are
+  # unreachable — force enabled=false and switch the gateway to NodePort.
   - name: lb_effective
     when: workstation.runtime == 'docker-desktop'
     value:
       enabled: false
       mode: nodeport
 
-  # Explicit gateway.service_type wins over driver/platform auto-detect. Lets
-  # any platform expose the gateway via NodePort (e.g. single-node Talos VMs
-  # without a cluster LB) or force LoadBalancer on docker-desktop.
-  #
-  # NodePort also forces lb_effective.enabled=false: even when the cluster has
-  # a loadbalancer_driver configured (e.g. kube-vip), a NodePort service will
-  # never be assigned a LoadBalancer IP, so the lb-address patch and
-  # gateway_dns_target would reconcile against an IP that never materializes.
+  # Explicit gateway.service_type wins over auto-detect. NodePort also forces
+  # enabled=false: a NodePort service never gets a LoadBalancer IP, so the
+  # lb-address patch would reconcile against an IP that never materializes.
   - name: lb_effective
     when: gateway.service_type == 'NodePort'
     value:
@@ -142,45 +88,20 @@ config:
     value:
       mode: loadbalancer
 
-  # True when an in-cluster LB controller is required — i.e. the `lb`
-  # system's install tier (compiled name `lb-install`) will be composed into
-  # the blueprint. This is the union of every `when:` that produces a
-  # non-empty install component across the platform facets:
-  #   - platform-aws: always (aws-lb-controller manages cloud NLBs/ALBs).
-  #   - platform-metal/incus/docker/hyperv: when lb_effective.enabled
-  #     (metallb or kube-vip — both ship an install-tier HelmRelease).
-  #   - platform-azure: never (Azure native LBs, no in-cluster controller).
-  # Consumers (gateway-resources, anything that owns a Service type=LoadBalancer
-  # or Ingress class managed by aws-lb-controller) reference this in their
-  # dependsOn so reverse-topo destroy ordering puts the controller last among
-  # in-cluster controllers — it's alive to lift its finalizers (e.g.
-  # service.k8s.aws/resources, elbv2.k8s.aws/resources) on Service /
-  # TargetGroupBinding deletion before its own Kustomization is torn down.
-  # Keep this in sync if a new platform facet adds another path that creates
-  # an `lb-install` Kustomization.
+  # True when an in-cluster LB controller (lb-install) is required: aws always
+  # (aws-lb-controller), metal/incus/docker/hyperv when lb_effective.enabled,
+  # azure never. Consumers dependsOn this so reverse-topo destroy keeps the
+  # controller alive to lift its finalizers before its Kustomization is torn
+  # down. Keep in sync if a new platform facet creates an lb-install.
   - name: lb_effective
     value:
       controller_required: "${platform == 'aws' || lb_effective.enabled == true}"
 
-  # ---------------------------------------------------------------------------
-  # DNS domains
-  # ---------------------------------------------------------------------------
-  #
-  # Three views of the same setting so callers can be specific:
-  #   - domain:         user-facing root, used when public/private aren't split.
-  #   - public_domain:  publicly-routable hostname pattern (external-dns
-  #                     publication, ACME cert SAN). Explicit only — never
-  #                     filled in from `domain`. The trigger for "this
-  #                     deployment has real public DNS" must be the operator
-  #                     setting public_domain themselves; falling back from
-  #                     `domain` would silently activate ACME paths whenever
-  #                     anyone configured a domain at all.
-  #   - private_domain: records served inside the cluster (CoreDNS).
-  #
-  # `dev: true` defaults `domain` and `private_domain` to 'test' so local dev
-  # works without any DNS configuration; public_domain stays empty in dev
-  # because there's no real public DNS to talk to.
-  #
+  # DNS domains. domain: user-facing root. public_domain: publicly-routable
+  # pattern (external-dns, ACME SAN) — explicit only, never from `domain`, so
+  # configuring a domain doesn't silently activate ACME. private_domain:
+  # in-cluster records (CoreDNS). dev:true defaults domain/private_domain to
+  # 'test'; public_domain stays empty (no real public DNS).
   - name: dns
     value:
       domain: "${dns.domain ?? (dev == true ? 'test' : '')}"
@@ -188,20 +109,10 @@ config:
       private_domain: "${dns.private_domain ?? dns.domain ?? (dev == true ? 'test' : '')}"
       enabled: "${(addons.private_dns.enabled ?? false) == true || (dns.public_domain ?? '') != '' || (gateway.access == 'private' && (dns.private_domain ?? '') != '')}"
 
-  # ---------------------------------------------------------------------------
-  # Cluster provisioning flags
-  # ---------------------------------------------------------------------------
-  #
-  # cluster_provisioned: true when a cluster should actually exist. On docker,
-  # the cluster only exists when a workstation runtime is set — `platform:
-  # docker` without workstation is a no-op scaffold used for tests.
-  #
-  # talos_enabled / eks_enabled: driver-specific gates for cluster.enabled.
-  # Used by option-cni and related facets to decide whether to bootstrap.
-  #
-  # talos_provisioned: talos_enabled + cluster actually provisioned (matters
-  # on docker where provisioning requires workstation).
-  #
+  # Cluster provisioning flags. cluster_provisioned: a cluster should exist —
+  # on docker only when a workstation runtime is set (bare `platform: docker`
+  # is a test scaffold). talos_enabled/eks_enabled: driver-specific gates.
+  # talos_provisioned: talos_enabled and actually provisioned.
   - name: cluster_provisioned
     value: "${(cluster.enabled ?? true) && (platform != 'docker' || (workstation.runtime != null && workstation.runtime != ''))}"
   - name: talos_enabled
@@ -211,29 +122,11 @@ config:
   - name: eks_enabled
     value: "${cluster.driver == 'eks' && (cluster.enabled ?? true)}"
 
-  # ---------------------------------------------------------------------------
-  # Topology
-  # ---------------------------------------------------------------------------
-  #
-  # Resolves the user-facing `topology` field to a concrete value so downstream
-  # facets can read `${topology}` directly without re-implementing the fallback
-  # chain. Explicit `topology` always wins. Otherwise:
-  #
-  #   - Layout declared (metal, incus, docker-compose-style): derive from
-  #     effective node counts — `count` wins when set, otherwise fall back to
-  #     `len(nodes)`. 1 total → single-node; 3+ CPs → ha; else multi-node.
-  #
-  #   - Workstation runtime with no layout (colima, docker-desktop): platform
-  #     implicitly provisions 1 CP, so default to single-node.
-  #
-  #   - Otherwise (cloud platforms with no layout): multi-node.
-  #
-  # Written as a single expression because writing the result back to
-  # `topology` itself means later entries can't read the original user input —
-  # they'd see whatever the previous entry set. Inlining the count expressions
-  # also avoids the engine's spotty support for cross-entry helper visibility
-  # in `when:` clauses.
-  #
+  # Resolve `topology` to a concrete value. Explicit wins; else from node
+  # counts (count ?? len(nodes)): 1 → single-node, 3+ CPs → ha, else
+  # multi-node; workstation runtime with no layout → single-node; cloud with
+  # no layout → multi-node. Single inline expression so later entries still
+  # read the original user input, not a value this entry wrote back.
   - name: topology
     value: >-
       ${
@@ -255,23 +148,10 @@ config:
         )
       }
 
-  # ---------------------------------------------------------------------------
-  # Network defaults
-  # ---------------------------------------------------------------------------
-  #
-  # Populate user-facing `network.*` fields so downstream facets can read
-  # `network.cidr_block` / `network.loadbalancer_ips.*` directly without
-  # re-applying the fallback chain.
-  #
-  # Each entry uses `when:` (evaluated against user input only) instead of
-  # the self-referencing `${network.X ?? default}` pattern in `value:`. The
-  # engine stores config-block bodies unevaluated in globalScope and
-  # iterates blocks in last-writer order; a self-referencing template can
-  # be read as the literal template string by a config block in another
-  # facet that evaluates earlier in the round. The when-guarded form has
-  # no self-reference (bodies may still compute over other user inputs,
-  # like cidrhost over network.cidr_block), so cross-block reads resolve.
-  #
+  # Network defaults for downstream facets. Each entry is when:-guarded rather
+  # than self-referencing `${network.X ?? default}`: unevaluated block bodies
+  # can leak the literal template to an earlier-evaluating facet, so the
+  # when-form avoids the self-reference while still computing over other inputs.
   - name: network
     when: (network.cidr_block ?? '') == ''
     value:
@@ -287,25 +167,10 @@ config:
       loadbalancer_ips:
         end: "${cidrhost(network.cidr_block ?? '10.5.0.0/16', 356)}"
 
-  # ---------------------------------------------------------------------------
-  # Telemetry driver
-  # ---------------------------------------------------------------------------
-  #
-  # metrics_enabled / logs_enabled: independent gates for the two halves of the
-  # telemetry pipeline. Both default on; disable individually to trim resources
-  # on small clusters (e.g. metrics-only when HPA is needed but logs aren't, or
-  # logs-only for debugging without the Prometheus overhead).
-  #
-  # Both are force-on when addons.observability is enabled — the observability
-  # addon expects a metrics backend and a log pipeline to be present, so opting
-  # the addon in trumps explicit disables here.
-  #
-  # logs_driver: aggregator choice. Valid values: 'fluentd' (default), 'none'
-  # (keep fluent-bit shipper but drop the fluentd aggregator), 'elasticsearch'
-  # (filebeat → Elasticsearch, set by addon-observability). Coerced to 'none'
-  # when the logs pipeline is disabled so downstream `when:` guards on the
-  # fluentd aggregator fall through cleanly.
-  #
+  # Telemetry driver. metrics/logs: independent gates, both default on.
+  # addons.observability forces both on. logs.driver: 'fluentd' (default),
+  # 'none' (shipper only, no aggregator), or 'elasticsearch' (via
+  # addon-observability); coerced to 'none' when the logs pipeline is off.
   - name: telemetry
     value:
       metrics:
@@ -330,10 +195,8 @@ config:
       logs:
         driver: none
 
-  # Default-on opt-out for our metrics-server copy. Managed-K8s platforms
-  # that ship metrics-server as a built-in add-on (AKS, future GKE)
-  # override to false in their own facet to avoid two instances fighting
-  # on the same APIService.
+  # metrics-server, default-on. Managed-K8s platforms that ship it built-in
+  # (AKS, future GKE) override to false to avoid two instances on one APIService.
   - name: telemetry
     value:
       metrics_server_enabled: true
@@ -341,34 +204,22 @@ config:
 # =============================================================================
 # Global substitutions
 # =============================================================================
-#
-# Variables exposed to every kustomization's postBuild via Flux variable
-# substitution. Declared here (rather than per-kustomization) because they
-# are consumed across many components — HTTPRoutes, certificates, external-dns
-# annotations — and hardcoding them in each would mean chasing down every
-# site on a domain change. Add new globals here only when they are truly
-# cross-cutting; per-kustomization values belong on the kustomization.
-#
+# Variables exposed to every kustomization's postBuild via Flux substitution.
+# Declared here because they're consumed cross-cutting (HTTPRoutes, certs,
+# external-dns). Add only truly cross-cutting values; else per-kustomization.
 substitutions:
-  # FQDN suffix for internal/cluster-local resources (e.g. grafana.test,
-  # flux-webhook.test). Resolved by the in-cluster CoreDNS and the workstation
-  # DNS forwarder.
+  # FQDN suffix for cluster-local resources (grafana.test), resolved by CoreDNS.
   private_domain: ${dns.private_domain}
 
-  # FQDN suffix for externally-reachable resources on cloud platforms. Unused
-  # on local/workstation contexts where private_domain covers everything.
+  # FQDN suffix for externally-reachable resources on cloud platforms.
   public_domain: ${dns.public_domain}
 
 # =============================================================================
 # CRDs — vendored, applied ahead of the controller
 # =============================================================================
-#
-# cert-manager, prometheus-operator, and fluent-operator CRDs ship vendored under
-# kustomize/crds/ and are applied before the controllers; the charts run with CRD
-# install disabled. Every kustomization auto-depends on this layer, so the
-# ServiceMonitor CRD is present for scrape configs across every facet, and a
-# fluent-operator teardown can't cascade-delete its CRs (see issue #2021).
-#
+# cert-manager, prometheus-operator, fluent-operator CRDs vendored under
+# kustomize/crds/, applied before the controllers (charts run CRD-install off).
+# Every kustomization auto-depends on this layer (see issue #2021).
 crds:
   # renovate: datasource=github-releases depName=cert-manager/cert-manager package=cert-manager/cert-manager
   - cert-manager-1.21.0
@@ -383,13 +234,9 @@ crds:
 # =============================================================================
 # Terraform — shared gitops inputs
 # =============================================================================
-#
-# Each platform facet declares its own `gitops` terraform block with the
-# dependencies it needs. Windsor merges inputs across facets, so adding the
-# mode here applies to every platform without repeating it per-facet. In pull
-# mode the terraform module drops notification-controller and the webhook
-# token secret.
-#
+# Each platform facet declares its own `gitops` block; Windsor merges inputs,
+# so setting mode here applies everywhere. Pull mode drops notification-
+# controller and the webhook token secret.
 terraform:
   - name: gitops
     path: gitops/flux
@@ -399,22 +246,11 @@ terraform:
 # =============================================================================
 # Flux systems — policy, telemetry, pki (install/resources tier split)
 # =============================================================================
-#
-# policy: install installs the Kyverno controller. resources applies cluster
-# policies; each policy is individually toggleable via the top-level
-# `policies.*` field (defaults to enabled). resources implicitly depends on
-# install; no dependsOn is written for that edge.
-#
-# telemetry: install is the operators (Prometheus, fluent-bit, fluent-operator).
-# resources is metrics-server, scrape jobs, fluent-bit filters, and the
-# fluent-bit → fluentd shipper when fluentd is the chosen aggregator.
-# addon-observability replaces this whole system (strategy: replace) when the
-# Elasticsearch log driver is selected, swapping fluent-bit for filebeat.
-#
-# pki: install is cert-manager. resources is empty here — platform and addon
-# facets (aws, azure, hyperv, dev, private-ca) each contribute their own
-# ClusterIssuer variant, merged into the same pki-resources kustomization.
-#
+# resources implicitly dependsOn install. policy: Kyverno controller + cluster
+# policies (globalDependency — every workload implicitly waits on its resources
+# tier; toggle via policies.*). telemetry: operators + metrics-server/
+# scrape/filters; addon-observability replaces it for the Elasticsearch driver.
+# pki: cert-manager; resources empty here (platform/addon facets add issuers).
 flux:
   - name: policy
     when: (policies.enabled ?? true) == true
@@ -493,16 +329,9 @@ flux:
           - "${telemetry.metrics.enabled ? 'fluentd/prometheus' : ''}"
           - "${log_level != 'trace' ? 'fluentd/filters/log-level/' + (log_level ?? 'info') : ''}"
 
-  # ---------------------------------------------------------------------------
-  # GitOps webhook receiver
-  # ---------------------------------------------------------------------------
-  #
-  # Flux webhook for push-driven source reconciliation. Reconciled onto the
-  # terraform-bootstrapped Flux, so it is a resources-only system. With a
-  # gateway present it also lands the port-80 HTTPRoute (Envoy or Cilium) and
-  # waits for gateway-install so the route CRDs exist first. Emission tracks
-  # gitops.mode — push emits, pull skips the whole system.
-  #
+  # GitOps webhook — push-driven Flux reconciliation, resources-only (onto the
+  # terraform-bootstrapped Flux). With a gateway, adds the port-80 HTTPRoute and
+  # waits for gateway-install. push emits, pull skips the system.
   - name: gitops
     path: gitops
     when: (gitops.mode ?? 'push') == 'push'
@@ -516,14 +345,8 @@ flux:
         substitutions:
           git_repository_name: ${gitops.repository.name ?? "local"}
 
-  # ---------------------------------------------------------------------------
-  # Flux Operator web UI
-  # ---------------------------------------------------------------------------
-  #
-  # Opt-in (gitops.web_ui) HTTPRoute exposing the operator web UI at
-  # flux.<domain> when a gateway is present. Resources-only; cilium adds a CNP
-  # allowing the gateway to reach the operator.
-  #
+  # Flux Operator web UI — opt-in (gitops.web_ui) HTTPRoute at flux.<domain>
+  # when a gateway is present. Resources-only; cilium adds a gateway-reach CNP.
   - name: flux-ui
     path: gitops
     when: gateway.enabled == true && (gitops.web_ui ?? false) == true

--- a/contexts/_template/facets/platform-docker.yaml
+++ b/contexts/_template/facets/platform-docker.yaml
@@ -4,34 +4,24 @@ metadata:
   name: docker
   description: "Docker provider basic infrastructure for local development"
 
-# Docker is only supported with Talos as the cluster driver and a workstation
-# runtime. With cluster disabled or workstation runtime unset, this facet is
-# a true no-op — nothing materializes that would reference its config or the
-# `backend: cluster` setting below.
+# Docker requires Talos and a workstation runtime; otherwise this facet is a no-op.
 when: "platform == 'docker' && cluster.driver == 'talos' && (cluster.enabled ?? true) && (workstation.runtime ?? '') != ''"
 
-# Terraform remote state lives in the local Talos cluster (Kubernetes
-# backend, secrets-as-state). The `cluster` component itself uses local
-# state since it's the one that creates the cluster.
+# Remote state lives in the local Talos cluster (Kubernetes backend); the
+# `cluster` component uses local state since it creates the cluster.
 backend: cluster
 
 # =============================================================================
 # Config — docker-specific Talos values
 # =============================================================================
-#
 config:
 
-  # The first controlplane gets a fixed IP at CIDR offset 10; offsets 2–9 are
-  # reserved for workstation services (DNS, registries, git livereload).
-  # Mirrors the incus provider convention so cross-platform logic is uniform.
+  # Controlplane at CIDR offset 10; offsets 2–9 reserved for workstation services.
   - name: talos_common
     value:
       k8s_service_host: "${cidrhost(network.cidr_block, 10)}"
 
-  # Node targets for post-cluster steps (e.g. cluster/talos/extensions). Reads
-  # compute outputs (compute always runs before cluster, which runs before
-  # extensions), projected to the {node, endpoint} shape that the extensions
-  # module accepts.
+  # Node targets for post-cluster steps (e.g. extensions), from compute outputs.
   - name: talos_node_targets
     value:
       controlplanes: >-
@@ -39,19 +29,8 @@ config:
       workers: >-
         ${map(terraform_output("compute", "workers") ?? [], fromPairs(filter(toPairs(#), get(#, 0) == "node" || get(#, 0) == "endpoint")))}
 
-  # ---------------------------------------------------------------------------
-  # cluster_endpoint_fallback — best-effort Talos API endpoint
-  # ---------------------------------------------------------------------------
-  #
-  # Resolution order:
-  #   1. Compute output with a real endpoint → use that host on port 6443.
-  #   2. No compute output (docker-desktop bootstrap, no cluster yet)
-  #      → localhost:6443 (host port-forwarded into the control plane
-  #      container).
-  #   3. Compute exists but has empty endpoint → fall back to the first
-  #      configured controlplane node.
-  #   4. Nothing — last-ditch localhost:6443.
-  #
+  # Best-effort Talos API endpoint: compute output if present, else localhost:6443
+  # (docker-desktop bootstrap), else first configured controlplane node.
   - name: cluster_endpoint_fallback
     value:
       endpoint: >-
@@ -67,12 +46,9 @@ config:
 # =============================================================================
 # Terraform — cluster/talos with docker-specific node rewriting
 # =============================================================================
-#
-# Runs only when workstation is up and cluster is enabled. option-workstation
-# owns `compute` and wires the workstation → compute → cluster chain; this
-# facet provides the cluster-step inputs (docker-specific endpoint rewriting
-# and certSAN patching).
-#
+# Runs only with workstation up and cluster enabled. option-workstation owns
+# `compute`; this facet provides the cluster-step inputs (endpoint rewriting,
+# certSAN patching).
 terraform:
 
   - name: cluster
@@ -86,16 +62,9 @@ terraform:
       cluster_name: talos
       talos_version: ${talos.talos_version}
 
-      # controlplanes: two code paths per node —
-      #
-      # Path A (compute output present): pass nodes through unchanged.
-      # docker-desktop adds a per-node machine.certSANs patch including the
-      # real IP, hostname, localhost, and 127.0.0.1 so Talos API certs work
-      # when the client is the host reaching through the docker-desktop tunnel.
-      #
-      # Path B (no compute output, bootstrap-from-host): rewrite
-      # endpoint/node to 127.0.0.1:(50000+i). This lets the host Talos
-      # CLI bootstrap the control plane containers via port forwards.
+      # With compute output: pass nodes through; docker-desktop adds a certSANs
+      # patch. Without it (bootstrap-from-host): rewrite endpoint/node to
+      # 127.0.0.1:(50000+i) so the host Talos CLI can reach containers via port forwards.
       controlplanes: >-
         ${map(
           len(terraform_output("compute", "controlplanes") ?? []) > 0
@@ -116,9 +85,7 @@ terraform:
             : #
         )}
 
-      # workers: mirror of controlplanes. Pass nodes through when compute
-      # output is present; rewrite endpoint to 127.0.0.1 offsets when
-      # bootstrapping from the host. Worker ports are offset by controlplane count.
+      # Mirror of controlplanes; worker ports offset by controlplane count.
       workers: >-
         ${len(terraform_output("compute", "controlplanes") ?? []) > 0
           ? (terraform_output("compute", "workers") ?? [])
@@ -142,21 +109,9 @@ terraform:
 # =============================================================================
 # Flux systems — MetalLB / kube-vip for colima / docker / linux runtimes
 # =============================================================================
-#
-# Docker Desktop has no node-level IP routing, so MetalLB can't work there —
-# skip the whole system when runtime is docker-desktop. Other docker runtimes
-# (colima, native linux) have a real network and use MetalLB or kube-vip as
-# the LB.
-#
-# install ships the driver's controller HelmRelease. kube-vip/arp builds
-# here too — it's a patch on the kube-vip HelmRelease, not a separate CR —
-# and loadbalancer_ip_range is set here because the kube-vip cloud-provider
-# HelmRelease reads it directly.
-#
-# resources ships metallb/arp or metallb/layer2, the IPAddressPool /
-# L2Advertisement CRs metallb's controller consumes. No component for
-# kube-vip, which has nothing left to configure once install has run.
-#
+# Skipped on docker-desktop (no node-level IP routing). colima/native linux use
+# MetalLB or kube-vip. install ships the driver's controller HelmRelease (plus
+# kube-vip's arp patch); resources ships metallb's IPAddressPool/L2Advertisement CRs.
 flux:
 
   - name: lb

--- a/contexts/_template/facets/platform-hyperv.yaml
+++ b/contexts/_template/facets/platform-hyperv.yaml
@@ -4,49 +4,28 @@ metadata:
   name: hyperv
   description: Hyper-V compute platform infrastructure
 
-# Hyper-V is supported only with Talos. Connection details (host, credentials,
-# backend) are read from HYPERV_* env vars by the provider — there is no
-# workstation-overlay path here.
+# Talos-only. Connection details come from HYPERV_* env vars; no workstation overlay.
 when: "platform == 'hyperv' && cluster.driver == 'talos'"
 
-# Terraform remote state lives in the local Talos cluster (Kubernetes
-# backend, secrets-as-state). The `cluster` component itself uses local
-# state since it's the one that creates the cluster.
+# Remote state lives in the local Talos cluster (Kubernetes backend).
 backend: cluster
 
 # =============================================================================
 # Config — Hyper-V-specific Talos values
 # =============================================================================
-#
 config:
 
-  # ---------------------------------------------------------------------------
-  # hyperv_effective — switch topology / paths / image source
-  # ---------------------------------------------------------------------------
-  #
-  # Resolves the schema's `hyperv.*` block into a concrete shape the terraform
-  # inputs consume. Switch type is derived purely from intent declared
-  # elsewhere — operators don't pick External/Internal/NAT directly:
-  #   - gateway.service_type == 'NodePort' → NAT (handled in the layered
-  #     entry below, after this base resolution)
-  #   - hyperv.net_adapter set             → External (L2-bridged, LAN-reachable)
-  #   - else                                → Internal (host-only, bench-safe)
-  #
-  # Paths are derived from a single `hyperv.base_dir` (default C:/hyperv)
-  # rather than two separate dirs — VHDs and images cohabit on the same drive
-  # in every realistic deployment.
-  #
-  # The Talos image URL is fully derivable from talos.talos_version (renovate-
-  # pinned) plus a hardcoded schematic ID, so there's no operator override
-  # path. The schematic adds `talos.platform=nocloud` to the kernel cmdline
-  # so Talos boots in `nocloud` mode and reads the CIDATA seed volume — Image
-  # Factory doesn't publish prebuilt hyperv VHDXs, so the metal-amd64.iso +
-  # CIDATA path is the canonical Talos-on-Hyper-V flow. Schematic ID is
-  # deterministic from the customization YAML; recompute via:
+  # Resolve schema `hyperv.*` into concrete terraform inputs. Switch type is
+  # derived from intent, not picked directly: NodePort → NAT (layered below);
+  # net_adapter set → External (L2-bridged); else Internal (host-only). Paths
+  # derive from a single hyperv.base_dir (default C:/hyperv). Image URL derives
+  # from renovate-pinned talos_version + a hardcoded schematic that sets
+  # talos.platform=nocloud so Talos reads the CIDATA seed (Image Factory has no
+  # prebuilt hyperv VHDX; metal-amd64.iso + CIDATA is the canonical flow).
+  # Recompute schematic ID:
   #   curl -X POST -H 'Content-Type: application/yaml' \
   #     -d $'customization:\n  extraKernelArgs:\n    - talos.platform=nocloud\n' \
   #     https://factory.talos.dev/schematics
-  # Hyper-V hosts are universally amd64 in production; arch hardcoded.
   - name: hyperv_effective
     value:
       switch_type: "${len(hyperv.net_adapter ?? []) > 0 ? 'External' : 'Internal'}"
@@ -57,15 +36,8 @@ config:
       image_destination: "${(hyperv.base_dir ?? 'C:/hyperv') + '/images/talos-' + talos.talos_version + '-metal-amd64.iso'}"
       image_url: "${'https://factory.talos.dev/image/a9999ca75e856f927166016d16df9f9705927a18fc2f7a0c92b1ac96a376f9a6/v' + talos.talos_version + '/metal-amd64.iso'}"
 
-  # ---------------------------------------------------------------------------
-  # Network gateway and nameservers — needed for the CIDATA seed
-  # ---------------------------------------------------------------------------
-  #
-  # Land defaults on the user-facing `network` field so any platform that
-  # consumes them picks them up uniformly. Conditional `when:` writes
-  # (gated on user input) — see the rationale in platform-base.yaml's
-  # "Network defaults" block.
-  #
+  # Network gateway and nameserver defaults for the CIDATA seed. Written only
+  # when unset; see platform-base.yaml "Network defaults" for the pattern.
   - name: network
     when: (network.gateway ?? '') == ''
     value:
@@ -75,34 +47,17 @@ config:
     value:
       nameservers: ['1.1.1.1', '8.8.8.8']
 
-  # ---------------------------------------------------------------------------
-  # cluster.cni.driver override — default to Talos flannel
-  # ---------------------------------------------------------------------------
-  #
-  # platform-base defaults cluster.cni.driver to 'cilium' whenever
-  # cluster.driver is 'talos'. Hyper-V instead defaults to Talos's built-in
-  # flannel: no Cilium bootstrap stage, no cni:none / proxy:disabled patches,
-  # kubelet's CNI plugin comes up automatically. Operators can still opt in
-  # to Cilium via cluster.cni.driver: cilium.
+  # Default the CNI to Talos's built-in flannel (platform-base would default
+  # talos to cilium). Operators can still opt into cilium via cluster.cni.driver.
   - name: cluster
     value:
       cni:
         driver: "${cluster.cni.driver ?? 'flannel'}"
 
-  # ---------------------------------------------------------------------------
-  # NodePort branch — flip topology to NAT switch + bench-side port forwards
-  # ---------------------------------------------------------------------------
-  #
-  # When gateway.service_type=NodePort, the VM moves onto a private NetNat
-  # subnet and the bench publishes the cluster's listen ports on its LAN IP.
-  # External clients hit <bench_ip>:80, :443, :6443, :40000 etc.; the kernel
-  # forwards into the VM. Switch type flips to NAT (Internal + NetNat), and
-  # the network CIDR / gateway are overridden to the NAT-internal subnet so
-  # the per-node static IP patch (in cluster/talos/config) and compute's
-  # ipv4 derivation both line up with the new topology.
-  #
-  # bench_ip is derived from cluster.endpoint (the operator-facing URL the
-  # talosconfig and kubeconfig also embed) — required in NodePort mode.
+  # NodePort mode: move VMs onto a private NetNat subnet and publish cluster
+  # ports on the bench LAN IP (kernel forwards into the VM). CIDR/gateway are
+  # overridden to the NAT-internal subnet so per-node static IPs line up.
+  # bench_ip derives from cluster.endpoint, required in NodePort mode.
   - name: hyperv_effective
     when: gateway.service_type == 'NodePort'
     requires:
@@ -112,59 +67,30 @@ config:
     value:
       switch_type: NAT
       nat_name: "windsor-${id ?? 'hyperv'}"
-      # nat_internal_prefix / prefix_length / host_address all derive from
-      # network.cidr_block — the platform-agnostic "cluster network" knob.
-      # In NodePort mode it's interpreted as the private subnet NetNat
-      # routes for; in LAN-bridged modes the same field describes the
-      # bench LAN. Override via values.yaml when the default conflicts
-      # with another routed subnet on the bench.
+      # Derived from network.cidr_block, interpreted here as the NAT private
+      # subnet. Override via values.yaml if it conflicts with another bench subnet.
       nat_internal_prefix: "${network.cidr_block ?? '10.5.0.0/16'}"
       nat_prefix_length: "${split(network.cidr_block ?? '10.5.0.0/16', '/')[1]}"
       nat_host_address: "${cidrhost(network.cidr_block ?? '10.5.0.0/16', 1)}"
       bench_ip: "${(cluster.endpoint ?? '') != '' ? split(split(cluster.endpoint, '://')[1], ':')[0] : ''}"
 
-  # NodePort overrides network.gateway so cluster-config's per-node default
-  # route points at the NAT host vNIC (the only address reachable from
-  # inside the NAT subnet), regardless of any bench-LAN `network.gateway`
-  # the operator set for LAN-bridge documentation.
+  # Point each node's default route at the NAT host vNIC (the only address
+  # reachable from inside the NAT subnet), overriding any bench-LAN gateway.
   - name: network
     when: gateway.service_type == 'NodePort'
     value:
       gateway: "${cidrhost(network.cidr_block ?? '10.5.0.0/16', 1)}"
 
-  # ---------------------------------------------------------------------------
-  # Per-VM derivation lists (NodePort)
-  # ---------------------------------------------------------------------------
-  #
-  # Mirrors platform-docker's docker-desktop pattern: each Talos node is
-  # individually addressable via a distinct bench-side port forward. The
-  # facet derives every operator-facing detail from a single signal — count
-  # — so values.yaml stays free of NAT-subnet / port-offset bookkeeping.
-  #
-  # IP scheme on the NAT subnet (192.168.200.0/24):
-  #   - controlplane-N → 192.168.200.(10+N-1)  (cp-1=.10, cp-2=.11, …)
-  #   - worker-N       → 192.168.200.(20+N-1)  (worker-1=.20, worker-2=.21, …)
-  #
-  # Talos API port-forward scheme on the bench. Bench-side base is 40000 to
-  # stay below the Windows TCP dynamic-port floor (default 49152) — anything
-  # in 49152-65535 is rejected by Add-NetNatStaticMapping. In-VM target stays
-  # at Talos's canonical 50000. CPs and workers use disjoint 100-port ranges
-  # so growing one role doesn't renumber the other (a cp_count bump under a
-  # shared offset would shift every worker's bench port, destroying its NAT
-  # mapping and breaking saved talosconfig/kubeconfig entries).
-  #   - controlplane-N → bench:(40000+N-1) → cp-N:50000
-  #   - worker-N       → bench:(40100+N-1) → worker-N:50000
-  #
-  # Each entry exposes two shapes:
-  #   - for_config: {hostname, node, address}. Consumed by cluster-config to
-  #     bake the static IP into per-node CIDATA seeds.
-  #   - for_cluster: {hostname, node, endpoint}. Consumed by the cluster
-  #     step (talos provider). endpoint is the bench-side host:port pair so
-  #     talosctl reaches each node directly via its dedicated forward.
-  #
-  # `len(#acc)` gives the zero-based index inside reduce; we only iterate up
-  # to count to support the case where values.yaml has more node entries
-  # than count requests (operator narrowing the cluster without retemplating).
+  # Per-VM derivation lists (NodePort): each node is individually addressable
+  # via a distinct bench-side port forward, all derived from count.
+  # NAT-subnet IPs: controlplane-N → .(10+N-1), worker-N → .(20+N-1).
+  # Talos API forwards: cp-N → bench:(40000+N-1), worker-N → bench:(40100+N-1),
+  # both → :50000 in-VM. Base 40000 stays below Windows' 49152 dynamic-port
+  # floor (Add-NetNatStaticMapping rejects above it); disjoint 100-port ranges
+  # keep growing one role from renumbering the other's saved NAT mappings.
+  # Each entry has two forms: for_config {hostname,node,address} bakes the
+  # static IP into CIDATA seeds; for_cluster {hostname,node,endpoint} gives
+  # talosctl a bench-side host:port to reach each node.
   - name: hyperv_controlplanes
     when: gateway.service_type == 'NodePort'
     value:
@@ -197,26 +123,13 @@ config:
           ["endpoint", hyperv_effective.bench_ip + ":" + string(40099 + #)]
         ]))}
 
-  # Forward map: bench-side listen port → in-VM port, plus per-port
-  # target_ip overrides so each Talos API forward lands at its node. The
-  # gateway / k8s-API forwards stay single-target (cp-1) — kube-proxy and
-  # the apiserver replication handle inter-node routing internally.
-  #
-  # tcp_forwards layout in NodePort mode:
-  #   6443       → 6443 (cp-1; apiserver replicated to other cps)
-  #   30053      → 30053 (cp-1; only when private-dns / dev DNS is active)
-  #   30292      → 30292 (cp-1; only when gitops.mode = push)
-  #   40000+i    → 50000 (one entry per cp, target overridden per-port)
-  #   40100+i    → 50000 (one entry per worker, target overridden per-port)
-  #
-  # 30053 / 30292 are gated on the same signals that gate the matching
-  # envoy/nodeport/dns and envoy/nodeport/flux-webhook patch components in
-  # option-gateway, so the bench-side forward and the Service NodePort stay
-  # in sync — no orphan forwards when DNS or push-mode gitops are off.
-  #
-  # talos_api_forwards / talos_api_targets are derived from
-  # hyperv_{controlplanes,workers}.for_cluster — endpoint already contains
-  # the right port (split off the colon, the value is the external port).
+  # Forward map: bench listen port → in-VM port, with per-port target_ip
+  # overrides so each Talos API forward lands at its node. Gateway / k8s-API
+  # forwards stay single-target (cp-1); apiserver replication handles the rest.
+  # tcp_forwards: 6443→6443; 30053→30053 (only when private/dev DNS active);
+  # 30292→30292 (only when gitops.mode=push); 40000+i / 40100+i → 50000 per node.
+  # 30053 / 30292 gate on the same signals as the matching option-gateway
+  # nodeport patches, keeping forward and Service NodePort in sync.
   - name: nat_effective
     when: gateway.service_type == 'NodePort'
     value:
@@ -238,13 +151,9 @@ config:
           [split(get(#, "endpoint"), ":")[1], get(#, "node")]
         ))}
 
-  # Flat compute instance list — one entry per VM, count=1 each. Required
-  # because cidata_iso_path is per-instance (one ISO per VM with that VM's
-  # static IP / hostname baked in by cluster-config), so the module's
-  # built-in count expansion (which shares cidata_iso_path across the pool)
-  # can't be used. The per-VM lists from hyperv_controlplanes /
-  # hyperv_workers carry the hostname + NAT IP each VM needs; cpu/memory/
-  # root_disk_size still come from the per-pool block in cluster.*.
+  # Flat compute instance list, one entry per VM (count=1). Needed because
+  # cidata_iso_path is per-VM, so the module's count expansion (shared ISO)
+  # can't be used. cpu/memory/root_disk_size still come from cluster.* pools.
   - name: hyperv_compute_instances
     when: gateway.service_type == 'NodePort'
     value:
@@ -284,21 +193,15 @@ config:
           ]))
         )}
 
-  # Storage falls through to config-talos.yaml's openebs default (hostPath
-  # over the VM's root VHDX) — no second disk required for the common case.
-  # Operators with capacity needs can opt into longhorn via cluster.storage.driver
-  # and supply cluster.controlplanes.disks. The controlplane sits at CIDR
-  # offset 10 so k8s_service_host is stable independent of DHCP.
+  # Storage falls through to config-talos.yaml's openebs default (hostPath).
+  # Controlplane sits at CIDR offset 10 so k8s_service_host is DHCP-independent.
   - name: talos_common
     value:
       k8s_service_host: "${cidrhost(network.cidr_block, 10)}"
 
-  # NodePort-mode certSANs: workstations reach the Talos API and Kubernetes
-  # API at the bench's external IP (e.g. 192.168.3.77), but Talos auto-
-  # derives apid SANs only from machine.network.interfaces (NAT-internal
-  # 192.168.200.10) and apiserver SANs from cluster.controlPlane.endpoint.
-  # Layer the bench IP into both certSANs lists so talosctl + kubectl
-  # don't trip TLS verification when hitting the port-forwarded address.
+  # NodePort certSANs: workstations reach both APIs at the bench external IP,
+  # but Talos auto-derives SANs only from NAT-internal addresses. Add the bench
+  # IP to both certSANs lists so talosctl + kubectl pass TLS verification.
   - name: talos_common
     when: gateway.service_type == 'NodePort'
     value:
@@ -311,21 +214,10 @@ config:
             certSANs:
               - "${hyperv_effective.bench_ip}"
 
-  # ---------------------------------------------------------------------------
-  # dns.private_domain default — gateway cert needs a non-empty SAN
-  # ---------------------------------------------------------------------------
-  #
-  # Hyper-V deployments are LAN-only with no real DNS by default. The gateway
-  # cert (kustomize/gateway/resources/certificate.yaml) substitutes
-  # external_domain into spec.dnsNames; if empty cert-manager rejects the
-  # Certificate as invalid. Default private_domain to '<id>.local' so the
-  # cert is valid out of the box. Operators can override via dns.domain or
-  # dns.private_domain. Empty-string check (not just `??`) because
-  # platform-base may have already resolved private_domain to '' for
-  # non-dev contexts.
-  # Ordered fallback, written only when private_domain is unset so we never
-  # self-overwrite an operator value (the guards are mutually exclusive):
-  # dns.domain when set, else '<id>.local'.
+  # dns.private_domain default — the gateway cert needs a non-empty SAN or
+  # cert-manager rejects it. Ordered fallback written only when unset (guards
+  # mutually exclusive): dns.domain when set, else '<id>.local'. Empty-string
+  # check because platform-base may have already resolved it to ''.
   - name: dns
     when: (dns.private_domain ?? '') == '' && (dns.domain ?? '') != ''
     value:
@@ -335,13 +227,8 @@ config:
     value:
       private_domain: "${(id ?? 'windsor') + '.local'}"
 
-  # ---------------------------------------------------------------------------
-  # cluster_endpoint_fallback
-  # ---------------------------------------------------------------------------
-  #
-  # Compute reports controlplane endpoints once Hyper-V integration services
-  # surface a guest IP; until then, fall back to an explicit cluster.endpoint.
-  #
+  # Derive the endpoint from compute's controlplane output once Hyper-V surfaces
+  # a guest IP; empty until then (callers fall back to explicit cluster.endpoint).
   - name: cluster_endpoint_fallback
     value:
       endpoint: >-
@@ -370,30 +257,14 @@ config:
 # =============================================================================
 # Terraform — compute → cluster → gitops
 # =============================================================================
-#
-# Hyper-V doesn't support workstation overlays, so this facet always owns the
-# full chain.
-#
+# No workstation overlays on Hyper-V, so this facet owns the full chain.
 terraform:
 
-  # ---------------------------------------------------------------------------
-  # cluster-config — cluster identity + per-node signed machineconfig + CIDATA
-  # ---------------------------------------------------------------------------
-  #
-  # Owns three responsibilities, all of which must complete before compute
-  # creates VMs (so each VM can mount its CIDATA seed at boot):
-  #
-  #   1. Generate the Talos cluster identity (CA, etcd CA, k8s CA, bootstrap
-  #      token) via the shared cluster/talos/modules/secrets submodule.
-  #   2. Sign per-node machineconfigs against that identity, including a
-  #      machine.network.interfaces patch that puts each node on its static IP.
-  #   3. Wrap each per-node config + a cloud-init network-config + meta-data
-  #      into a CIDATA seed ISO via hyperv_iso_volume.
-  #
-  # The cluster identity is exported back to the cluster step so it shares
-  # the same CA — cluster/talos then skips talos_machine_configuration_apply
-  # (already delivered via CIDATA) and runs straight to bootstrap + health.
-  #
+  # cluster-config — generates the Talos cluster identity, signs per-node
+  # machineconfigs (with a static-IP interface patch), and wraps each into a
+  # CIDATA seed ISO. Must complete before compute so VMs mount their seed at
+  # boot. Identity is exported to the cluster step, which then skips config
+  # apply (delivered via CIDATA) and runs straight to bootstrap + health.
   - name: cluster-config
     path: cluster/talos/config
     inputs:
@@ -406,28 +277,16 @@ terraform:
         cidr_block: ${network.cidr_block}
         gateway: ${network.gateway}
         nameservers: ${network.nameservers}
-      # In NodePort mode every node's static IP must be a NAT-internal
-      # address (per the per-VM offset scheme in hyperv_controlplanes /
-      # hyperv_workers), not whatever bench-side address operators wrote
-      # in values.yaml. The facet-built lists carry the right hostname +
-      # node + address per VM so cluster/talos/config's CIDATA patches
-      # land NAT-private IPs on each NIC.
+      # In NodePort mode, feed the facet-built lists so CIDATA patches land
+      # NAT-internal static IPs (per the per-VM offset scheme) on each NIC.
       controlplanes: "${gateway.service_type == 'NodePort' ? hyperv_controlplanes.for_config : values(cluster.controlplanes.nodes ?? {})}"
       workers: "${gateway.service_type == 'NodePort' ? hyperv_workers.for_config : ((cluster.workers.count ?? 0) > 0 ? values(cluster.workers.nodes ?? {}) : [])}"
 
-  # ---------------------------------------------------------------------------
-  # compute — Talos VMs on a Hyper-V virtual switch
-  # ---------------------------------------------------------------------------
-  #
-  # Each VM gets a fresh dynamic VHDX (image: "" → no parent), the Talos
-  # metal-amd64.iso (with talos.platform=nocloud cmdline override baked in
-  # via the schematic) on DVD slot 1, and the per-node CIDATA seed on DVD
-  # slot 2. Boot order is HDD-first — UEFI falls through to the OS ISO on a
-  # fresh disk for the install; once Talos is installed it boots from disk
-  # and the CIDATA volume is read by the running OS for static-network +
-  # machineconfig. CIDATA stays attached for the VM's lifetime; harmless
-  # because Talos's NoCloud reader is idempotent.
-  #
+  # compute — Talos VMs on a Hyper-V virtual switch. Each VM gets a fresh
+  # dynamic VHDX, the metal-amd64.iso on DVD slot 1, and its CIDATA seed on
+  # slot 2. Boot is HDD-first: UEFI falls through to the ISO on a fresh disk,
+  # then boots from disk once installed. CIDATA stays attached (NoCloud reader
+  # is idempotent).
   - name: compute
     path: compute/hyperv
     dependsOn:
@@ -437,27 +296,21 @@ terraform:
       create_network: true
       switch_type: ${hyperv_effective.switch_type}
       net_adapter_names: ${hyperv_effective.net_adapter}
-      # NAT-only inputs — null on External/Internal/Private (the compute
-      # module ignores them when switch_type != "NAT").
+      # NAT-only inputs — null otherwise (compute ignores them when not NAT).
       nat_name: "${hyperv_effective.switch_type == 'NAT' ? hyperv_effective.nat_name : null}"
       nat_internal_address_prefix: "${hyperv_effective.switch_type == 'NAT' ? hyperv_effective.nat_internal_prefix : null}"
       nat_host_address: "${hyperv_effective.switch_type == 'NAT' ? hyperv_effective.nat_host_address : null}"
-      # Port forwards land alongside the switch + VMs in the compute step.
-      # platform facet builds the always-on baseline (k8s/Talos APIs, gateway
-      # NodePorts) in nat_effective.tcp_forwards; gateway.publish_ports
-      # layers operator-pinned ports (typical: 80 -> 30080, 443 -> 30443).
+      # nat_effective.tcp_forwards is the always-on baseline (k8s/Talos APIs,
+      # gateway NodePorts); gateway.publish_ports layers operator-pinned ports.
       port_forwards: "${gateway.service_type == 'NodePort' ? nat_effective.tcp_forwards : {}}"
       extra_port_forwards: "${gateway.service_type == 'NodePort' ? (gateway.publish_ports ?? {}) : {}}"
       udp_port_forwards: "${gateway.service_type == 'NodePort' ? nat_effective.udp_forwards : {}}"
-      # Default target = cp-1 (the gateway / k8s-API forwards land here;
-      # kube-proxy and apiserver replication carry the rest). Per-port
-      # overrides below redirect each Talos API forward (40000+i) to the
-      # node it belongs to.
+      # Default target = cp-1; per-port overrides redirect each Talos API
+      # forward (40000+i) to its own node.
       port_forward_target_ip: "${gateway.service_type == 'NodePort' ? cidrhost(hyperv_effective.nat_internal_prefix, 10) : null}"
       port_forward_target_overrides: "${gateway.service_type == 'NodePort' ? nat_effective.talos_api_targets : {}}"
-      # Default 0.0.0.0 means "any host NIC". Pinning to a specific bench IP
-      # would require Add-NetNatExternalAddress to be called first; on a
-      # single-LAN-NIC bench the wildcard is functionally identical anyway.
+      # 0.0.0.0 = any host NIC. Pinning a bench IP would need
+      # Add-NetNatExternalAddress first; identical on a single-LAN-NIC bench.
       port_forward_external_ip: "0.0.0.0"
       port_forward_name_prefix: "windsor-${id ?? 'hyperv'}"
       network_cidr: ${network.cidr_block}
@@ -467,12 +320,8 @@ terraform:
           destination_path: "${hyperv_effective.image_destination}"
           url: ${hyperv_effective.image_url}
           keep_on_destroy: true
-      # In NodePort mode the facet builds a flat per-VM instance list
-      # (one entry per cp/worker, count=1 each) so each VM gets its own
-      # cidata_iso_path with the node's static IP / hostname baked in by
-      # cluster-config. Outside NodePort, fall back to the count-based
-      # two-entry shape (single-VM today; multi-VM in External / Internal
-      # modes hasn't been wired and would need the same per-VM treatment).
+      # NodePort uses the flat per-VM list (own cidata_iso_path per VM).
+      # Otherwise fall back to the count-based two-entry form (single-VM today).
       instances: >-
         ${gateway.service_type == 'NodePort' ? hyperv_compute_instances.list : [
           fromPairs([
@@ -516,24 +365,15 @@ terraform:
       - cluster-config
     parallelism: 1
     inputs:
-      # cluster.endpoint is the schema-declared endpoint (e.g. https://192.168.0.10:6443
-      # in the hyperv-test context); cluster_endpoint_fallback derives from compute
-      # output but Talos doesn't report IPs through Hyper-V KVP, so fallback returns
-      # empty. Prefer the explicit schema value first.
+      # Prefer the schema-declared cluster.endpoint; the compute-derived fallback
+      # returns empty because Talos doesn't report IPs through Hyper-V KVP.
       cluster_endpoint: "${(cluster.endpoint ?? '') != '' ? cluster.endpoint : cluster_endpoint_fallback.endpoint}"
       cluster_name: talos
       talos_version: ${talos.talos_version}
-      # `??` only fires on null, not on empty list — and compute output is an
-      # empty list (Talos doesn't report through Hyper-V KVP). Length-check the
-      # output and fall through to the schema-declared cluster.controlplanes.nodes
-      # when empty, matching the platform-incus / platform-metal pattern.
-      # In NodePort + NAT mode, compute's output endpoints carry the VM's
-      # NAT-internal IPs, which are unreachable from the terraform runner —
-      # the workstation only has a route to the bench. Use the facet-built
-      # for_cluster lists so each node has its own bench-side host:port pair
-      # (40000+i) routing to the right VM via per-port NAT forwards. node is
-      # the NAT-internal IP, used as Talos's machine identity but not for
-      # network reach.
+      # Length-check compute output (empty list, not null, since Talos doesn't
+      # report through Hyper-V KVP) and fall through to schema-declared nodes.
+      # In NodePort+NAT, compute's NAT-internal endpoints are unreachable from
+      # the runner, so use for_cluster (bench-side host:port routing to each VM).
       controlplanes: "${gateway.service_type == 'NodePort' ? hyperv_controlplanes.for_cluster : (len(terraform_output(\"compute\", \"controlplanes\") ?? []) > 0 ? terraform_output(\"compute\", \"controlplanes\") : values(cluster.controlplanes.nodes))}"
       workers: "${gateway.service_type == 'NodePort' ? hyperv_workers.for_cluster : (len(terraform_output(\"compute\", \"workers\") ?? []) > 0 ? terraform_output(\"compute\", \"workers\") : ((cluster.workers.count ?? 0) > 0 ? values(cluster.workers.nodes) : []))}"
       controlplane_disks: ${talos_common.controlplane_disks}
@@ -541,11 +381,9 @@ terraform:
       common_config_patches: ${talos_common.common_config_patches}
       controlplane_volumes: ${talos_common.controlplane_volumes ?? []}
       worker_volumes: ${talos_common.worker_volumes ?? []}
-      # Shared cluster identity from cluster-config — cluster/talos's
-      # talos_machine_secrets call is count-gated off when these are non-null,
-      # and talos_machine_configuration_apply is also skipped (the
-      # machineconfig was already delivered via CIDATA). Bootstrap, kubeconfig
-      # download, and health-check still run.
+      # Shared identity from cluster-config: when non-null, cluster/talos skips
+      # machine_secrets and config apply (delivered via CIDATA). Bootstrap,
+      # kubeconfig download, and health-check still run.
       machine_secrets: ${terraform_output("cluster-config", "machine_secrets")}
       client_configuration: ${terraform_output("cluster-config", "client_configuration")}
 
@@ -560,17 +398,9 @@ terraform:
 # =============================================================================
 # Flux systems — pki resources overlay
 # =============================================================================
-#
-# selfsigned `private` ClusterIssuer for the gateway cert
-# --------------------------------------------------------
-#
-# gateway_cert_issuer (option-gateway) resolves to 'private' on hyperv (no
-# public_domain, not aws/azure), so the gateway's external-web-tls
-# Certificate references a ClusterIssuer named exactly `private`. The
-# private-issuer/selfsigned component creates that. Skipped when
-# addon-private-ca is enabled — that addon emits its own pki-resources
-# with a CA-backed `private` issuer; running both would conflict.
-#
+# The gateway cert references a ClusterIssuer named `private`, which the
+# private-issuer/selfsigned component creates. Skipped when addon-private-ca
+# is enabled — it emits its own CA-backed `private` issuer (both would conflict).
 flux:
 
   - name: pki
@@ -581,25 +411,12 @@ flux:
         timeout: 5m
         interval: 5m
 
-  # ---------------------------------------------------------------------------
-  # MetalLB / kube-vip
-  # ---------------------------------------------------------------------------
-  #
-  # Hyper-V External switches expose a real L2 bridge to the bench's LAN, so
-  # MetalLB ARP / Cilium L2 announcements work when an LB is requested. Internal
-  # switches keep traffic on the host-only segment — LB still works for
-  # host-to-VM traffic but won't reach the wider LAN. lb_effective.enabled is
-  # false when Cilium is the CNI (Cilium's built-in LB is preferred).
-  #
-  # install ships the driver's controller HelmRelease. kube-vip/arp builds
-  # here too — it's a patch on the kube-vip HelmRelease, not a separate CR —
-  # and loadbalancer_ip_range is set here because the kube-vip cloud-provider
-  # HelmRelease reads it directly.
-  #
-  # resources ships metallb/arp or metallb/layer2, the IPAddressPool /
-  # L2Advertisement CRs metallb's controller consumes. No component for
-  # kube-vip, which has nothing left to configure once install has run.
-  #
+  # MetalLB / kube-vip. External switches L2-bridge to the LAN so MetalLB ARP /
+  # Cilium L2 announcements reach it; Internal switches stay host-only.
+  # lb_effective.enabled is false under Cilium (its built-in LB is preferred).
+  # install ships the driver's controller; kube-vip/arp is a patch on that
+  # HelmRelease. resources ships metallb's IPAddressPool / L2Advertisement CRs
+  # (kube-vip needs no resources once install has run).
   - name: lb
     when: lb_effective.enabled
     install:

--- a/contexts/_template/facets/platform-incus.yaml
+++ b/contexts/_template/facets/platform-incus.yaml
@@ -4,25 +4,22 @@ metadata:
   name: incus
   description: Incus compute platform infrastructure
 
-# Incus is only supported with Talos. Without workstation, this facet owns
-# the full terraform chain directly; with workstation, option-workstation
-# owns compute/cluster and this facet contributes config only.
+# Incus requires Talos. Without workstation, this facet owns the full terraform
+# chain; with workstation, option-workstation owns compute/cluster and this
+# facet contributes config only.
 when: "platform == 'incus' && cluster.driver == 'talos'"
 
-# Terraform remote state lives in the local Talos cluster (Kubernetes
-# backend, secrets-as-state). The `cluster` component itself uses local
-# state since it's the one that creates the cluster.
+# Remote state lives in the local Talos cluster (Kubernetes backend); the
+# `cluster` component uses local state since it creates the cluster.
 backend: cluster
 
 # =============================================================================
 # Config — Incus-specific Talos values
 # =============================================================================
-#
 config:
 
-  # Incus VMs have dedicated block devices, making Longhorn the natural choice
-  # (distributed block storage over the VM disks). The controlplane always
-  # sits at CIDR offset 10 so k8s_service_host is stable.
+  # Incus VMs have dedicated block devices, so Longhorn is the default storage.
+  # Controlplane sits at CIDR offset 10 for a stable k8s_service_host.
   - name: talos_common
     value:
       storage_driver: "${cluster.storage.driver ?? 'longhorn'}"
@@ -31,13 +28,8 @@ config:
           size: 30
       k8s_service_host: "${cidrhost(network.cidr_block, 10)}"
 
-  # ---------------------------------------------------------------------------
-  # cluster_endpoint_fallback
-  # ---------------------------------------------------------------------------
-  #
-  # Only derivable from compute output — if there's no compute yet, return
-  # empty string and let the caller fall back to an explicit cluster.endpoint.
-  #
+  # Derivable only from compute output; empty string otherwise, so the caller
+  # falls back to an explicit cluster.endpoint.
   - name: cluster_endpoint_fallback
     value:
       endpoint: >-
@@ -48,9 +40,8 @@ config:
             : ""
         }
 
-  # Node targets for post-cluster steps (e.g. cluster/talos/extensions). Mirrors
-  # the same compute-output-or-fallback resolution that the `cluster` step uses,
-  # projected to the {node, endpoint} shape that the extensions module accepts.
+  # Node targets for post-cluster steps (e.g. extensions), using the same
+  # compute-output-or-fallback resolution as the `cluster` step.
   - name: talos_node_targets
     value:
       controlplanes: >-
@@ -69,22 +60,12 @@ config:
 # =============================================================================
 # Terraform — standalone incus (no workstation)
 # =============================================================================
-#
-# When workstation.runtime is unset, this facet owns the full chain:
-#   compute → cluster → gitops
-#
-# With workstation set, option-workstation owns this chain (and adds a
-# workstation → compute link), so everything here is gated off.
-#
+# With workstation.runtime unset, this facet owns compute → cluster → gitops.
+# With workstation set, option-workstation owns the chain and these are gated off.
 terraform:
 
-  # ---------------------------------------------------------------------------
-  # compute — Talos VMs on a fresh Incus network
-  # ---------------------------------------------------------------------------
-  #
-  # Creates its own network (create_network: true) because there's no
-  # workstation stack to inherit one from. Uses the default incus storage pool.
-  #
+  # Talos VMs on a fresh Incus network (create_network: true — no workstation
+  # stack to inherit one from). Uses the default incus storage pool.
   - name: compute
     when: "workstation.runtime == null || workstation.runtime == ''"
     path: compute/incus
@@ -131,13 +112,7 @@ terraform:
             environment.TALOSSKU: "${string(cluster.workers.cpu) + 'CPU-' + string(cluster.workers.memory * 1024) + 'RAM'}"
             raw.qemu: -boot order=c,menu=off
 
-  # ---------------------------------------------------------------------------
-  # cluster — Talos bootstrap/apply
-  # ---------------------------------------------------------------------------
-  #
-  # Uses compute output when available, falling back to user-supplied nodes
-  # for scenarios where we describe an existing cluster.
-  #
+  # Talos bootstrap/apply. Uses compute output when available, else user-supplied nodes.
   - name: cluster
     when: "workstation.runtime == null || workstation.runtime == ''"
     path: cluster/talos
@@ -156,13 +131,7 @@ terraform:
       controlplane_volumes: ${talos_common.controlplane_volumes ?? []}
       worker_volumes: ${talos_common.worker_volumes ?? []}
 
-  # ---------------------------------------------------------------------------
-  # gitops — Flux
-  # ---------------------------------------------------------------------------
-  #
-  # destroy: false — we don't uninstall Flux on `windsor destroy`; the
-  # cluster teardown takes it with it.
-  #
+  # Flux. destroy: false — cluster teardown removes it; we don't uninstall on `windsor destroy`.
   - name: gitops
     when: "workstation.runtime == null || workstation.runtime == ''"
     path: gitops/flux
@@ -175,19 +144,9 @@ terraform:
 # =============================================================================
 # Flux systems — MetalLB / kube-vip
 # =============================================================================
-#
-# Incus always has a real bridge network, so MetalLB or kube-vip works
-# unconditionally when an LB is requested.
-#
-# install ships the driver's controller HelmRelease. kube-vip/arp builds
-# here too — it's a patch on the kube-vip HelmRelease, not a separate CR —
-# and loadbalancer_ip_range is set here because the kube-vip cloud-provider
-# HelmRelease reads it directly.
-#
-# resources ships metallb/arp or metallb/layer2, the IPAddressPool /
-# L2Advertisement CRs metallb's controller consumes. No component for
-# kube-vip, which has nothing left to configure once install has run.
-#
+# Incus always has a real bridge network, so MetalLB or kube-vip works whenever
+# an LB is requested. install ships the driver's controller HelmRelease (plus
+# kube-vip's arp patch); resources ships metallb's IPAddressPool/L2Advertisement CRs.
 flux:
 
   - name: lb

--- a/contexts/_template/facets/platform-metal.yaml
+++ b/contexts/_template/facets/platform-metal.yaml
@@ -4,20 +4,17 @@ metadata:
   name: metal
   description: "Metal provider basic infrastructure"
 
-# Bare metal: the user supplies fully-provisioned nodes with real IPs, and
-# we just run Talos apply against them. No compute terraform, no network
-# creation — everything upstream is the operator's responsibility.
+# Bare metal: operator supplies fully-provisioned nodes; we run Talos apply
+# against them. No compute terraform, no network creation.
 when: platform == 'metal'
 
-# Terraform remote state lives in the local Talos cluster (Kubernetes
-# backend, secrets-as-state). The `cluster` component itself uses local
-# state since it's the one that creates the cluster.
+# Remote state lives in the local Talos cluster (Kubernetes backend); the
+# `cluster` component uses local state since it creates the cluster.
 backend: cluster
 
 # =============================================================================
 # Requires
 # =============================================================================
-#
 requires:
   - paths:
       - cluster.controlplanes.nodes
@@ -26,20 +23,15 @@ requires:
 # =============================================================================
 # Config
 # =============================================================================
-#
 config:
 
-  # On metal we always have at least one controlplane node with a concrete
-  # endpoint, so the fallback derivation is always valid (unlike incus/docker
-  # which may have no compute output yet).
+  # Always at least one controlplane with a concrete endpoint, so the fallback
+  # is always derivable (unlike incus/docker).
   - name: cluster_endpoint_fallback
     value:
       endpoint: "${cluster.endpoint ?? ('https://' + split(values(cluster.controlplanes.nodes)[0].endpoint, ':')[0] + ':6443')}"
 
-  # Node targets for post-cluster steps (e.g. cluster/talos/extensions). Same
-  # node list the `cluster` step receives, projected to the {node, endpoint}
-  # shape that the extensions module's variable schema accepts. No compute
-  # layer on metal — read straight from the user-supplied node map.
+  # Node targets for post-cluster steps (e.g. extensions), from the user-supplied node map.
   - name: talos_node_targets
     value:
       controlplanes: >-
@@ -52,10 +44,8 @@ config:
 # =============================================================================
 # Terraform — cluster/talos + gitops
 # =============================================================================
-#
-# No compute step: metal nodes exist externally. We go straight from the
-# user-supplied node list to Talos bootstrap/apply.
-#
+# No compute step: metal nodes exist externally. Straight from the user-supplied
+# node list to Talos bootstrap/apply.
 terraform:
 
   - name: cluster
@@ -73,8 +63,7 @@ terraform:
       controlplane_volumes: ${talos_common.controlplane_volumes ?? []}
       worker_volumes: ${talos_common.worker_volumes ?? []}
 
-  # destroy: false — Flux is tied to cluster lifetime; cluster teardown
-  # takes it with it.
+  # destroy: false — Flux is tied to cluster lifetime; teardown takes it along.
   - name: gitops
     path: gitops/flux
     dependsOn:
@@ -86,20 +75,10 @@ terraform:
 # =============================================================================
 # Flux systems — MetalLB / kube-vip
 # =============================================================================
-#
-# Metal nodes have real IPs and routes, so MetalLB or kube-vip works whenever
-# an LB is requested. Cilium installations skip this (Cilium's built-in LB is
-# preferred) via lb_effective.enabled being false when Cilium is the CNI.
-#
-# install ships the driver's controller HelmRelease. kube-vip/arp builds
-# here too — it's a patch on the kube-vip HelmRelease, not a separate CR —
-# and loadbalancer_ip_range is set here because the kube-vip cloud-provider
-# HelmRelease reads it directly.
-#
-# resources ships metallb/arp or metallb/layer2, the IPAddressPool /
-# L2Advertisement CRs metallb's controller consumes. No component for
-# kube-vip, which has nothing left to configure once install has run.
-#
+# Metal nodes have real IPs, so MetalLB or kube-vip works whenever an LB is
+# requested; skipped when Cilium is the CNI (lb_effective.enabled false). install
+# ships the driver's controller HelmRelease (plus kube-vip's arp patch); resources
+# ships metallb's IPAddressPool/L2Advertisement CRs.
 flux:
 
   - name: lb

--- a/contexts/_template/tests/addon-private-ca.test.yaml
+++ b/contexts/_template/tests/addon-private-ca.test.yaml
@@ -41,9 +41,7 @@ cases:
             components:
               - trust-manager
           resources:
-            - dependsOn:
-                - policy-resources
-              timeout: 5m
+            - timeout: 5m
               interval: 5m
               components:
                 - private-issuer/ca
@@ -66,9 +64,7 @@ cases:
             components:
               - trust-manager
           resources:
-            - dependsOn:
-                - policy-resources
-              timeout: 5m
+            - timeout: 5m
               interval: 5m
               components:
                 - private-issuer/ca

--- a/contexts/_template/tests/platform-aws.test.yaml
+++ b/contexts/_template/tests/platform-aws.test.yaml
@@ -219,9 +219,7 @@ cases:
       flux:
         - name: pki
           resources:
-            - dependsOn:
-                - policy-resources
-              components:
+            - components:
                 - public-issuer/acme/route53
               substitutions:
                 acme_server: https://acme-v02.api.letsencrypt.org/directory

--- a/contexts/_template/tests/platform-azure.test.yaml
+++ b/contexts/_template/tests/platform-azure.test.yaml
@@ -230,9 +230,7 @@ cases:
               cert_manager_client_id: 11111111-aaaa-aaaa-aaaa-111111111111
               cert_manager_tenant_id: 33333333-cccc-cccc-cccc-333333333333
           resources:
-            - dependsOn:
-                - policy-resources
-              components:
+            - components:
                 - public-issuer/acme/azuredns
               substitutions:
                 acme_server: https://acme-v02.api.letsencrypt.org/directory


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> Removes explicit `policy-resources` ordering guards from five locations and condenses verbose comments across 16 facet files; the dependency removals carry behavioral risk when `policies.enabled: false`.
>
> **Overview**
>
> The bulk of the diff is editorial: multi-paragraph comment blocks in every facet are tightened into single-line inline comments with no change to YAML keys, expressions, or structure. The five functional edits remove explicit `dependsOn: - policy-resources` entries from `addon-private-ca`, `addon-private-dns`, `option-cni` (both platform variants), `platform-aws`, and `platform-azure`.
>
> The removed dependencies were documented guards ensuring Kyverno CRDs exist before components that ship `ClusterPolicy` resources are applied (private-issuer/ca, external-dns/localhost, cilium/gateway LBIPAM). The PR relies on Kyverno's `globalDependency` barrier instead, but that barrier is itself gated on `(policies.enabled ?? true) == true`, leaving the `policies.enabled: false` path unguarded and potentially surfacing hard-to-diagnose Flux reconciliation failures instead of a clean `DependencyNotReady`.
>
> Reviewed by Claude for commit `90671b3`.

<!-- /claude-code-review:summary -->
