### PR TITLE
fix(dns): reconcile external-dns on resource events, not just the poll interval

### DIFF
--- a/kustomize/dns/install/external-dns/helm-release.yaml
+++ b/kustomize/dns/install/external-dns/helm-release.yaml
@@ -29,6 +29,8 @@ spec:
     env: []
     extraVolumes: []
     extraVolumeMounts: []
+    # Reconcile on Service/HTTPRoute events, not just the interval poll.
+    triggerLoopOnEvent: true
     sources:
       - ingress
     domainFilters:

--- a/kustomize/dns/install/external-dns/helm-release.yaml
+++ b/kustomize/dns/install/external-dns/helm-release.yaml
@@ -29,7 +29,6 @@ spec:
     env: []
     extraVolumes: []
     extraVolumeMounts: []
-    # Reconcile on Service/HTTPRoute events, not just the interval poll.
     triggerLoopOnEvent: true
     sources:
       - ingress


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change touches only the external-dns HelmRelease values and is trivially reversible by removing the flag.
>
> **Overview**
>
> The PR adds `triggerLoopOnEvent: true` to the external-dns Helm values. This enables external-dns to run its reconciliation loop immediately when a watched resource (Service, HTTPRoute, Ingress) changes, rather than waiting for the next poll interval to tick. The change improves DNS propagation latency without altering what records are managed or how they are structured.
>
> The one behavioral side-effect worth noting is that bursts of resource churn (e.g. a rolling deployment updating many Services) will now issue a corresponding burst of DNS provider API calls. Providers with strict rate limits may throttle; if that occurs the fix is to set `triggerLoopOnEvent: false` or raise the provider's rate limit.

<!-- /claude-code-review:summary -->
