### PR TITLE
fix(cluster): default node cpu/memory in facets

### DIFF
--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -130,8 +130,8 @@ terraform:
       # CPU-derived formula overshoots and floods apiserver. Clamp to 2 there.
       concurrency: >-
         ${platform == 'incus' ? 2 : max(2, min(
-          floor(cluster.controlplanes.cpu / 2),
-          floor(cluster.controlplanes.memory / 2),
+          floor(cluster_resources_effective.controlplanes.cpu / 2),
+          floor(cluster_resources_effective.controlplanes.memory / 2),
           10
         ))}
       git_username: ${workstation.git.username ?? "local"}
@@ -233,12 +233,12 @@ terraform:
           storage_pool: "${(workstation.runtime ?? '') == 'colima' ? 'local' : 'default'}"
           root_disk_size: ${string(cluster.controlplanes.root_disk_size ?? 30) + "GB"}
           limits:
-            cpu: ${string(cluster.controlplanes.cpu)}
-            memory: ${string(cluster.controlplanes.memory) + "GB"}
+            cpu: ${string(cluster_resources_effective.controlplanes.cpu)}
+            memory: ${string(cluster_resources_effective.controlplanes.memory) + "GB"}
           disks: ${talos_common.controlplane_disks}
           config:
             user.hostname: ${values(cluster.controlplanes.nodes)[0].hostname ?? "controlplane-1"}
-            environment.TALOSSKU: ${string(cluster.controlplanes.cpu) + "CPU-" + string(cluster.controlplanes.memory * 1024) + "RAM"}
+            environment.TALOSSKU: ${string(cluster_resources_effective.controlplanes.cpu) + "CPU-" + string(cluster_resources_effective.controlplanes.memory * 1024) + "RAM"}
             raw.qemu: -boot order=c,menu=off
         - name: worker
           role: worker
@@ -250,12 +250,12 @@ terraform:
           storage_pool: "${(workstation.runtime ?? '') == 'colima' ? 'local' : 'default'}"
           root_disk_size: ${string(cluster.workers.root_disk_size ?? 50) + "GB"}
           limits:
-            cpu: ${string(cluster.workers.cpu)}
-            memory: ${string(cluster.workers.memory) + "GB"}
+            cpu: ${string(cluster_resources_effective.workers.cpu)}
+            memory: ${string(cluster_resources_effective.workers.memory) + "GB"}
           disks: ${talos_common.worker_disks}
           config:
             user.hostname: "${cluster.workers.nodes != null ? (values(cluster.workers.nodes)[0].hostname ?? 'worker-1') : 'worker-1'}"
-            environment.TALOSSKU: "${string(cluster.workers.cpu) + 'CPU-' + string(cluster.workers.memory * 1024) + 'RAM'}"
+            environment.TALOSSKU: "${string(cluster_resources_effective.workers.cpu) + 'CPU-' + string(cluster_resources_effective.workers.memory * 1024) + 'RAM'}"
             raw.qemu: -boot order=c,menu=off
 
   # Docker: run Talos controlplane/worker containers on the workstation
@@ -277,15 +277,15 @@ terraform:
         controlplanes:
           count: ${cluster.controlplanes.count ?? 1}
           image: ${cluster.controlplanes.image ?? talos.docker_image}
-          cpu: ${cluster.controlplanes.cpu}
-          memory: ${cluster.controlplanes.memory}
+          cpu: ${cluster_resources_effective.controlplanes.cpu}
+          memory: ${cluster_resources_effective.controlplanes.memory}
           hostports: "${workstation.runtime == \"docker-desktop\" ? (cluster.controlplanes.hostports ?? [\"8080:30080/tcp\", \"8443:30443/tcp\"]) : []}"
           volumes: ${cluster.controlplanes.volumes ?? []}
         workers:
           count: ${cluster.workers.count ?? 0}
           image: ${cluster.workers.image ?? talos.docker_image}
-          cpu: ${cluster.workers.cpu}
-          memory: ${cluster.workers.memory}
+          cpu: ${cluster_resources_effective.workers.cpu}
+          memory: ${cluster_resources_effective.workers.memory}
           hostports: "${workstation.runtime == \"docker-desktop\" ? (cluster.workers.hostports ?? [\"8080:30080/tcp\", \"8443:30443/tcp\"]) : []}"
           volumes: ${cluster.workers.volumes ?? []}
 

--- a/contexts/_template/facets/platform-base.yaml
+++ b/contexts/_template/facets/platform-base.yaml
@@ -47,11 +47,12 @@ config:
   # rather than cluster.* because some platform facets replace cluster.controlplanes
   # with a terraform list. A controlplane that runs workloads — flagged schedulable
   # or in a workerless cluster — gets a larger baseline than a dedicated one.
