### PR TITLE
fix(hyperv): default network.cidr_block at every read site

### DIFF
--- a/contexts/_template/facets/platform-hyperv.yaml
+++ b/contexts/_template/facets/platform-hyperv.yaml
@@ -38,6 +38,14 @@ config:
 
   # Network gateway and nameserver defaults for the CIDATA seed. Written only
   # when unset; see platform-base.yaml "Network defaults" for the pattern.
+  #
+  # Every network.cidr_block read below repeats `?? '10.5.0.0/16'`. The schema
+  # default does not reach facet expressions, and platform-base's when:-gated
+  # default cannot supply it either: that guard reads the key it writes, so the
+  # entry resolves after other consumers of `network`. A read that omits the
+  # fallback fails composition with "cidrhost() ... got <nil>" whenever
+  # cidr_block is unset. All of these collapse to a bare read once the schema
+  # default is applied at composition (windsorcli/cli#3031).
   - name: network
     when: (network.gateway ?? '') == ''
     value:
@@ -197,7 +205,7 @@ config:
   # Controlplane sits at CIDR offset 10 so k8s_service_host is DHCP-independent.
   - name: talos_common
     value:
-      k8s_service_host: "${cidrhost(network.cidr_block, 10)}"
+      k8s_service_host: "${cidrhost(network.cidr_block ?? '10.5.0.0/16', 10)}"
 
   # NodePort certSANs: workstations reach both APIs at the bench external IP,
   # but Talos auto-derives SANs only from NAT-internal addresses. Add the bench
@@ -270,11 +278,11 @@ terraform:
     inputs:
       talos_version: ${talos.talos_version}
       cluster_name: talos
-      cluster_endpoint: "${cluster.endpoint ?? ('https://' + cidrhost(network.cidr_block, 10) + ':6443')}"
+      cluster_endpoint: "${cluster.endpoint ?? ('https://' + cidrhost(network.cidr_block ?? '10.5.0.0/16', 10) + ':6443')}"
       destination_dir: "${hyperv_effective.images_dir}"
       common_config_patches: ${talos_common.common_config_patches}
       network:
-        cidr_block: ${network.cidr_block}
+        cidr_block: ${network.cidr_block ?? '10.5.0.0/16'}
         gateway: ${network.gateway}
         nameservers: ${network.nameservers}
       # In NodePort mode, feed the facet-built lists so CIDATA patches land
@@ -313,7 +321,7 @@ terraform:
       # Add-NetNatExternalAddress first; identical on a single-LAN-NIC bench.
       port_forward_external_ip: "0.0.0.0"
       port_forward_name_prefix: "windsor-${id ?? 'hyperv'}"
-      network_cidr: ${network.cidr_block}
+      network_cidr: ${network.cidr_block ?? '10.5.0.0/16'}
       vhd_dir: "${hyperv_effective.vhd_dir}"
       images:
         talos:
@@ -328,7 +336,7 @@ terraform:
             ["name", "controlplane"],
             ["role", "controlplane"],
             ["count", cluster.controlplanes.count ?? 1],
-            ["ipv4", cidrhost(network.cidr_block, 10)],
+            ["ipv4", cidrhost(network.cidr_block ?? '10.5.0.0/16', 10)],
             ["image", ""],
             ["dvd_iso_path", "talos"],
             ["cidata_iso_path", hyperv_effective.images_dir + "/" + ((values(cluster.controlplanes.nodes ?? {}))[0].hostname ?? "controlplane-1") + "-cidata.iso"],
@@ -344,7 +352,7 @@ terraform:
             ["name", "worker"],
             ["role", "worker"],
             ["count", cluster.workers.count ?? 0],
-            ["ipv4", cidrhost(network.cidr_block, 20)],
+            ["ipv4", cidrhost(network.cidr_block ?? '10.5.0.0/16', 20)],
             ["image", ""],
             ["dvd_iso_path", "talos"],
             ["cidata_iso_path", (cluster.workers.count ?? 0) > 0 ? (hyperv_effective.images_dir + "/" + ((values(cluster.workers.nodes ?? {}))[0].hostname ?? "worker-1") + "-cidata.iso") : ""],

