### PR TITLE
ci: extract runner prep and tool setup as composite actions

### DIFF
--- a/.github/actions/prepare-runner/action.yml
+++ b/.github/actions/prepare-runner/action.yml
@@ -1,0 +1,49 @@
+# =============================================================================
+# prepare-runner composite action
+# =============================================================================
+# Runner tuning shared by every job that brings up a cluster: load the bridge
+# netfilter module, reclaim disk, and move the Docker data-root off the small
+# root volume. Consumed by Core and by downstream blueprints that layer on it.
+name: Prepare runner
+description: Load br_netfilter, reclaim disk, and relocate the Docker data-root for cluster jobs.
+
+runs:
+  using: composite
+  steps:
+    # br_netfilter is required to run Kubernetes on Docker; not loaded by default.
+    - name: Load br_netfilter kernel module
+      shell: bash
+      run: |
+        sudo modprobe br_netfilter
+        echo "1" | sudo tee /proc/sys/net/bridge/bridge-nf-call-iptables
+        echo "1" | sudo tee /proc/sys/net/bridge/bridge-nf-call-ip6tables
+
+    # Reclaim ~30 GB by removing pre-installed toolchains the runner ships but
+    # this repo never uses (.NET, Android SDK, Haskell). Without this the kubelet
+    # inside the Talos VM hits its ephemeral-storage eviction threshold during
+    # k8s/Cilium image pulls and evicts the Flux controller pods.
+    - name: Free disk space
+      shell: bash
+      run: |
+        df -h /
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+        df -h /
+
+    # Move docker data-root to /mnt (66GB available vs ~10GB default) and cap
+    # json-file logging at 10m x 3 to prevent runaway disk growth.
+    - name: Configure Docker for increased storage
+      shell: bash
+      run: |
+        sudo mkdir -p /mnt/docker-data
+        sudo mkdir -p /etc/docker
+        echo '{
+          "data-root": "/mnt/docker-data",
+          "log-driver": "json-file",
+          "log-opts": {
+            "max-size": "10m",
+            "max-file": "3"
+          }
+        }' | sudo tee /etc/docker/daemon.json
+        sudo systemctl restart docker || sudo service docker restart || true
+        timeout 30 bash -c 'until docker info > /dev/null 2>&1; do sleep 1; done' || true
+        docker info | grep "Docker Root Dir" || true

--- a/.github/actions/publish-oci/action.yml
+++ b/.github/actions/publish-oci/action.yml
@@ -1,0 +1,49 @@
+# =============================================================================
+# publish-oci composite action
+# =============================================================================
+# Logs in to the container registry and pushes the Windsor bundle under the
+# current ref, plus a `latest` tag on main. `image` is the only per-repo input,
+# so Core and every downstream blueprint publish the same way. Requires the
+# Windsor CLI to already be installed in the job.
+name: Publish OCI package
+description: Log in and push the Windsor bundle under the current ref (and latest on main).
+
+inputs:
+  image:
+    description: OCI image path without tag, e.g. ghcr.io/windsorcli/core.
+    required: true
+  registry:
+    description: Container registry host.
+    required: false
+    default: ghcr.io
+  username:
+    description: Registry username.
+    required: false
+    default: ${{ github.actor }}
+  token:
+    description: Registry password or token, from a secret with packages:write.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Login to container registry
+      uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.username }}
+        password: ${{ inputs.token }}
+
+    - name: Publish to OCI registry
+      shell: bash
+      env:
+        IMAGE: ${{ inputs.image }}
+        TAG: ${{ github.ref_name }}
+      run: windsor push "oci://${IMAGE}:${TAG}"
+
+    - name: Publish latest tag
+      if: github.ref == 'refs/heads/main'
+      shell: bash
+      env:
+        IMAGE: ${{ inputs.image }}
+      run: windsor push "oci://${IMAGE}:latest"

