### PR TITLE
fix(identity): correct renovate annotation placement on keycloak CRD refs

### DIFF
--- a/contexts/_template/facets/addon-identity.yaml
+++ b/contexts/_template/facets/addon-identity.yaml
@@ -53,8 +53,8 @@ requires:
 
 # Keycloak's CRDs are vendored (kustomize/crds/keycloak-26.7.0), owned by the crds:
 # layer, not the operator. Only the hosted keycloak driver needs them.
-# renovate: datasource=github-releases depName=keycloak/keycloak-k8s-resources package=keycloak/keycloak-k8s-resources
 crds:
+  # renovate: datasource=github-releases depName=keycloak/keycloak-k8s-resources package=keycloak/keycloak-k8s-resources
   - "${(identity.driver ?? 'keycloak') == 'keycloak' ? 'keycloak-26.7.0' : ''}"
 
 # =============================================================================

--- a/contexts/_template/tests/addon-identity.test.yaml
+++ b/contexts/_template/tests/addon-identity.test.yaml
@@ -329,6 +329,7 @@ cases:
       flux:
         - name: identity
       crds:
+        # renovate: datasource=github-releases depName=keycloak/keycloak-k8s-resources package=keycloak/keycloak-k8s-resources
         - keycloak-26.7.0
 
   # Disabled: no identity system and no Keycloak CRDs.
@@ -349,4 +350,5 @@ cases:
       flux:
         - name: identity
       crds:
+        # renovate: datasource=github-releases depName=keycloak/keycloak-k8s-resources package=keycloak/keycloak-k8s-resources
         - keycloak-26.7.0


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This PR moves a Renovate dependency-update annotation within YAML files, with no change to runtime behavior.
>
> **Overview**
>
> The change repositions the `# renovate:` comment in `addon-identity.yaml` from above the `crds:` key to inside the `crds:` block, directly preceding the list item it annotates (`keycloak-26.7.0`). The same annotation is added in the same position to both matching test cases in `addon-identity.test.yaml`. No logic, defaults, or values are altered.
>
> The fix ensures Renovate can locate and bump the Keycloak CRD version string correctly; previously the comment was one structural level above the target line, which could cause Renovate to miss or misattribute the version.

<!-- /claude-code-review:summary -->
