### PR TITLE
fix(telemetry): nest alertmanager slack secret under data:

### DIFF
--- a/contexts/_template/facets/platform-base.yaml
+++ b/contexts/_template/facets/platform-base.yaml
@@ -339,7 +339,8 @@ flux:
     when: (telemetry.alerts.slack.webhook_url ?? '') != ''
     secrets:
       alertmanager-notification-slack:
-        url: ${telemetry.alerts.slack.webhook_url}
+        data:
+          url: ${telemetry.alerts.slack.webhook_url}
 
   # Depends on telemetry-install so cert-manager's ServiceMonitor has a
   # working Prometheus target from the moment it's created.

--- a/contexts/_template/tests/platform-base.test.yaml
+++ b/contexts/_template/tests/platform-base.test.yaml
@@ -557,7 +557,8 @@ cases:
                 - fluentbit/fluentd
               secrets:
                 alertmanager-notification-slack:
-                  url: https://hooks.slack.com/services/T000/B000/XXXXXXXX
+                  data:
+                    url: https://hooks.slack.com/services/T000/B000/XXXXXXXX
               substitutions:
                 slack_channel: '"#test-alerts"'
                 severity_regex: warning|critical
@@ -585,7 +586,8 @@ cases:
                 - prometheus/notifications/slack
               secrets:
                 alertmanager-notification-slack:
-                  url: https://hooks.slack.com/services/T000/B000/XXXXXXXX
+                  data:
+                    url: https://hooks.slack.com/services/T000/B000/XXXXXXXX
               substitutions:
                 slack_channel: '"#test-alerts"'
                 severity_regex: critical


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This fix corrects the structure of the Alertmanager Slack webhook secret in the platform-base facet template, affecting only users who have configured `telemetry.alerts.slack.webhook_url`.
>
> **Overview**
>
> The PR wraps the `url` field of the `alertmanager-notification-slack` secret under a `data:` key, matching the expected schema for secrets in the Windsor facet system. Both affected test cases in `platform-base.test.yaml` are updated in lock-step to reflect the corrected structure.
>
> The old layout placed `url` as a sibling of the secret name rather than as a child of `data:`, which would have produced a malformed secret. No other behavior changes.
>
> Reviewed by Claude for commit `9efd1f04`.

<!-- /claude-code-review:summary -->
