### PR TITLE
fix(observability): remove dns-install dependency for provider-less platforms

### DIFF
--- a/contexts/_template/facets/addon-observability.yaml
+++ b/contexts/_template/facets/addon-observability.yaml
@@ -74,7 +74,6 @@ flux:
     when: addons.observability.dashboards == 'grafana'
     dependsOn:
       - telemetry-install
-      - "${dns.enabled ? 'dns-install' : ''}"
     install:
       timeout: 15m
       interval: 10m

--- a/contexts/_template/facets/option-gateway.yaml
+++ b/contexts/_template/facets/option-gateway.yaml
@@ -114,7 +114,6 @@ flux:
     resources:
       - dependsOn:
           - pki-install
-          - "${dns.enabled ? 'dns-install' : ''}"
         components:
           # cilium LBIPAM patch (lbipam.cilium.io/ips) — skipped when a cloud LB
           # controller owns the IP (hetzner CCM); the plain Gateway Service is

--- a/contexts/_template/tests/addon-observability.test.yaml
+++ b/contexts/_template/tests/addon-observability.test.yaml
@@ -434,3 +434,24 @@ cases:
               components:
                 - grafana/gateway
                 - kibana/gateway
+
+  # Regression (#2311): dns.public_domain sets dns.enabled=true, but metal/incus ship no
+  # dns-install (external-dns needs a provider only cloud platforms have). The observability
+  # install tier must not depend on dns-install, or composition dangles on a system that was
+  # never contributed and blueprint load fails.
+  - name: observability omits dns-install dependency when dns is enabled on a provider-less platform
+    values:
+      platform: metal
+      dns:
+        domain: example.com
+        public_domain: example.com
+      network: *default-network
+      cluster: *default-cluster
+      addons:
+        observability:
+          enabled: true
+    expect:
+      flux:
+        - name: observability
+          dependsOn:
+            - telemetry-install

--- a/contexts/_template/tests/option-gateway.test.yaml
+++ b/contexts/_template/tests/option-gateway.test.yaml
@@ -672,3 +672,23 @@ cases:
       network: *default-network
       cluster: *default-cluster
     expectError: true
+
+  # Regression (#2311): dns.public_domain enables dns without shipping dns-install on
+  # metal/incus. The gateway resources tier must depend only on pki-install, or composition
+  # dangles on a dns-install that was never contributed.
+  - name: gateway resources omit dns-install when dns is enabled on a provider-less platform
+    values:
+      platform: metal
+      dns:
+        domain: example.com
+        public_domain: example.com
+      gateway:
+        enabled: true
+        driver: envoy
+      network: *default-network
+      cluster: *default-cluster
+    expect:
+      flux:
+        - name: gateway
+          resources:
+            - <<: *gateway-resources-envoy

--- a/kustomize/observability/README.md
+++ b/kustomize/observability/README.md
@@ -49,7 +49,7 @@ flowchart LR
 
 ```yaml
 - name: observability
-  dependsOn: [telemetry-install, dns-install]
+  dependsOn: [telemetry-install]
   install:
     components:
       - grafana


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change removes a conditional Flux dependency expression from two facets (observability addon and gateway option), fixing a blueprint composition failure on provider-less platforms such as metal and incus.
>
> **Overview**
>
> On provider-less platforms, `dns.public_domain` can set `dns.enabled=true` without contributing a `dns-install` step (external-dns requires a cloud provider). The previous facets used `"${dns.enabled ? 'dns-install' : ''}"` in their `dependsOn` lists, which would dangle when `dns-install` was never contributed, causing blueprint load to fail. The fix removes these conditional expressions entirely and updates the observability README example to match. Both facets receive targeted regression test cases covering the metal-platform-with-public_domain scenario that triggered issue #2311.
>
> The dependency is removed unconditionally rather than narrowed to provider-less platforms, meaning cloud deployments where `dns-install` does exist will no longer gate observability or gateway on DNS readiness — a behavioral delta worth noting, though it is likely intentional given that pod startup does not require DNS entries to be registered first.

<!-- /claude-code-review:summary -->