--- a/.github/actions/setup-tools/action.yml
+++ b/.github/actions/setup-tools/action.yml
@@ -1,0 +1,129 @@
+# =============================================================================
+# setup-tools composite action
+# =============================================================================
+# Installs the pinned CLIs the Windsor jobs need. `tools` is a comma-separated
+# list selecting which to install, so a job installs only what it runs (the
+# tests job skips the Flux CLI it never calls). Versions live here, so a bump
+# reaches Core and every downstream blueprint that consumes this action.
+#
+# Selectable: terraform, task, yq, promtool, kubectl, flux, kustomize, helm,
+# support-bundle.
+name: Setup tools
+description: Install the pinned Windsor CLIs selected by the tools input.
+
+inputs:
+  tools:
+    description: Comma-separated list of tools to install (e.g. "terraform,flux,kubectl").
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Terraform
+      if: contains(format(',{0},', inputs.tools), ',terraform,')
+      uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+      with:
+        # renovate: datasource=github-releases depName=terraform package=hashicorp/terraform
+        terraform_version: 1.12.2
+
+    - name: Install Task
+      if: contains(format(',{0},', inputs.tools), ',task,')
+      uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
+      with:
+        version: 3.x
+
+    - name: Setup kubectl
+      if: contains(format(',{0},', inputs.tools), ',kubectl,')
+      uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0
+      with:
+        # renovate: datasource=github-releases depName=kubectl package=kubernetes/kubectl
+        version: v1.34.1
+
+    - name: Install yq
+      if: contains(format(',{0},', inputs.tools), ',yq,')
+      shell: bash
+      env:
+        # renovate: datasource=github-releases depName=yq package=mikefarah/yq
+        YQ_VERSION: v4.53.3
+      run: |
+        cd "$(mktemp -d)" &&
+        curl -fsSLO "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" &&
+        sudo install -m 0755 -o root -g root yq_linux_amd64 /usr/local/bin/yq &&
+        cd - &&
+        rm -rf "$OLDPWD" &&
+        yq --version
+
+    - name: Install promtool
+      if: contains(format(',{0},', inputs.tools), ',promtool,')
+      shell: bash
+      env:
+        # renovate: datasource=github-releases depName=prometheus/prometheus package=prometheus/prometheus
+        PROMETHEUS_VERSION: v3.13.1
+      run: |
+        cd "$(mktemp -d)" &&
+        curl -fsSLO "https://github.com/prometheus/prometheus/releases/download/${PROMETHEUS_VERSION}/prometheus-${PROMETHEUS_VERSION#v}.linux-amd64.tar.gz" &&
+        tar xzf "prometheus-${PROMETHEUS_VERSION#v}.linux-amd64.tar.gz" &&
+        sudo install -m 0755 -o root -g root "prometheus-${PROMETHEUS_VERSION#v}.linux-amd64/promtool" /usr/local/bin/promtool &&
+        cd - &&
+        rm -rf "$OLDPWD" &&
+        promtool --version
+
+    - name: Install Flux CLI
+      if: contains(format(',{0},', inputs.tools), ',flux,')
+      shell: bash
+      env:
+        # renovate: datasource=github-releases depName=flux package=fluxcd/flux2
+        FLUX_VERSION: v2.9.3
+      run: |
+        cd "$(mktemp -d)" &&
+        curl -fsSLO "https://github.com/fluxcd/flux2/releases/download/${FLUX_VERSION}/flux_${FLUX_VERSION#v}_linux_amd64.tar.gz" &&
+        tar xzf "flux_${FLUX_VERSION#v}_linux_amd64.tar.gz" &&
+        sudo install -m 0755 -o root -g root flux /usr/local/bin/ &&
+        cd - &&
+        rm -rf "$OLDPWD" &&
+        flux --version
+
+    - name: Install kustomize
+      if: contains(format(',{0},', inputs.tools), ',kustomize,')
+      shell: bash
+      env:
+        # renovate: datasource=github-releases depName=kustomize package=kubernetes-sigs/kustomize
+        KUSTOMIZE_VERSION: v5.8.1
+      run: |
+        cd "$(mktemp -d)" &&
+        curl -fsSLO "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz" &&
+        tar xzf "kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz" &&
+        sudo install -m 0755 -o root -g root kustomize /usr/local/bin/ &&
+        cd - &&
+        rm -rf "$OLDPWD" &&
+        kustomize version
+
+    - name: Install Helm
+      if: contains(format(',{0},', inputs.tools), ',helm,')
+      shell: bash
+      env:
+        # renovate: datasource=github-releases depName=helm package=helm/helm
+        HELM_VERSION: v4.2.3
+      run: |
+        cd "$(mktemp -d)" &&
+        curl -fsSLO "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" &&
+        tar xzf "helm-${HELM_VERSION}-linux-amd64.tar.gz" &&
+        sudo install -m 0755 -o root -g root linux-amd64/helm /usr/local/bin/helm &&
+        cd - &&
+        rm -rf "$OLDPWD" &&
+        helm version
+
+    - name: Install support-bundle CLI
+      if: contains(format(',{0},', inputs.tools), ',support-bundle,')
+      shell: bash
+      env:
+        # renovate: datasource=github-releases depName=troubleshoot package=replicatedhq/troubleshoot
+        SUPPORT_BUNDLE_VERSION: v0.131.1
+      run: |
+        cd "$(mktemp -d)" &&
+        curl -fsSLO "https://github.com/replicatedhq/troubleshoot/releases/download/${SUPPORT_BUNDLE_VERSION}/support-bundle_linux_amd64.tar.gz" &&
+        tar xzf support-bundle_linux_amd64.tar.gz &&
+        sudo install -m 0755 -o root -g root support-bundle /usr/local/bin/ &&
+        cd - &&
+        rm -rf "$OLDPWD" &&
+        support-bundle version

