### PR TITLE
chore(review): enable full output for thread resolution in Claude Code Review

### DIFF
--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -294,6 +294,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          show_full_output: true
           prompt: |
             Your only job is to identify which existing review threads on
             this PR have been addressed. Do NOT call any GitHub write API


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!WARNING]
>
> **Review did not complete**
>
> The automated review produced no summary. See the [run](https://github.com/windsorcli/core/actions/runs/29698100337).

<!-- /claude-code-review:summary -->
