### PR TITLE
fix(flux): add missing timeout/interval to gitops and demo resources tiers

### DIFF
--- a/contexts/_template/facets/option-demo.yaml
+++ b/contexts/_template/facets/option-demo.yaml
@@ -26,3 +26,5 @@ flux:
           - "${demo.resources.database == true ? 'database' : ''}"
           - "${demo.resources.static == true ? 'static' : ''}"
           - "${demo.resources.bookinfo == true ? 'bookinfo' : ''}"
+        timeout: 10m
+        interval: 5m

--- a/contexts/_template/facets/platform-base.yaml
+++ b/contexts/_template/facets/platform-base.yaml
@@ -348,6 +348,8 @@ flux:
           - "${gateway.enabled == true && gateway.driver == 'cilium' ? 'webhook/gateway/cilium' : ''}"
         substitutions:
           git_repository_name: ${gitops.repository.name ?? "local"}
+        timeout: 5m
+        interval: 5m
 
   # Flux Operator web UI — opt-in (gitops.web_ui) HTTPRoute at flux.<domain>
   # when a gateway is present. Merges into the gitops system above (same
@@ -367,3 +369,5 @@ flux:
           - "${gateway.driver == 'cilium' ? 'ui/cilium' : ''}"
         substitutions:
           external_domain: ${gateway_effective.external_domain}
+        timeout: 5m
+        interval: 5m

--- a/contexts/_template/tests/option-demo.test.yaml
+++ b/contexts/_template/tests/option-demo.test.yaml
@@ -44,7 +44,9 @@ cases:
           dependsOn:
             - database-install
           resources:
-            - components:
+            - timeout: 10m
+              interval: 5m
+              components:
                 - database
 
   # static + bookinfo apps carry no database dependency, and demo is a

--- a/contexts/_template/tests/option-gateway.test.yaml
+++ b/contexts/_template/tests/option-gateway.test.yaml
@@ -373,7 +373,9 @@ cases:
         - name: gitops
           path: gitops
           resources:
-            - components:
+            - timeout: 5m
+              interval: 5m
+              components:
                 - webhook
     exclude:
       kustomize:
@@ -479,7 +481,9 @@ cases:
           dependsOn:
             - gateway-resources
           resources:
-            - components:
+            - timeout: 5m
+              interval: 5m
+              components:
                 - webhook
                 - webhook/gateway
                 - ui


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change adds explicit `timeout` and `interval` fields to three Flux Kustomization tiers in the template facets, making previously-implicit defaults explicit and consistent.
>
> **Overview**
>
> The PR sets `timeout: 5m` and `interval: 5m` on the gitops and web-UI Kustomization tiers in `platform-base.yaml`, and `timeout: 10m` / `interval: 5m` on the demo-resources Kustomization in `option-demo.yaml`. These additions mirror the fix in the parent commit (#2252) that resolved cascading Kustomization flaps caused by missing interval/timeout values. The diff is self-contained to two template facet files and carries no schema changes or behavioral surprises beyond the now-explicit reconciliation cadence.
>
> The demo tier intentionally uses a 10-minute timeout (vs. 5 minutes for gitops/web-UI), which is appropriate for heavier workloads like the database and bookinfo sub-resources.
>
> Reviewed by Claude for commit `4d5ce2fa`.

<!-- /claude-code-review:summary -->