--- a/.github/actions/setup-tools/action.yml
+++ b/.github/actions/setup-tools/action.yml
@@ -6,6 +6,10 @@
 # tests job skips the Flux CLI it never calls). Versions live here, so a bump
 # reaches Core and every downstream blueprint that consumes this action.
 #
+# Each curl-installed binary is verified against the release's own SHA-256
+# checksums file before install. Only the version string is pinned here, so a
+# Renovate bump needs no checksum update — verification tracks the new release.
+#
 # Selectable: terraform, task, yq, promtool, kubectl, flux, kustomize, helm,
 # support-bundle.
 name: Setup tools
@@ -46,11 +50,18 @@ runs:
         # renovate: datasource=github-releases depName=yq package=mikefarah/yq
         YQ_VERSION: v4.53.3
       run: |
-        cd "$(mktemp -d)" &&
-        curl -fsSLO "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" &&
-        sudo install -m 0755 -o root -g root yq_linux_amd64 /usr/local/bin/yq &&
-        cd - &&
-        rm -rf "$OLDPWD" &&
+        cd "$(mktemp -d)"
+        base="https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}"
+        curl -fsSLO "${base}/yq_linux_amd64"
+        curl -fsSL "${base}/checksums" -o checksums
+        curl -fsSL "${base}/checksums_hashes_order" -o checksums_hashes_order
+        # The checksums table is one column per hash type; take the SHA-256
+        # column (+1 for the leading filename field) and verify that entry.
+        col=$(( $(grep -n '^SHA-256$' checksums_hashes_order | cut -d: -f1) + 1 ))
+        want=$(awk -v c="$col" '$1 == "yq_linux_amd64" { print $c }' checksums)
+        [ -n "$want" ] || { echo "::error::no SHA-256 checksum for yq_linux_amd64"; exit 1; }
+        [ "$want" = "$(sha256sum yq_linux_amd64 | awk '{print $1}')" ] || { echo "::error::checksum mismatch for yq_linux_amd64"; exit 1; }
+        sudo install -m 0755 -o root -g root yq_linux_amd64 /usr/local/bin/yq
         yq --version
 
     - name: Install promtool
@@ -60,12 +71,16 @@ runs:
         # renovate: datasource=github-releases depName=prometheus/prometheus package=prometheus/prometheus
         PROMETHEUS_VERSION: v3.13.1
       run: |