+  # Dedicated memory is 8Gi (not 4) to leave etcd + kube-apiserver headroom.
   - name: cluster_resources_effective
     value:
       controlplanes:
         cpu: "${cluster.controlplanes.cpu ?? (((cluster.workers.count ?? len(cluster.workers.nodes ?? {})) == 0 || (cluster.controlplanes.schedulable ?? false)) ? 8 : 4)}"
-        memory: "${cluster.controlplanes.memory ?? (((cluster.workers.count ?? len(cluster.workers.nodes ?? {})) == 0 || (cluster.controlplanes.schedulable ?? false)) ? 12 : 4)}"
+        memory: "${cluster.controlplanes.memory ?? (((cluster.workers.count ?? len(cluster.workers.nodes ?? {})) == 0 || (cluster.controlplanes.schedulable ?? false)) ? 12 : 8)}"
       workers:
         cpu: "${cluster.workers.cpu ?? 4}"
         memory: "${cluster.workers.memory ?? 8}"

--- a/contexts/_template/facets/platform-base.yaml
+++ b/contexts/_template/facets/platform-base.yaml
@@ -42,6 +42,20 @@ config:
       cni:
         driver: "${cluster.cni.driver ?? 'flannel'}"
 
+  # Node CPU/memory defaults. The CLI no longer injects these (it leaves them nil
+  # when unset so facets own the defaults). Consumers read cluster_resources_effective
+  # rather than cluster.* because some platform facets replace cluster.controlplanes
+  # with a terraform list. A controlplane that runs workloads — flagged schedulable
+  # or in a workerless cluster — gets a larger baseline than a dedicated one.
+  - name: cluster_resources_effective
+    value:
+      controlplanes:
+        cpu: "${cluster.controlplanes.cpu ?? (((cluster.workers.count ?? len(cluster.workers.nodes ?? {})) == 0 || (cluster.controlplanes.schedulable ?? false)) ? 8 : 4)}"
+        memory: "${cluster.controlplanes.memory ?? (((cluster.workers.count ?? len(cluster.workers.nodes ?? {})) == 0 || (cluster.controlplanes.schedulable ?? false)) ? 12 : 4)}"
+      workers:
+        cpu: "${cluster.workers.cpu ?? 4}"
+        memory: "${cluster.workers.memory ?? 8}"
+
   # Gateway driver. First non-null wins: explicit gateway.driver; legacy
   # ingress.driver alias (envoy-gateway/nginx → envoy); else platform default
   # — docker-desktop and AWS use envoy, otherwise cilium when it's the CNI.

--- a/contexts/_template/facets/platform-hyperv.yaml
+++ b/contexts/_template/facets/platform-hyperv.yaml
@@ -170,8 +170,8 @@ config:
             ["boot_from_dvd", false],
             ["generation", 2],
             ["secure_boot", false],
-            ["cpu", cluster.controlplanes.cpu],
-            ["memory", cluster.controlplanes.memory],
+            ["cpu", cluster_resources_effective.controlplanes.cpu],
+            ["memory", cluster_resources_effective.controlplanes.memory],
             ["root_disk_size", cluster.controlplanes.root_disk_size ?? 30],
             ["notes", "Talos control plane node"]
           ])),
@@ -186,8 +186,8 @@ config:
             ["boot_from_dvd", false],
             ["generation", 2],
             ["secure_boot", false],
-            ["cpu", cluster.workers.cpu],
-            ["memory", cluster.workers.memory],
+            ["cpu", cluster_resources_effective.workers.cpu],
+            ["memory", cluster_resources_effective.workers.memory],
             ["root_disk_size", cluster.workers.root_disk_size ?? 50],
             ["notes", "Talos worker node"]
           ]))
@@ -335,8 +335,8 @@ terraform:
             ["boot_from_dvd", false],
             ["generation", 2],
             ["secure_boot", false],
-            ["cpu", cluster.controlplanes.cpu],
-            ["memory", cluster.controlplanes.memory],
+            ["cpu", cluster_resources_effective.controlplanes.cpu],
+            ["memory", cluster_resources_effective.controlplanes.memory],
             ["root_disk_size", cluster.controlplanes.root_disk_size ?? 30],
             ["notes", "Talos control plane node"]
           ]),
@@ -351,8 +351,8 @@ terraform:
             ["boot_from_dvd", false],
             ["generation", 2],
             ["secure_boot", false],
-            ["cpu", cluster.workers.cpu],
-            ["memory", cluster.workers.memory],
+            ["cpu", cluster_resources_effective.workers.cpu],
+            ["memory", cluster_resources_effective.workers.memory],
             ["root_disk_size", cluster.workers.root_disk_size ?? 50],
             ["notes", "Talos worker node"]
           ])
@@ -392,7 +392,7 @@ terraform:
     dependsOn:
       - cluster
     inputs:
