### PR TITLE
fix(observability): stop assuming telemetry is always enabled

### DIFF
--- a/contexts/_template/facets/addon-database.yaml
+++ b/contexts/_template/facets/addon-database.yaml
@@ -29,7 +29,5 @@ flux:
   - name: observability
     when: addons.database.postgres.driver == 'cloudnativepg' && addons.observability.enabled == true
     resources:
-      - dependsOn:
-          - telemetry-install
-        components:
+      - components:
           - grafana/dashboards/cloudnativepg

--- a/contexts/_template/facets/addon-observability.yaml
+++ b/contexts/_template/facets/addon-observability.yaml
@@ -72,14 +72,12 @@ flux:
   # format to panel defs so timestamps match operator locale.
   - name: observability
     when: addons.observability.dashboards == 'grafana'
-    dependsOn:
-      - telemetry-install
     install:
       timeout: 15m
       interval: 10m
       components:
         - grafana
-        - grafana/prometheus
+        - "${telemetry.metrics.enabled ? 'grafana/prometheus' : ''}"
         # Single sign-on against the cluster identity provider. Inferred on when identity
         # is enabled (opt out with grafana.sso: false); provider-agnostic — label,
         # issuer, and endpoints come from identity.

--- a/contexts/_template/facets/option-dev.yaml
+++ b/contexts/_template/facets/option-dev.yaml
@@ -44,8 +44,6 @@ flux:
   # Grafana dev credentials (default admin password "grafana"). In production
   # observability.admin_password is expected to come from a secret.
   - name: observability
-    dependsOn:
-      - telemetry-install
     install:
       components:
         - grafana/dev

--- a/contexts/_template/facets/option-storage.yaml
+++ b/contexts/_template/facets/option-storage.yaml
@@ -79,7 +79,5 @@ flux:
   - name: observability
     when: talos_common.storage_driver == 'longhorn' && (addons.observability.enabled == true || dev == true)
     resources:
-      - dependsOn:
-          - telemetry-install
-        components:
+      - components:
           - grafana/dashboards/longhorn

--- a/contexts/_template/facets/platform-base.yaml
+++ b/contexts/_template/facets/platform-base.yaml
@@ -223,18 +223,9 @@ config:
         - prometheus/alerts/flux
         - "${gateway.enabled == true && gateway.driver == 'envoy' ? 'prometheus/alerts/envoy' : ''}"
 
-  # Observability addon forces both pipelines on.
-  - name: telemetry
-    when: addons.observability.enabled == true
-    value:
-      metrics:
-        enabled: true
-      logs:
-        enabled: true
-
   # No logs pipeline → nothing to aggregate.
   - name: telemetry
-    when: telemetry.logs.enabled == false && addons.observability.enabled != true
+    when: telemetry.logs.enabled == false
     value:
       logs:
         driver: none

--- a/contexts/_template/schema.yaml
+++ b/contexts/_template/schema.yaml
@@ -476,8 +476,7 @@ properties:
             description: >
               Deploy the metrics pipeline (Prometheus operator, kube-prometheus-stack, metrics-server)
               and all per-component ServiceMonitors. Disable on resource-constrained clusters that
-              don't need in-cluster metrics. Force-on when addons.observability.enabled is true,
-              since the observability addon requires Prometheus to scrape.
+              don't need in-cluster metrics.
         additionalProperties: false
       logs:
         type: object

--- a/contexts/_template/tests/addon-database.test.yaml
+++ b/contexts/_template/tests/addon-database.test.yaml
@@ -43,9 +43,7 @@ cases:
               - cloudnativepg/prometheus
         - name: observability
           resources:
-            - dependsOn:
-                - telemetry-install
-              components:
+            - components:
                 - grafana/dashboards/cloudnativepg
 
   # Full: database with HA and observability. Intended: addon observability overrides. See docs/cli-bugs.md if this fails.
@@ -74,9 +72,34 @@ cases:
               - cloudnativepg/ha
         - name: observability
           resources:
-            - dependsOn:
-                - telemetry-install
-              components:
+            - components:
+                - grafana/dashboards/cloudnativepg
+
+  # Regression: the dashboard patch has no dependency on telemetry-install (a plain
+  # ConfigMap Grafana's sidecar loads regardless of the telemetry pipeline's state), so
+  # disabling telemetry entirely must not affect composition.
+  - name: cloudnativepg dashboard patch composes with telemetry fully disabled
+    values:
+      platform: metal
+      network: *default-network
+      cluster: *default-cluster
+      telemetry:
+        metrics:
+          enabled: false
+        logs:
+          enabled: false
+      addons:
+        database:
+          postgres:
+            enabled: true
+            driver: cloudnativepg
+        observability:
+          enabled: true
+    expect:
+      flux:
+        - name: observability
+          resources:
+            - components:
                 - grafana/dashboards/cloudnativepg
 
   # Edge case: Explicit disable

--- a/contexts/_template/tests/option-dev.test.yaml
+++ b/contexts/_template/tests/option-dev.test.yaml
@@ -61,3 +61,26 @@ cases:
         - name: pki-resources
     # pki-resources (the compiled tier name) doesn't exist on non-dev,
     # non-private-ca metal — no facet contributes any resources components.