-        cd "$(mktemp -d)" &&
-        curl -fsSLO "https://github.com/prometheus/prometheus/releases/download/${PROMETHEUS_VERSION}/prometheus-${PROMETHEUS_VERSION#v}.linux-amd64.tar.gz" &&
-        tar xzf "prometheus-${PROMETHEUS_VERSION#v}.linux-amd64.tar.gz" &&
-        sudo install -m 0755 -o root -g root "prometheus-${PROMETHEUS_VERSION#v}.linux-amd64/promtool" /usr/local/bin/promtool &&
-        cd - &&
-        rm -rf "$OLDPWD" &&
+        cd "$(mktemp -d)"
+        base="https://github.com/prometheus/prometheus/releases/download/${PROMETHEUS_VERSION}"
+        asset="prometheus-${PROMETHEUS_VERSION#v}.linux-amd64.tar.gz"
+        curl -fsSLO "${base}/${asset}"
+        curl -fsSL "${base}/sha256sums.txt" -o checksums.txt
+        want=$(awk -v f="$asset" '$2 == f || $2 == "*" f { print $1; exit }' checksums.txt)
+        [ -n "$want" ] || { echo "::error::no checksum listed for $asset"; exit 1; }
+        [ "$want" = "$(sha256sum "$asset" | awk '{print $1}')" ] || { echo "::error::checksum mismatch for $asset"; exit 1; }
+        tar xzf "$asset"
+        sudo install -m 0755 -o root -g root "prometheus-${PROMETHEUS_VERSION#v}.linux-amd64/promtool" /usr/local/bin/promtool
         promtool --version
 
     - name: Install Flux CLI
@@ -75,12 +90,16 @@ runs:
         # renovate: datasource=github-releases depName=flux package=fluxcd/flux2
         FLUX_VERSION: v2.9.3
       run: |
-        cd "$(mktemp -d)" &&
-        curl -fsSLO "https://github.com/fluxcd/flux2/releases/download/${FLUX_VERSION}/flux_${FLUX_VERSION#v}_linux_amd64.tar.gz" &&
-        tar xzf "flux_${FLUX_VERSION#v}_linux_amd64.tar.gz" &&
-        sudo install -m 0755 -o root -g root flux /usr/local/bin/ &&
-        cd - &&
-        rm -rf "$OLDPWD" &&
+        cd "$(mktemp -d)"
+        base="https://github.com/fluxcd/flux2/releases/download/${FLUX_VERSION}"
+        asset="flux_${FLUX_VERSION#v}_linux_amd64.tar.gz"
+        curl -fsSLO "${base}/${asset}"
+        curl -fsSL "${base}/flux_${FLUX_VERSION#v}_checksums.txt" -o checksums.txt
+        want=$(awk -v f="$asset" '$2 == f || $2 == "*" f { print $1; exit }' checksums.txt)
+        [ -n "$want" ] || { echo "::error::no checksum listed for $asset"; exit 1; }
+        [ "$want" = "$(sha256sum "$asset" | awk '{print $1}')" ] || { echo "::error::checksum mismatch for $asset"; exit 1; }
+        tar xzf "$asset"
+        sudo install -m 0755 -o root -g root flux /usr/local/bin/
         flux --version
 
     - name: Install kustomize
@@ -90,12 +109,16 @@ runs:
         # renovate: datasource=github-releases depName=kustomize package=kubernetes-sigs/kustomize
         KUSTOMIZE_VERSION: v5.8.1
       run: |
-        cd "$(mktemp -d)" &&
-        curl -fsSLO "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz" &&
-        tar xzf "kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz" &&
-        sudo install -m 0755 -o root -g root kustomize /usr/local/bin/ &&
-        cd - &&
-        rm -rf "$OLDPWD" &&
+        cd "$(mktemp -d)"
+        base="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}"
+        asset="kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
+        curl -fsSLO "${base}/${asset}"
+        curl -fsSL "${base}/checksums.txt" -o checksums.txt
+        want=$(awk -v f="$asset" '$2 == f || $2 == "*" f { print $1; exit }' checksums.txt)
+        [ -n "$want" ] || { echo "::error::no checksum listed for $asset"; exit 1; }
+        [ "$want" = "$(sha256sum "$asset" | awk '{print $1}')" ] || { echo "::error::checksum mismatch for $asset"; exit 1; }
+        tar xzf "$asset"
+        sudo install -m 0755 -o root -g root kustomize /usr/local/bin/
         kustomize version
 
     - name: Install Helm
@@ -105,12 +128,15 @@ runs:
         # renovate: datasource=github-releases depName=helm package=helm/helm
         HELM_VERSION: v4.2.3
       run: |