-      concurrency: ${max(2, min(floor(cluster.controlplanes.cpu / 2), floor(cluster.controlplanes.memory / 2), 10))}
+      concurrency: ${max(2, min(floor(cluster_resources_effective.controlplanes.cpu / 2), floor(cluster_resources_effective.controlplanes.memory / 2), 10))}
     destroy: false
 
 # =============================================================================

--- a/contexts/_template/facets/platform-incus.yaml
+++ b/contexts/_template/facets/platform-incus.yaml
@@ -87,12 +87,12 @@ terraform:
           storage_pool: "default"
           root_disk_size: ${string(cluster.controlplanes.root_disk_size ?? 30) + "GB"}
           limits:
-            cpu: ${string(cluster.controlplanes.cpu)}
-            memory: ${string(cluster.controlplanes.memory) + "GB"}
+            cpu: ${string(cluster_resources_effective.controlplanes.cpu)}
+            memory: ${string(cluster_resources_effective.controlplanes.memory) + "GB"}
           disks: ${talos_common.controlplane_disks}
           config:
             user.hostname: ${values(cluster.controlplanes.nodes)[0].hostname ?? "controlplane-1"}
-            environment.TALOSSKU: ${string(cluster.controlplanes.cpu) + "CPU-" + string(cluster.controlplanes.memory * 1024) + "RAM"}
+            environment.TALOSSKU: ${string(cluster_resources_effective.controlplanes.cpu) + "CPU-" + string(cluster_resources_effective.controlplanes.memory * 1024) + "RAM"}
             raw.qemu: -boot order=c,menu=off
         - name: worker
           role: worker
@@ -104,12 +104,12 @@ terraform:
           storage_pool: "default"
           root_disk_size: ${string(cluster.workers.root_disk_size ?? 50) + "GB"}
           limits:
-            cpu: ${string(cluster.workers.cpu)}
-            memory: ${string(cluster.workers.memory) + "GB"}
+            cpu: ${string(cluster_resources_effective.workers.cpu)}
+            memory: ${string(cluster_resources_effective.workers.memory) + "GB"}
           disks: ${talos_common.worker_disks}
           config:
             user.hostname: "${len(cluster.workers.nodes ?? {}) > 0 ? (values(cluster.workers.nodes)[0].hostname ?? 'worker-1') : 'worker-1'}"
-            environment.TALOSSKU: "${string(cluster.workers.cpu) + 'CPU-' + string(cluster.workers.memory * 1024) + 'RAM'}"
+            environment.TALOSSKU: "${string(cluster_resources_effective.workers.cpu) + 'CPU-' + string(cluster_resources_effective.workers.memory * 1024) + 'RAM'}"
             raw.qemu: -boot order=c,menu=off
 
   # Talos bootstrap/apply. Uses compute output when available, else user-supplied nodes.
@@ -138,7 +138,7 @@ terraform:
     dependsOn:
       - cluster
     inputs:
-      concurrency: ${max(2, min(floor(cluster.controlplanes.cpu / 2), floor(cluster.controlplanes.memory / 2), 10))}
+      concurrency: ${max(2, min(floor(cluster_resources_effective.controlplanes.cpu / 2), floor(cluster_resources_effective.controlplanes.memory / 2), 10))}
     destroy: false
 
 # =============================================================================

--- a/contexts/_template/facets/platform-metal.yaml
+++ b/contexts/_template/facets/platform-metal.yaml
@@ -69,7 +69,7 @@ terraform:
     dependsOn:
       - cluster
     inputs:
-      concurrency: ${max(2, min(floor(cluster.controlplanes.cpu / 2), floor(cluster.controlplanes.memory / 2), 10))}
+      concurrency: ${max(2, min(floor(cluster_resources_effective.controlplanes.cpu / 2), floor(cluster_resources_effective.controlplanes.memory / 2), 10))}
     destroy: false
 
 # =============================================================================


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This change moves CPU/memory defaults for cluster nodes from CLI injection into the facet layer, touching every platform that provisions VMs or containers — a shared infrastructure default that affects all users who rely on unset values.
>
> **Overview**
>
> A new `cluster_resources_effective` intermediate variable is introduced in `platform-base.yaml` that resolves CPU/memory to either the user-supplied value or a facet-owned default. All platform facets (workstation, Hyper-V, Incus, Metal) are updated to read from this variable instead of raw `cluster.controlplanes.*` and `cluster.workers.*`. The defaults are differentiated: controlplanes that schedule workloads (single-node or `schedulable: true`) get 8 CPU / 12 GB, dedicated controlplanes get 4 CPU / 4 GB, and workers get 4 CPU / 8 GB.
>
> Users with explicitly set CPU/memory values are unaffected. Users who relied on the former CLI-injected defaults will receive these new facet defaults on next apply; the risk is a plan diff that resizes VM resources if the CLI's previous defaults differed from these values.
>
> Reviewed by Claude for commit `f6b22ea1`.

<!-- /claude-code-review:summary -->
