### PR TITLE
fix(observability): add zap-console fluent-bit parser for envoy-gateway

### DIFF
--- a/kustomize/telemetry/resources/fluentbit/parser/kustomization.yaml
+++ b/kustomize/telemetry/resources/fluentbit/parser/kustomization.yaml
@@ -16,6 +16,7 @@ kind: Component
 components:
   - coredns
   - klog
+  - zap-console
   - json-structured
   - envoy-access
   - zerolog

--- a/kustomize/telemetry/resources/fluentbit/parser/zap-console/fluentbit-clusterfilter.yaml
+++ b/kustomize/telemetry/resources/fluentbit/parser/zap-console/fluentbit-clusterfilter.yaml
@@ -1,0 +1,17 @@
+apiVersion: fluentbit.fluent.io/v1alpha2
+kind: ClusterFilter
+metadata:
+  labels:
+    fluentbit.fluent.io/component: logging
+    fluentbit.fluent.io/enabled: "true"
+  name: zap-console
+spec:
+  ordinal: 25
+  match: kube.*
+  filters:
+  - lua:
+      call: parse_zap_console
+      script:
+        key: zap-console.lua
+        name: fluent-bit-zap-console-config
+      timeAsTable: true

--- a/kustomize/telemetry/resources/fluentbit/parser/zap-console/kustomization.yaml
+++ b/kustomize/telemetry/resources/fluentbit/parser/zap-console/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# Zap "console" encoder log parser
+# Matches: controller-runtime-based controllers using zap's console encoder
+# (e.g. envoy-gateway). Format: <epoch>\t<level>\t[<logger>\t]<caller>\t<msg>\t[<json>]
+#
+# Extracts:
+#   - severity_text/number: from the level field
+#   - body: from the message field
+
+resources:
+  - fluentbit-clusterfilter.yaml
+
+configMapGenerator:
+  - name: fluent-bit-zap-console-config
+    namespace: system-telemetry
+    files:
+      - zap-console.lua
+    options:
+      disableNameSuffixHash: true

--- a/kustomize/telemetry/resources/fluentbit/parser/zap-console/zap-console.lua
+++ b/kustomize/telemetry/resources/fluentbit/parser/zap-console/zap-console.lua
@@ -1,0 +1,68 @@
+-- Zap "console" encoder parser (controller-runtime / zap-based Go controllers)
+-- Format: <epoch-seconds float>\t<level>\t[<logger>\t]<caller>\t<message>\t[<json context>]
+-- The logger-name field only appears when the zap logger was given a name
+-- (.Named(...)); root loggers omit it, so the field count varies.
+-- Examples:
+--   1.784389225979603e+09	info	provider.controller-runtime.cache	rest/warnings.go:107	Warning: deprecated	{"runner": "provider"}
+--   1.7843423937898643e+09	info	cmd/certgen.go:133	created secret	{"namespace": "system-gateway", "name": "envoy-oidc-hmac"}
+--
+-- Common in: envoy-gateway and other controller-runtime-based controllers
+-- configured with zap's console encoder (as opposed to the JSON encoder,
+-- handled by json-structured).
+
+-- OTEL severity number mapping
+local SEVERITY_MAP = {
+  DEBUG  = { text = "DEBUG", number = 5 },
+  INFO   = { text = "INFO",  number = 9 },
+  WARN   = { text = "WARN",  number = 13 },
+  ERROR  = { text = "ERROR", number = 17 },
+  DPANIC = { text = "FATAL", number = 21 },
+  PANIC  = { text = "FATAL", number = 21 },
+  FATAL  = { text = "FATAL", number = 21 }
+}
+
+function parse_zap_console(tag, timestamp, record)
+  local log = record["log"]
+  if not log then return 0, timestamp, record end
+
+  -- Skip if already parsed (severity already set by another parser)
+  if record["severity_text"] and record["severity_text"] ~= "" then
+    return 0, timestamp, record
+  end
+
+  local parts = {}
+  for part in log:gmatch("[^\t]+") do
+    table.insert(parts, part)
+  end
+
+  -- Minimum shape: epoch, level, caller, message
+  if #parts < 4 then
+    return 0, timestamp, record
+  end
+
+  -- First field must look like a Unix epoch (integer, decimal, or scientific notation)
+  if not parts[1]:match("^%d+%.?%d*[eE]?[%+%-]?%d*$") then
+    return 0, timestamp, record
+  end
+
+  local sev = SEVERITY_MAP[parts[2]:upper()]
+  if not sev then
+    return 0, timestamp, record
+  end
+
+  record["severity_text"] = sev.text
+  record["severity_number"] = sev.number
+
+  -- Message is the last field, unless zap appended a trailing JSON context
+  -- blob, in which case the message is the field before it.
+  local last = parts[#parts]
+  if last:match("^%s*{") and #parts > 4 then
+    record["body"] = parts[#parts - 1]
+  else
+    record["body"] = last
+  end
+
+  -- No body.* / logger / caller extraction - schema doesn't support dynamic fields
+
+  return 1, timestamp, record
+end

--- a/kustomize/telemetry/resources/fluentbit/parser/zap-console/zap-console.lua
+++ b/kustomize/telemetry/resources/fluentbit/parser/zap-console/zap-console.lua
@@ -54,9 +54,12 @@ function parse_zap_console(tag, timestamp, record)
   record["severity_number"] = sev.number
 
   -- Message is the last field, unless zap appended a trailing JSON context
-  -- blob, in which case the message is the field before it.
+  -- blob, in which case the message is the field before it. Require the
+  -- last field to look like a *complete* JSON object (starts with { and
+  -- ends with }) rather than merely starting with {, so a named-logger
+  -- line whose message itself begins with a brace isn't misread as caller.
   local last = parts[#parts]
-  if last:match("^%s*{") and #parts > 4 then
+  if #parts > 4 and last:match("^%s*{.*}%s*$") then
     record["body"] = parts[#parts - 1]
   else
     record["body"] = last


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> Additive observability change that introduces a new Fluent Bit parser component; no existing parsers are modified and the worst-case failure is missed or mis-parsed log lines.
>
> **Overview**
>
> This PR adds a `zap-console` Fluent Bit parser for Go controllers that use zap's console encoder (e.g. envoy-gateway). It ships three new files: a `ClusterFilter` manifest that attaches a Lua script via ConfigMap, a `kustomization.yaml` component, and the Lua parser itself. The component is wired into the existing parser `kustomization.yaml` component list between `klog` and `json-structured`.
>
> The Lua script guards against double-parsing by checking `severity_text` first, then validates the first tab-delimited field as a Unix epoch before attempting level and body extraction. One edge case in the message-extraction logic (see inline finding) can produce an incorrect `body` when a named logger is present and the message text begins with `{`.
>
> Reviewed by Claude for commit `1d0f1263`.

<!-- /claude-code-review:summary -->