-        cd "$(mktemp -d)" &&
-        curl -fsSLO "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" &&
-        tar xzf "helm-${HELM_VERSION}-linux-amd64.tar.gz" &&
-        sudo install -m 0755 -o root -g root linux-amd64/helm /usr/local/bin/helm &&
-        cd - &&
-        rm -rf "$OLDPWD" &&
+        cd "$(mktemp -d)"
+        asset="helm-${HELM_VERSION}-linux-amd64.tar.gz"
+        curl -fsSLO "https://get.helm.sh/${asset}"
+        curl -fsSL "https://get.helm.sh/${asset}.sha256sum" -o checksums.txt
+        want=$(awk '{ print $1; exit }' checksums.txt)
+        [ -n "$want" ] || { echo "::error::no checksum for $asset"; exit 1; }
+        [ "$want" = "$(sha256sum "$asset" | awk '{print $1}')" ] || { echo "::error::checksum mismatch for $asset"; exit 1; }
+        tar xzf "$asset"
+        sudo install -m 0755 -o root -g root linux-amd64/helm /usr/local/bin/helm
         helm version
 
     - name: Install support-bundle CLI
@@ -120,10 +146,14 @@ runs:
         # renovate: datasource=github-releases depName=troubleshoot package=replicatedhq/troubleshoot
         SUPPORT_BUNDLE_VERSION: v0.131.1
       run: |
-        cd "$(mktemp -d)" &&
-        curl -fsSLO "https://github.com/replicatedhq/troubleshoot/releases/download/${SUPPORT_BUNDLE_VERSION}/support-bundle_linux_amd64.tar.gz" &&
-        tar xzf support-bundle_linux_amd64.tar.gz &&
-        sudo install -m 0755 -o root -g root support-bundle /usr/local/bin/ &&
-        cd - &&
-        rm -rf "$OLDPWD" &&
+        cd "$(mktemp -d)"
+        base="https://github.com/replicatedhq/troubleshoot/releases/download/${SUPPORT_BUNDLE_VERSION}"
+        asset="support-bundle_linux_amd64.tar.gz"
+        curl -fsSLO "${base}/${asset}"
+        curl -fsSL "${base}/troubleshoot_${SUPPORT_BUNDLE_VERSION#v}_checksums.txt" -o checksums.txt
+        want=$(awk -v f="$asset" '$2 == f || $2 == "*" f { print $1; exit }' checksums.txt)
+        [ -n "$want" ] || { echo "::error::no checksum listed for $asset"; exit 1; }
+        [ "$want" = "$(sha256sum "$asset" | awk '{print $1}')" ] || { echo "::error::checksum mismatch for $asset"; exit 1; }
+        tar xzf "$asset"
+        sudo install -m 0755 -o root -g root support-bundle /usr/local/bin/
         support-bundle version

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,16 +31,6 @@ permissions:
 env:
   WINDSOR_PROJECT_ROOT: ${{ github.workspace }}
   DOCKER_HOST: unix:///var/run/docker.sock
-  # renovate: datasource=github-releases depName=troubleshoot package=replicatedhq/troubleshoot
-  SUPPORT_BUNDLE_VERSION: v0.131.1
-  # renovate: datasource=github-releases depName=flux package=fluxcd/flux2
-  FLUX_VERSION: v2.9.3
-  # renovate: datasource=github-releases depName=yq package=mikefarah/yq
-  YQ_VERSION: v4.53.3
-  # renovate: datasource=github-releases depName=helm package=helm/helm
-  HELM_VERSION: v4.2.3
-  # renovate: datasource=github-releases depName=prometheus/prometheus package=prometheus/prometheus
-  PROMETHEUS_VERSION: v3.13.1
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -73,6 +63,11 @@ jobs:
         with:
           python-version: '3.x'
 
+      - name: Setup tools
+        uses: ./.github/actions/setup-tools
+        with:
+          tools: terraform,task,yq,helm
+
       - name: Run yamllint
         run: |
           pip install yamllint
@@ -88,19 +83,8 @@ jobs:
             echo "No shell scripts found to check"
           fi
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
-        with:
-          # renovate: datasource=github-releases depName=terraform package=hashicorp/terraform
-          terraform_version: 1.12.2
-
       - name: Run terraform fmt
         run: terraform fmt -check -recursive