+
+  # Regression: dev mode auto-enables observability; the dev-credentials patch (a plain
+  # HelmRelease values patch) has no dependency on telemetry-install, so disabling
+  # telemetry entirely must not affect composition.
+  - name: dev grafana credentials patch composes with telemetry fully disabled
+    values:
+      platform: metal
+      dev: true
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster: *default-cluster
+      telemetry:
+        metrics:
+          enabled: false
+        logs:
+          enabled: false
+    expect:
+      flux:
+        - name: observability
+          install:
+            components:
+              - grafana/dev

--- a/contexts/_template/tests/option-storage.test.yaml
+++ b/contexts/_template/tests/option-storage.test.yaml
@@ -84,6 +84,40 @@ cases:
               - longhorn
               - longhorn/ha
 
+  # Regression: the dashboard patch has no dependency on telemetry-install (a plain
+  # ConfigMap Grafana's sidecar loads regardless of the telemetry pipeline's state), so
+  # disabling telemetry entirely must not affect composition.
+  - name: longhorn dashboard patch composes with telemetry fully disabled
+    values:
+      platform: metal
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster:
+        driver: talos
+        controlplanes:
+          nodes:
+            controlplane-1: *cp1-node
+        workers:
+          volumes:
+            - /var/mnt/local
+        storage:
+          driver: longhorn
+      telemetry:
+        metrics:
+          enabled: false
+        logs:
+          enabled: false
+      addons:
+        observability:
+          enabled: true
+    expect:
+      flux:
+        - name: observability
+          resources:
+            - components:
+                - grafana/dashboards/longhorn
+
   # Explicit openebs driver is same as default
   - name: explicit openebs driver produces same result as default
     values:

--- a/contexts/_template/tests/platform-base.test.yaml
+++ b/contexts/_template/tests/platform-base.test.yaml
@@ -720,9 +720,12 @@ cases:
         # renovate: datasource=github-releases depName=prometheus-operator/prometheus-operator package=prometheus-operator/prometheus-operator
         - prometheus-operator-0.92.1
 
-  # Observability addon force-overrides both telemetry toggles — Grafana needs
-  # Prometheus to scrape and the fluentbit→fluentd path to ship logs.
-  - name: observability addon overrides telemetry metrics and logs disabled
+  # Both telemetry pipelines off means telemetry-install itself doesn't compose. Observability
+  # has no dependency on it (a plain ordering nicety that bought nothing — external-dns-style
+  # watchers don't need it), so Grafana still installs. grafana/prometheus is separately
+  # gated on telemetry.metrics.enabled and correctly drops out — its ServiceMonitor CRD and
+  # its HelmRelease-level dependsOn on kube-prometheus-stack are only real when metrics is on.
+  - name: observability with both telemetry pipelines disabled still composes
     values:
       platform: metal
       gateway:
@@ -739,18 +742,33 @@ cases:
           enabled: true
     expect:
       flux:
+        - name: observability
+          install:
+            components:
+              - grafana
+    exclude:
+      flux:
+        - name: telemetry
+
+  # metrics off but logs on still composes telemetry-install; the operator's metrics
+  # opt-out is respected (no prometheus in telemetry's own components).
+  - name: observability with only metrics disabled still composes
+    values:
+      platform: metal
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster: *default-cluster
+      telemetry:
+        metrics:
+          enabled: false
+      addons:
+        observability:
+          enabled: true
+    expect:
+      flux:
         - name: telemetry
           install:
             components:
-              - prometheus
-              - prometheus/flux
               - fluentbit
-        - name: pki
-          dependsOn:
-            - policy-resources
-            - telemetry-install
-          install:
-            components:
-              - cert-manager
-              - cert-manager/prometheus
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This PR changes the behavior of the observability addon for any cluster that enables it alongside explicit telemetry configuration, removing a long-standing implicit coupling between the two subsystems.
>
> **Overview**
>
> The change removes the config block in `platform-base.yaml` that forced `telemetry.metrics.enabled` and `telemetry.logs.enabled` to `true` whenever `addons.observability.enabled` was true, and strips the corresponding `dependsOn: telemetry-install` ordering hints from the observability, dev-credentials, CloudNativePG, and Longhorn Grafana patches. The `grafana/prometheus` component is now conditionally composed using `telemetry.metrics.enabled` rather than being unconditionally included. Three new regression tests verify that dashboard and credentials patches compose correctly with telemetry fully disabled.
>
> Clusters that rely on the implicit force-override — enabling observability without explicitly setting `telemetry.metrics.enabled: true` — are unaffected as long as `telemetry.metrics.enabled` defaults to `true` in the schema; the behavioral risk is limited to clusters where metrics were explicitly disabled but observability was still active, which is precisely the case the PR is fixing. The removal of the top-level `dependsOn: telemetry-install` from the observability flux section means Grafana reconciliation can now begin before the Prometheus stack is ready on a fresh install, relying on Flux retries rather than an explicit ordering guarantee.

<!-- /claude-code-review:summary -->
