### PR TITLE
chore(ci): skip upgrade CI on Talos version bumps and re-arm node health check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -300,6 +300,22 @@ jobs:
             exit 1
           fi
           git fetch origin main
+          # A Talos version bump replaces the docker control plane (the version is
+          # the node image) and container mode has no in-place upgrade, so the
+          # cluster must be rebuilt. Fresh mode covers that. Keyed to the one
+          # field that sets the version so it can't mask other upgrade breakage.
+          TALOS_VERSION_FILE=contexts/_template/facets/config-talos.yaml
+          talos_version_of() { git show "$1:$TALOS_VERSION_FILE" 2>/dev/null | sed -n 's/^ *talos_version: *"\(.*\)"$/\1/p'; }
+          base_talos=$(talos_version_of origin/main)
+          head_talos=$(talos_version_of HEAD)
+          if [ -n "$base_talos" ] && [ -n "$head_talos" ] && [ "$base_talos" != "$head_talos" ]; then
+            echo "Talos version changed ${base_talos} -> ${head_talos}. Skipping upgrade test:"
+            echo "  container-mode Talos has no in-place upgrade, so compute/docker replaces"
+            echo "  the control plane and the cluster must be rebuilt. Covered by fresh mode."
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "expect_bump=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
           if git diff --quiet origin/main HEAD -- terraform kustomize contexts windsor.yaml; then
             echo "No infra changes (terraform, kustomize, contexts, windsor.yaml). Skipping upgrade test."
             echo "skip=true" >> $GITHUB_OUTPUT

--- a/terraform/cluster/talos/modules/machine/main.tf
+++ b/terraform/cluster/talos/modules/machine/main.tf
@@ -129,6 +129,13 @@ resource "null_resource" "node_healthcheck" {
     # race against the reboot. When apply is skipped (out-of-band config
     # delivery) the trigger is constant — the config can't drift here.
     config_hash = try(talos_machine_configuration_apply.this[0].machine_configuration_hash, "skipped")
+
+    # Re-run when the Talos version changes: it reboots the node, or replaces it
+    # where the version is the node image (compute/docker). The triggers above
+    # miss that (var.node keeps the reused IP, the machineconfig is unchanged),
+    # so a replaced node only surfaced as a downstream failure against an
+    # unreachable API.
+    talos_version = var.talos_version
   }
 
   depends_on = [


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> Additive, defensive changes to CI and Terraform that close a gap where Talos version bumps were silently mishandled; no existing behavior is altered for non-version-change paths.
>
> **Overview**
>
> The PR adds a pre-flight check to the upgrade CI job that detects when the Talos version field changes between `origin/main` and `HEAD`; if it does, the job exits early with `skip=true` rather than running an upgrade test that cannot succeed in container mode. In parallel, a `talos_version` trigger is added to the `null_resource.node_healthcheck` Terraform resource so that a version change — which may replace the node outright on compute/docker platforms — always re-runs the health check even when the node IP and generated machineconfig are otherwise unchanged.
>
> Both changes are conservative: the CI gate fails open (runs the test) whenever the version field is missing or cannot be parsed, and `var.talos_version` is already declared in the module's variables file, so no new Terraform surface is introduced.

<!-- /claude-code-review:summary -->