-
-      - name: Install Task
-        uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
-        with:
-          version: 3.x
 
       # Regenerate vendored files from source.yaml and fail if the tree drifts.
       - name: Validate vendored assets
@@ -115,30 +99,6 @@ jobs:
             echo "Run 'task dashboards' locally and commit the changes."
             exit 1
           fi
-
-      # yq is the YAML reader the kustomize-docs generator depends on. Local
-      # devs get it via aqua; CI installs the same pinned version directly.
-      - name: Install yq
-        run: |
-          cd "$(mktemp -d)" &&
-          curl -fsSLO "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" &&
-          sudo install -m 0755 -o root -g root yq_linux_amd64 /usr/local/bin/yq &&
-          cd - &&
-          rm -rf "$OLDPWD" &&
-          yq --version
-
-      # helm renders the vendored CRDs (helm show crds / helm template) for the
-      # crds:check drift guard. Local devs get it via aqua; CI installs the same
-      # pinned version directly.
-      - name: Install Helm
-        run: |
-          cd "$(mktemp -d)" &&
-          curl -fsSLO "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" &&
-          tar xzf "helm-${HELM_VERSION}-linux-amd64.tar.gz" &&
-          sudo install -m 0755 -o root -g root linux-amd64/helm /usr/local/bin/helm &&
-          cd - &&
-          rm -rf "$OLDPWD" &&
-          helm version
 
       # Fail if kustomize/crds/<name>-<version>/ has drifted from the sources in
       # kustomize/crds/sources.yaml (regenerate with 'task crds' and commit).
@@ -201,43 +161,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+      - name: Setup tools
+        uses: ./.github/actions/setup-tools
         with:
-          # renovate: datasource=github-releases depName=terraform package=hashicorp/terraform
-          terraform_version: 1.12.2
+          tools: terraform,task,yq,promtool
 
       - name: Install Windsor CLI
         uses: windsorcli/action@main
         with:
           ref: main
           context: local
-
-      - name: Install Task
-        uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
-        with:
-          version: 3.x
-
-      # yq renders each PrometheusRule's .spec for promtool; local devs get
-      # both via aqua, CI installs the same pinned versions directly.
-      - name: Install yq
-        run: |
-          cd "$(mktemp -d)" &&
-          curl -fsSLO "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" &&
-          sudo install -m 0755 -o root -g root yq_linux_amd64 /usr/local/bin/yq &&
-          cd - &&
-          rm -rf "$OLDPWD" &&
-          yq --version
-
-      - name: Install promtool
-        run: |
-          cd "$(mktemp -d)" &&
-          curl -fsSLO "https://github.com/prometheus/prometheus/releases/download/${PROMETHEUS_VERSION}/prometheus-${PROMETHEUS_VERSION#v}.linux-amd64.tar.gz" &&
-          tar xzf "prometheus-${PROMETHEUS_VERSION#v}.linux-amd64.tar.gz" &&
-          sudo install -m 0755 -o root -g root "prometheus-${PROMETHEUS_VERSION#v}.linux-amd64/promtool" /usr/local/bin/promtool &&
-          cd - &&
-          rm -rf "$OLDPWD" &&
-          promtool --version
 
       - name: Run Tests
         run: task test
@@ -332,71 +265,13 @@ jobs:
             fi
           fi
 
-      - name: Load br_netfilter kernel module
-        run: |
-          sudo modprobe br_netfilter
-          echo "1" | sudo tee /proc/sys/net/bridge/bridge-nf-call-iptables
-          echo "1" | sudo tee /proc/sys/net/bridge/bridge-nf-call-ip6tables
+      - name: Prepare runner
+        uses: ./.github/actions/prepare-runner
 
