### PR TITLE
ci: drop "Reviewed by Claude" attribution from review and diagnosis comments

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -732,8 +732,7 @@ jobs:
               >
               > **Suggested next step:** {one actionable sentence}
               >
-              > _Live read-only inspection by Claude. Support bundle attached
-              > to the run artifacts._
+              > _Support bundle attached to the run artifacts._
               <!-- /claude-integration-$MODE-diagnosis -->
 
             The marker lines are required — a later CI step uses them to anchor

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -73,8 +73,6 @@ jobs:
               >
               > {Optional second paragraph: the most notable behavioral or
               > structural detail — a rename, a new default, a migration.}
-              >
-              > Reviewed by Claude for commit `<short SHA of PR_HEAD_SHA>`.
 
             Tone: calm, specific, prose-first. No emojis, no bullet lists, no
             "Test plan", under ~150 words. Risk level: Low for isolated,
@@ -192,8 +190,6 @@ jobs:
               >
               > {Optional second paragraph: the most notable behavioral or
               > structural detail — a rename, a new default, a migration.}
-              >
-              > Reviewed by Claude for commit `<short SHA of PR_HEAD_SHA>`.
 
             Tone: calm, specific, prose-first. No emojis, no bullet lists, no
             "Test plan", under ~150 words. Risk level: Low for isolated,


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!WARNING]
>
> **Review did not complete**
>
> The automated review produced no summary. See the [run](https://github.com/windsorcli/core/actions/runs/30065544527).

<!-- /claude-code-review:summary -->
