### PR TITLE
feat(telemetry): add node PrometheusRule alerts and promtool test framework

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,8 @@ env:
   YQ_VERSION: v4.53.3
   # renovate: datasource=github-releases depName=helm package=helm/helm
   HELM_VERSION: v4.2.3
+  # renovate: datasource=github-releases depName=prometheus/prometheus package=prometheus/prometheus
+  PROMETHEUS_VERSION: v3.13.1
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -215,6 +217,27 @@ jobs:
         uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
         with:
           version: 3.x
+
+      # yq renders each PrometheusRule's .spec for promtool; local devs get
+      # both via aqua, CI installs the same pinned versions directly.
+      - name: Install yq
+        run: |
+          cd "$(mktemp -d)" &&
+          curl -fsSLO "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" &&
+          sudo install -m 0755 -o root -g root yq_linux_amd64 /usr/local/bin/yq &&
+          cd - &&
+          rm -rf "$OLDPWD" &&
+          yq --version
+
+      - name: Install promtool
+        run: |
+          cd "$(mktemp -d)" &&
+          curl -fsSLO "https://github.com/prometheus/prometheus/releases/download/${PROMETHEUS_VERSION}/prometheus-${PROMETHEUS_VERSION#v}.linux-amd64.tar.gz" &&
+          tar xzf "prometheus-${PROMETHEUS_VERSION#v}.linux-amd64.tar.gz" &&
+          sudo install -m 0755 -o root -g root "prometheus-${PROMETHEUS_VERSION#v}.linux-amd64/promtool" /usr/local/bin/promtool &&
+          cd - &&
+          rm -rf "$OLDPWD" &&
+          promtool --version
 
       - name: Run Tests
         run: task test

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ contexts/**/.gcp/
 # macOS system files
 **/.DS_Store
 