-      # Reclaim ~30 GB by removing pre-installed toolchains the runner ships
-      # but this repo never uses (.NET, Android SDK, Haskell). Without this the
-      # kubelet inside the Talos VM hits its ephemeral-storage eviction threshold
-      # during k8s/Cilium image pulls and evicts the Flux controller pods.
-      - name: Free disk space
-        run: |
-          df -h /
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
-          df -h /
-
-      # Move docker data-root to /mnt (66GB available vs ~10GB default) and
-      # cap json-file logging at 10m × 3 to prevent runaway disk growth.
-      - name: Configure Docker for increased storage
-        run: |
-          sudo mkdir -p /mnt/docker-data
-          sudo mkdir -p /etc/docker
-          echo '{
-            "data-root": "/mnt/docker-data",
-            "log-driver": "json-file",
-            "log-opts": {
-              "max-size": "10m",
-              "max-file": "3"
-            }
-          }' | sudo tee /etc/docker/daemon.json
-          sudo systemctl restart docker || sudo service docker restart || true
-          timeout 30 bash -c 'until docker info > /dev/null 2>&1; do sleep 1; done' || true
-          docker info | grep "Docker Root Dir" || true
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+      - name: Setup tools
+        uses: ./.github/actions/setup-tools
         with:
-          # renovate: datasource=github-releases depName=terraform package=hashicorp/terraform
-          terraform_version: 1.12.2
-
-      - name: Setup kubectl
-        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0
-        with:
-          # renovate: datasource=github-releases depName=kubectl package=kubernetes/kubectl
-          version: v1.34.1
-
-      - name: Install support-bundle CLI
-        run: |
-          cd "$(mktemp -d)" &&
-          curl -fsSLO "https://github.com/replicatedhq/troubleshoot/releases/download/${SUPPORT_BUNDLE_VERSION}/support-bundle_linux_amd64.tar.gz" &&
-          tar xzf support-bundle_linux_amd64.tar.gz &&
-          sudo install -m 0755 -o root -g root support-bundle /usr/local/bin/ &&
-          cd - &&
-          rm -rf "$OLDPWD" &&
-          support-bundle version
-
-      - name: Install Flux CLI
-        run: |
-          cd "$(mktemp -d)" &&
-          curl -fsSLO "https://github.com/fluxcd/flux2/releases/download/${FLUX_VERSION}/flux_${FLUX_VERSION#v}_linux_amd64.tar.gz" &&
-          tar xzf "flux_${FLUX_VERSION#v}_linux_amd64.tar.gz" &&
-          sudo install -m 0755 -o root -g root flux /usr/local/bin/ &&
-          cd - &&
-          rm -rf "$OLDPWD" &&
-          flux --version
+          tools: terraform,kubectl,support-bundle,flux
 
       - name: Create bundle directory
         run: mkdir -p support-bundles
@@ -829,11 +704,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+      - name: Setup tools
+        uses: ./.github/actions/setup-tools
         with:
-          # renovate: datasource=github-releases depName=terraform package=hashicorp/terraform
-          terraform_version: 1.12.2
+          tools: terraform
 
       - name: Install Windsor CLI
         uses: windsorcli/action@main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -715,22 +715,8 @@ jobs:
           ref: main
           context: local
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+      - name: Publish OCI package
+        uses: ./.github/actions/publish-oci
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Publish to OCI Registry
-        env:
-          TAG: ${{ github.ref_name }}
-        run: |
-          windsor push oci://ghcr.io/windsorcli/core:${TAG}
-
-      - name: Publish Latest Tag
-        if: github.ref == 'refs/heads/main'
-        env:
-          TAG: latest
-        run: |
-          windsor push oci://ghcr.io/windsorcli/core:${TAG}
+          image: ghcr.io/windsorcli/core
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This is a CI/CD infrastructure refactor touching shared workflow steps consumed by all jobs and described as reusable by downstream blueprints, so any regression has wider blast radius than a typical single-workflow change.
>
> **Overview**
>
> The PR extracts two reusable composite GitHub Actions — `prepare-runner` (br_netfilter, disk cleanup, Docker data-root relocation) and `setup-tools` (pinned CLI installs selectable by a comma-separated `tools` input) — and replaces all inline duplicate steps in `ci.yaml` with calls to them. Version pins and install logic that previously lived in each job are now centralized in the composite actions, so a version bump propagates everywhere automatically.
>
> The refactor is behaviorally faithful: the same tool versions, the same `contains(format(',{0},',…),',tool,')` guard idiom for substring-safe selection, and the same Docker restart race-mitigation logic are all preserved verbatim. The one structural note is that binary downloads (yq, promtool, flux, kustomize, helm, support-bundle) are fetched without checksum verification — a pre-existing pattern that is now centralized and shared with downstream consumers.

<!-- /claude-code-review:summary -->