--- a/contexts/_template/tests/platform-hyperv.test.yaml
+++ b/contexts/_template/tests/platform-hyperv.test.yaml
@@ -66,6 +66,25 @@ cases:
             - cluster
           destroy: false
 
+  # An unset cidr_block must still compose. The schema default does not reach
+  # facet expressions, so every read carries its own fallback; a site that
+  # misses one fails composition with "cidrhost() ... got <nil>".
+  - name: unset cidr_block composes from the per-usage default
+    values:
+      platform: hyperv
+      gateway:
+        enabled: false
+      network:
+        nameservers: ['1.1.1.1']
+      cluster: *default-cluster
+    terraformOutputs: *default-terraform-outputs
+    expect:
+      terraform:
+        - name: compute
+          path: compute/hyperv
+          inputs:
+            network_cidr: 10.5.0.0/16
+
   # External switch when net_adapter is set (the L2-routable path that lets
   # MetalLB / Cilium L2 announcements reach the bench's LAN).
   - name: net_adapter implies External switch

--- a/contexts/_template/tests/platform-hyperv.test.yaml
+++ b/contexts/_template/tests/platform-hyperv.test.yaml
@@ -68,7 +68,12 @@ cases:
 
   # An unset cidr_block must still compose. The schema default does not reach
   # facet expressions, so every read carries its own fallback; a site that
-  # misses one fails composition with "cidrhost() ... got <nil>".
+  # misses one fails composition with "cidrhost() ... got <nil>". Assert the
+  # bootstrap-critical derivations alongside network_cidr: cluster_endpoint and
+  # k8s_service_host both come from cidrhost(cidr, 10), so a regressed fallback
+  # at either site would crash or resolve wrong here. cilium is set so
+  # k8s_service_host surfaces as a cni substitution (hyperv defaults to flannel,
+  # which composes no cni system); the cidr fallbacks are CNI-independent.
   - name: unset cidr_block composes from the per-usage default
     values:
       platform: hyperv
@@ -76,7 +81,10 @@ cases:
         enabled: false
       network:
         nameservers: ['1.1.1.1']
-      cluster: *default-cluster
+      cluster:
+        <<: *default-cluster
+        cni:
+          driver: cilium
     terraformOutputs: *default-terraform-outputs
     expect:
       terraform:
@@ -84,6 +92,15 @@ cases:
           path: compute/hyperv
           inputs:
             network_cidr: 10.5.0.0/16
+        - name: cluster-config
+          path: cluster/talos/config
+          inputs:
+            cluster_endpoint: https://10.5.0.10:6443
+      flux:
+        - name: cni
+          install:
+            substitutions:
+              k8s_service_host: "10.5.0.10"
 
   # External switch when net_adapter is set (the L2-routable path that lets
   # MetalLB / Cilium L2 announcements reach the bench's LAN).


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> Targeted bug fix in the Hyper-V platform facet that prevents a nil-dereference crash during composition when `network.cidr_block` is not explicitly set by the user.
>
> **Overview**
>
> The change adds an explicit `?? '10.5.0.0/16'` fallback to every site in `platform-hyperv.yaml` that passes `network.cidr_block` to `cidrhost()` or forwards it to a Terraform input. Without these guards, any composition where the user omits `network.cidr_block` fails with `cidrhost() ... got <nil>` because schema defaults do not propagate into facet expressions. A new test case covering the unset-`cidr_block` path is added alongside the fix.
>
> The fallback value matches the existing schema default (`10.5.0.0/16`), so there is no behavioral change for users who already set the key. The comment block notes this workaround can be collapsed to bare reads once windsorcli/cli#3031 lands.

<!-- /claude-code-review:summary -->