+# scripts/test-prometheus-rules.sh promtool scratch output
+**/.rendered-rule.yml
+
 # IDE user config
 .cursor/
 .vscode/*.local.*

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -23,11 +23,18 @@ tasks:
       - cmd: source .venv/bin/activate && checkov -d {{.CLI_ARGS | default "terraform/"}} 2>/dev/null
 
   test:
-    desc: Run all tests (Terraform and Blueprint)
+    desc: Run all tests (Terraform, Blueprint, and Prometheus rules)
     silent: true
     cmds:
       - task: test:terraform
       - task: test:blueprint
+      - task: test:prometheus-rules
+
+  test:prometheus-rules:
+    desc: Unit-test PrometheusRule alerting rules via promtool
+    silent: true
+    cmds:
+      - scripts/test-prometheus-rules.sh
 
   test:terraform:
     desc: Run Terraform tests (all or specific module)

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -13,6 +13,7 @@ registries:
 packages:
   # Pinned to the 1.12 line for OpenTofu compatibility; see required_version "~> 1.12".
   - name: hashicorp/terraform@v1.12.2
+  - name: prometheus/prometheus@v3.13.1
   - name: siderolabs/talos@v1.13.6
   - name: siderolabs/omni/omnictl@v1.9.3
   - name: siderolabs/omni/omni@v1.9.3

--- a/contexts/_template/facets/addon-observability.yaml
+++ b/contexts/_template/facets/addon-observability.yaml
@@ -44,6 +44,7 @@ flux:
       - components:
           - prometheus
           - prometheus/flux
+          - "${(telemetry.alerts.enabled ?? true) ? 'prometheus/alerts/node' : ''}"
         timeout: 10m
         interval: 5m
 

--- a/contexts/_template/facets/platform-base.yaml
+++ b/contexts/_template/facets/platform-base.yaml
@@ -285,6 +285,7 @@ flux:
       - components:
           - "${telemetry.metrics.enabled ? 'prometheus' : ''}"
           - "${telemetry.metrics.enabled ? 'prometheus/flux' : ''}"
+          - "${(telemetry.alerts.enabled ?? true) && telemetry.metrics.enabled ? 'prometheus/alerts/node' : ''}"
           - "${telemetry.logs.enabled ? 'fluentbit' : ''}"
           - "${telemetry.logs.enabled ? 'fluentbit/containerd' : ''}"
           - "${telemetry.logs.enabled ? 'fluentbit/kubernetes' : ''}"

--- a/contexts/_template/schema.yaml
+++ b/contexts/_template/schema.yaml
@@ -435,6 +435,16 @@ properties:
             default: fluentd
             description: Log aggregation driver for FluentBit output (fluentd is default, none keeps the per-node shipper but drops the central aggregator)
         additionalProperties: false
+      alerts:
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: true
+            description: >
+              Deploy PrometheusRule alerting rules for core cluster components. Requires
+              telemetry.metrics.enabled.
+        additionalProperties: false
     additionalProperties: false
 
   policies:

--- a/contexts/_template/tests/addon-observability.test.yaml
+++ b/contexts/_template/tests/addon-observability.test.yaml
@@ -182,6 +182,7 @@ cases:
             - components:
                 - prometheus
                 - prometheus/flux
+                - prometheus/alerts/node
               timeout: 10m
           interval: 5m
         - name: observability

--- a/contexts/_template/tests/platform-base.test.yaml
+++ b/contexts/_template/tests/platform-base.test.yaml
@@ -60,6 +60,7 @@ cases:
             - components:
                 - prometheus
                 - prometheus/flux
+                - prometheus/alerts/node
                 - fluentbit
                 - fluentbit/containerd
                 - fluentbit/kubernetes
@@ -119,6 +120,7 @@ cases:
             - components:
                 - prometheus
                 - prometheus/flux
+                - prometheus/alerts/node
                 - fluentbit
                 - fluentbit/containerd
                 - fluentbit/kubernetes
@@ -200,6 +202,7 @@ cases:
             - components:
                 - prometheus
                 - prometheus/flux
+                - prometheus/alerts/node
               timeout: 10m
               interval: 5m
         - name: observability
@@ -235,6 +238,7 @@ cases:
             - components:
                 - prometheus
                 - prometheus/flux
+                - prometheus/alerts/node
                 - fluentbit
                 - fluentbit/containerd
                 - fluentbit/kubernetes
@@ -425,6 +429,7 @@ cases:
             - components:
                 - prometheus
                 - prometheus/flux
+                - prometheus/alerts/node
         - name: pki
           dependsOn:
             - policy-resources
@@ -436,6 +441,64 @@ cases:
     exclude:
       flux:
         - name: observability
+
+  # alerts.enabled: false drops the node PrometheusRule component; the rest
+  # of the metrics/logs pipeline is unaffected.
+  - name: telemetry alerts disabled excludes node prometheus rules
+    values:
+      platform: metal
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster: *default-cluster
+      telemetry:
+        alerts:
+          enabled: false
+    expect:
+      flux:
+        - name: telemetry
+          resources:
+            - components:
+                - prometheus
+                - prometheus/flux
+                - fluentbit
+                - fluentbit/containerd
+                - fluentbit/kubernetes
+                - fluentbit/parser
+                - fluentbit/systemd
+                - fluentbit/prometheus
+                - fluentbit/fluentd
+              timeout: 10m
+              interval: 5m
+
+  # No Prometheus to evaluate against, so the metrics guard excludes it
+  # even with alerts.enabled: true.
+  - name: telemetry alerts enabled without metrics excludes node prometheus rules
+    values:
+      platform: metal
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster: *default-cluster
+      telemetry:
+        metrics:
+          enabled: false
+        alerts:
+          enabled: true
+    expect:
+      flux:
+        - name: telemetry
+          install:
+            components:
+              - fluentbit
+          resources:
+            - components:
+                - fluentbit
+                - fluentbit/containerd
+                - fluentbit/kubernetes
+                - fluentbit/parser
+                - fluentbit/systemd
+                - fluentbit/fluentd
 
   # Logs on, metrics off: fluent-bit ships + fluentd aggregates, Prometheus
   # stack is dropped. cert-manager/prometheus and fluentbit/prometheus (the

--- a/contexts/_template/tests/platform-docker.test.yaml
+++ b/contexts/_template/tests/platform-docker.test.yaml
@@ -116,6 +116,7 @@ cases:
             - components:
                 - prometheus
                 - prometheus/flux
+                - prometheus/alerts/node
                 - fluentbit
                 - fluentbit/containerd
                 - fluentbit/kubernetes
@@ -283,6 +284,7 @@ cases:
             - components:
                 - prometheus
                 - prometheus/flux
+                - prometheus/alerts/node
                 - fluentbit
                 - fluentbit/containerd
                 - fluentbit/kubernetes

--- a/contexts/_template/tests/platform-metal.test.yaml
+++ b/contexts/_template/tests/platform-metal.test.yaml
@@ -87,6 +87,7 @@ cases:
             - components:
                 - prometheus
                 - prometheus/flux
+                - prometheus/alerts/node
                 - fluentbit
                 - fluentbit/containerd
                 - fluentbit/kubernetes
@@ -202,6 +203,7 @@ cases:
             - components:
                 - prometheus
                 - prometheus/flux
+                - prometheus/alerts/node
                 - fluentbit
                 - fluentbit/containerd
                 - fluentbit/kubernetes

--- a/kustomize/telemetry/.docs.yaml
+++ b/kustomize/telemetry/.docs.yaml
@@ -39,11 +39,15 @@ components:
   resources/prometheus:
     facet: telemetry-resources
     enable_when: "`telemetry.metrics.enabled: true`"
-    description: "ServiceMonitors and PrometheusRules that target the blueprint's core workloads (kube-state-metrics, the API server, etcd via Talos discovery). The ServiceMonitor / PrometheusRule CRDs come from the vendored `crds:` layer, applied ahead of the whole stack."
+    description: "Reserved anchor component for prometheus-adjacent resources; currently empty. ServiceMonitors and PrometheusRules live under `resources/prometheus/flux` and `resources/prometheus/alerts`."
   resources/prometheus/flux:
     facet: telemetry-resources
     enable_when: "`telemetry.metrics.enabled: true`"
-    description: "ServiceMonitor for Flux controllers and a PrometheusRule with the upstream Flux alert set."
+    description: "ServiceMonitor and PodMonitor for Flux controllers."
+  resources/prometheus/alerts:
+    facet: telemetry-resources
+    enable_when: "`telemetry.alerts.enabled: true` (default) and `telemetry.metrics.enabled: true`"
+    description: "Bundle of PrometheusRule alerting rules, curated from samber/awesome-prometheus-alerts, one system per sub-component (currently `node`; more land incrementally). Deliberately supplemental to kube-prometheus-stack's own defaultRules where those already cover a system well -- not a wholesale replacement. Reference the bundle for all always-on systems or an individual system (e.g. `resources/prometheus/alerts/node`) for selective inclusion."
   resources/fluentbit:
     facet: telemetry-resources
     enable_when: "`telemetry.logs.enabled: true`"

--- a/kustomize/telemetry/README.md
+++ b/kustomize/telemetry/README.md
@@ -145,8 +145,9 @@ install tier's `prometheus` and `prometheus/flux` components stay.
 
 | Component | Enable when | Effect |
 |---|---|---|
-| `resources/prometheus` | `telemetry.metrics.enabled: true` | ServiceMonitors and PrometheusRules that target the blueprint's core workloads (kube-state-metrics, the API server, etcd via Talos discovery). The ServiceMonitor / PrometheusRule CRDs come from the vendored `crds:` layer, applied ahead of the whole stack. |
-| `resources/prometheus/flux` | `telemetry.metrics.enabled: true` | ServiceMonitor for Flux controllers and a PrometheusRule with the upstream Flux alert set. |
+| `resources/prometheus` | `telemetry.metrics.enabled: true` | Reserved anchor component for prometheus-adjacent resources; currently empty. ServiceMonitors and PrometheusRules live under `resources/prometheus/flux` and `resources/prometheus/alerts`. |
+| `resources/prometheus/flux` | `telemetry.metrics.enabled: true` | ServiceMonitor and PodMonitor for Flux controllers. |
+| `resources/prometheus/alerts` | `telemetry.alerts.enabled: true` (default) and `telemetry.metrics.enabled: true` | Bundle of PrometheusRule alerting rules, curated from samber/awesome-prometheus-alerts, one system per sub-component (currently `node`; more land incrementally). Deliberately supplemental to kube-prometheus-stack's own defaultRules where those already cover a system well -- not a wholesale replacement. Reference the bundle for all always-on systems or an individual system (e.g. `resources/prometheus/alerts/node`) for selective inclusion. |
 | `resources/fluentbit` | `telemetry.logs.enabled: true` | `ClusterFluentBitConfig` + `ClusterOutput` (no-op by default; outputs are added by `addon-observability` based on `logs_driver`). Establishes the base FluentBit pipeline. |
 | `resources/fluentbit/containerd` | `telemetry.logs.enabled: true` | `ClusterInput` reading containerd logs from `/var/log/containers/*.log` with the multiline-parser configuration for containerd's CRI log format. |
 | `resources/fluentbit/kubernetes` | `telemetry.logs.enabled: true` | `ClusterFilter` enriching log records with Kubernetes metadata (Pod / Namespace / Container labels) from the kubelet API. |

--- a/kustomize/telemetry/install/prometheus/helm-release.yaml
+++ b/kustomize/telemetry/install/prometheus/helm-release.yaml
@@ -21,6 +21,14 @@ spec:
       enabled: false
     kubeStateMetrics:
       enabled: true
+    # Talos binds these to 127.0.0.1 only, unreachable from Prometheus --
+    # would otherwise permanently false-positive TargetDown/InstanceUnreachable.
+    kubeControllerManager:
+      enabled: false
+    kubeScheduler:
+      enabled: false
+    kubeProxy:
+      enabled: false
     kube-state-metrics:
       image:
         # renovate: datasource=docker depName=registry.k8s.io/kube-state-metrics/kube-state-metrics package=registry.k8s.io/kube-state-metrics/kube-state-metrics

--- a/kustomize/telemetry/resources/prometheus/alerts/kustomization.yaml
+++ b/kustomize/telemetry/resources/prometheus/alerts/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# Prometheus alerting rules bundle, curated from samber/awesome-prometheus-alerts.
+#
+# Use `prometheus/alerts` for every always-on system, or an individual
+# system (e.g. `prometheus/alerts/node`) for selective inclusion.
+
+components:
+  - node

--- a/kustomize/telemetry/resources/prometheus/alerts/node/kustomization.yaml
+++ b/kustomize/telemetry/resources/prometheus/alerts/node/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# Supplemental node-exporter alerts not already covered by
+# kube-prometheus-stack's own defaultRules. Curated from
+# samber/awesome-prometheus-alerts.
+
+resources:
+  - prometheus-rule.yaml

--- a/kustomize/telemetry/resources/prometheus/alerts/node/prometheus-rule.test.yaml
+++ b/kustomize/telemetry/resources/prometheus/alerts/node/prometheus-rule.test.yaml
@@ -1,0 +1,204 @@
+rule_files:
+  - .rendered-rule.yml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'node_vmstat_oom_kill{instance="node1"}'
+        values: '0+0x29 1'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: HostOomKillDetected
+        exp_alerts: []
+      - eval_time: 30m
+        alertname: HostOomKillDetected
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: node1
+            exp_annotations:
+              summary: 'Host OOM kill detected (instance node1)'
+              description: "OOM kill detected\n  VALUE = 1\n  LABELS = map[instance:node1]"
+
+  - interval: 1m
+    input_series:
+      - series: 'node_filesystem_device_error{instance="node1",fstype="ext4",mountpoint="/"}'
+        values: '0x5 1+0x10'
+    alert_rule_test:
+      - eval_time: 3m
+        alertname: HostFilesystemDeviceError
+        exp_alerts: []
+      - eval_time: 8m
+        alertname: HostFilesystemDeviceError
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              instance: node1
+              fstype: ext4
+              mountpoint: /
+            exp_annotations:
+              summary: 'Host filesystem device error (instance node1)'
+              description: "Error stat-ing the / filesystem\n  VALUE = 1\n  LABELS = map[__name__:node_filesystem_device_error fstype:ext4 instance:node1 mountpoint:/]"
+
+  # 30s scrape interval (this cluster's actual cadence) so rate([1m]) has
+  # 2+ samples in its window -- a 1m test interval would false-negative.
+  - interval: 30s
+    input_series:
+      - series: 'node_disk_read_time_seconds_total{instance="node1",device="sda"}'
+        values: '0+6x40'
+      - series: 'node_disk_reads_completed_total{instance="node1",device="sda"}'
+        values: '0+50x40'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: HostUnusualDiskReadLatency
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: node1
+              device: sda
+            exp_annotations:
+              summary: 'Host unusual disk read latency (instance node1)'
+              description: "Disk latency is growing (read operations > 100ms)\n  VALUE = 0.12\n  LABELS = map[device:sda instance:node1]"
+
+  - interval: 30s
+    input_series:
+      - series: 'node_disk_read_time_seconds_total{instance="node1",device="sda"}'
+        values: '0+0.5x40'
+      - series: 'node_disk_reads_completed_total{instance="node1",device="sda"}'
+        values: '0+50x40'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: HostUnusualDiskReadLatency
+        exp_alerts: []
+
+  - interval: 30s
+    input_series:
+      - series: 'node_disk_write_time_seconds_total{instance="node1",device="sda"}'
+        values: '0+6x40'
+      - series: 'node_disk_writes_completed_total{instance="node1",device="sda"}'
+        values: '0+50x40'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: HostUnusualDiskWriteLatency
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: node1
+              device: sda
+            exp_annotations:
+              summary: 'Host unusual disk write latency (instance node1)'
+              description: "Disk latency is growing (write operations > 100ms)\n  VALUE = 0.12\n  LABELS = map[device:sda instance:node1]"
+
+  - interval: 1m
+    input_series:
+      - series: 'node_cpu_seconds_total{instance="node1",cpu="0",mode="steal"}'
+        values: '0+7x10'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: HostCpuStealNoisyNeighbor
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: node1
+              mode: steal
+            exp_annotations:
+              summary: 'Host CPU steal noisy neighbor (instance node1)'
+              description: "CPU steal is > 10%. A noisy neighbor is killing VM performances or a spot instance may be out of credit.\n  VALUE = 11.666666666666666\n  LABELS = map[instance:node1 mode:steal]"
+
+  - interval: 1m
+    input_series:
+      - series: 'node_cpu_seconds_total{instance="node1",cpu="0",mode="steal"}'
+        values: '0+1x10'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: HostCpuStealNoisyNeighbor
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'node_memory_SwapFree_bytes{instance="node1"}'
+        values: '100000000+0x5'
+      - series: 'node_memory_SwapTotal_bytes{instance="node1"}'
+        values: '1000000000+0x5'
+    alert_rule_test:
+      - eval_time: 4m
+        alertname: HostSwapIsFillingUp
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: node1
+            exp_annotations:
+              summary: 'Host swap is filling up (instance node1)'
+              description: "Swap is filling up (>80%)\n  VALUE = 90\n  LABELS = map[instance:node1]"
+
+  - interval: 1m
+    input_series:
+      - series: 'node_cpu_seconds_total{instance="node1",cpu="0",mode="iowait"}'
+        values: '0+7x10'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: HostCpuHighIowait
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: node1
+              mode: iowait
+            exp_annotations:
+              summary: 'Host CPU high iowait (instance node1)'
+              description: "CPU iowait > 10%. Your CPU is idling waiting for storage to respond.\n  VALUE = 0.11666666666666667\n  LABELS = map[instance:node1 mode:iowait]"
+
+  - interval: 1h
+    input_series:
+      - series: 'node_memory_MemFree_bytes{instance="node1"}'
+        values: '900000000+0x170'
+      - series: 'node_memory_MemTotal_bytes{instance="node1"}'
+        values: '1000000000+0x170'
+    alert_rule_test:
+      - eval_time: 1w
+        alertname: HostMemoryIsUnderutilized
+        exp_alerts:
+          - exp_labels:
+              severity: info
+              instance: node1
+            exp_annotations:
+              summary: 'Host Memory is underutilized (instance node1)'
+              description: "Node memory usage is < 20% for 1 week. Consider reducing memory space. (instance node1)\n  VALUE = 9e+08\n  LABELS = map[instance:node1]"
+
+  - interval: 10m
+    input_series:
+      - series: 'node_cpu_seconds_total{instance="node1",cpu="0",mode="idle"}'
+        values: '0+500x1200'
+    alert_rule_test:
+      - eval_time: 1w1h
+        alertname: HostCpuIsUnderutilized
+        exp_alerts:
+          - exp_labels:
+              severity: info
+              instance: node1
+              mode: idle
+            exp_annotations:
+              summary: 'Host CPU is underutilized (instance node1)'
+              description: "CPU load has been < 20% for 1 week. Consider reducing the number of CPUs.\n  VALUE = 0.8333333333333333\n  LABELS = map[instance:node1 mode:idle]"
+
+  # Regression test for the changes()-on-a-label-change bug: a fresh series
+  # with no prior offset-1h data (cold start / genuine kernel bump) fires;
+  # a series present continuously for >1h does not.
+  - interval: 1m
+    input_series:
+      - series: 'node_uname_info{instance="node1",release="6.1.0"}'
+        values: '1+0x120'
+      - series: 'node_uname_info{instance="node2",release="6.1.0"}'
+        values: '_x65 1+0x60'
+    alert_rule_test:
+      - eval_time: 90m
+        alertname: HostKernelVersionDeviations
+        exp_alerts:
+          - exp_labels:
+              severity: info
+              instance: node2
+              release: 6.1.0
+            exp_annotations:
+              summary: 'Host kernel version deviations (instance node2)'
+              description: "Kernel version for node2 has changed.\n  VALUE = 1\n  LABELS = map[__name__:node_uname_info instance:node2 release:6.1.0]"

--- a/kustomize/telemetry/resources/prometheus/alerts/node/prometheus-rule.yaml
+++ b/kustomize/telemetry/resources/prometheus/alerts/node/prometheus-rule.yaml
@@ -1,0 +1,98 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: node-alerts
+  namespace: system-telemetry
+spec:
+  groups:
+    - name: node-supplemental.rules
+      rules:
+        - alert: HostOomKillDetected
+          expr: increase(node_vmstat_oom_kill[30m]) > 0
+          labels:
+            severity: warning
+          annotations:
+            summary: Host OOM kill detected (instance {{ $labels.instance }})
+            description: "OOM kill detected\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+
+        - alert: HostFilesystemDeviceError
+          expr: node_filesystem_device_error{fstype!~"^(fuse.*|tmpfs|cifs|nfs)"} == 1
+          for: 2m
+          labels:
+            severity: critical
+          annotations:
+            summary: Host filesystem device error (instance {{ $labels.instance }})
+            description: "Error stat-ing the {{ $labels.mountpoint }} filesystem\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+
+        - alert: HostUnusualDiskReadLatency
+          expr: rate(node_disk_read_time_seconds_total[1m]) / rate(node_disk_reads_completed_total[1m]) > 0.1 and rate(node_disk_reads_completed_total[1m]) > 0
+          for: 2m
+          labels:
+            severity: warning
+          annotations:
+            summary: Host unusual disk read latency (instance {{ $labels.instance }})
+            description: "Disk latency is growing (read operations > 100ms)\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+
+        - alert: HostUnusualDiskWriteLatency
+          expr: rate(node_disk_write_time_seconds_total[1m]) / rate(node_disk_writes_completed_total[1m]) > 0.1 and rate(node_disk_writes_completed_total[1m]) > 0
+          for: 2m
+          labels:
+            severity: warning
+          annotations:
+            summary: Host unusual disk write latency (instance {{ $labels.instance }})
+            description: "Disk latency is growing (write operations > 100ms)\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+
+        - alert: HostCpuStealNoisyNeighbor
+          expr: avg without (cpu) (rate(node_cpu_seconds_total{mode="steal"}[5m])) * 100 > 10
+          labels:
+            severity: warning
+          annotations:
+            summary: Host CPU steal noisy neighbor (instance {{ $labels.instance }})
+            description: "CPU steal is > 10%. A noisy neighbor is killing VM performances or a spot instance may be out of credit.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+
+        - alert: HostSwapIsFillingUp
+          expr: (1 - (node_memory_SwapFree_bytes / node_memory_SwapTotal_bytes)) * 100 > 80 and node_memory_SwapTotal_bytes > 0
+          for: 2m
+          labels:
+            severity: warning
+          annotations:
+            summary: Host swap is filling up (instance {{ $labels.instance }})
+            description: "Swap is filling up (>80%)\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+
+        - alert: HostCpuHighIowait
+          expr: avg without (cpu) (rate(node_cpu_seconds_total{mode="iowait"}[5m])) > .10
+          labels:
+            severity: warning
+          annotations:
+            summary: Host CPU high iowait (instance {{ $labels.instance }})
+            description: "CPU iowait > 10%. Your CPU is idling waiting for storage to respond.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+
+        - alert: HostMemoryIsUnderutilized
+          expr: min_over_time(node_memory_MemFree_bytes[1w]) > node_memory_MemTotal_bytes * .8
+          labels:
+            severity: info
+          annotations:
+            summary: Host Memory is underutilized (instance {{ $labels.instance }})
+            description: "Node memory usage is < 20% for 1 week. Consider reducing memory space. (instance {{ $labels.instance }})\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+
+        - alert: HostCpuIsUnderutilized
+          expr: min without (cpu) (rate(node_cpu_seconds_total{mode="idle"}[1h])) > 0.8
+          for: 1w
+          labels:
+            severity: info
+          annotations:
+            summary: Host CPU is underutilized (instance {{ $labels.instance }})
+            description: "CPU load has been < 20% for 1 week. Consider reducing the number of CPUs.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+
+        # Upstream's changes(node_uname_info[1h]) never fires: release is a
+        # label, so a version bump starts a new series rather than changing
+        # an existing one's value, which changes() can't see. This detects
+        # the new series directly; it also fires once at Prometheus startup
+        # (no 1h of history to compare against yet), which self-resolves.
+        - alert: HostKernelVersionDeviations
+          expr: node_uname_info unless node_uname_info offset 1h
+          labels:
+            severity: info
+          annotations:
+            summary: Host kernel version deviations (instance {{ $labels.instance }})
+            description: "Kernel version for {{ $labels.instance }} has changed.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"

--- a/scripts/test-prometheus-rules.sh
+++ b/scripts/test-prometheus-rules.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Unit-tests every PrometheusRule via promtool. Finds each prometheus-rule.yaml
+# with a sibling prometheus-rule.test.yaml, extracts .spec to a rule file
+# promtool can load, and runs the test against it.
+set -euo pipefail
+
+fail=0
+
+while IFS= read -r -d '' rule_file; do
+  dir=$(dirname "$rule_file")
+  test_file="$dir/prometheus-rule.test.yaml"
+  [ -f "$test_file" ] || continue
+
+  rendered="$dir/.rendered-rule.yml"
+  yq '.spec' "$rule_file" > "$rendered"
+
+  echo "=== $test_file ==="
+  if ! promtool test rules "$test_file"; then
+    fail=1
+  fi
+  rm -f "$rendered"
+done < <(find kustomize -name "prometheus-rule.yaml" -print0)
+
+exit $fail


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This PR adds opt-out Prometheus alerting rules that deploy by default to all existing observability stacks, and extends CI with binary downloads that lack integrity verification.
>
> **Overview**
>
> The PR introduces a new `telemetry.alerts.enabled` schema field (default `true`) that conditionally deploys a `prometheus/alerts/node` kustomize component containing 10 curated PrometheusRule alerts for node-exporter metrics. It also adds a `promtool`-based unit-test harness — both a shell script for local runs and two new CI steps to install `yq` and `promtool` at pinned versions. Three kube-prometheus-stack targets (`kubeControllerManager`, `kubeScheduler`, `kubeProxy`) are explicitly disabled in the Helm values because Talos binds them to 127.0.0.1.
>
> Because `telemetry.alerts.enabled` defaults to `true`, every existing deployment with metrics enabled will receive the new PrometheusRule on its next Flux reconciliation without any opt-in. The alert rules themselves are well-tested and the `HostKernelVersionDeviations` false-positive on cold start is acknowledged in both code and tests.
>
> Reviewed by Claude for commit `07475cde`.

<!-- /claude-code-review:summary -->
