### PR TITLE
fix(lb): disable kube-vip per-service election on single-node topology

### DIFF
--- a/contexts/_template/facets/platform-base.yaml
+++ b/contexts/_template/facets/platform-base.yaml
@@ -307,6 +307,26 @@ flux:
         interval: 5m
         retryInterval: 1m
 
+  # In-cluster LB (kube-vip/metallb) whenever the CNI doesn't already provide one and
+  # a driver is set. docker-desktop has no routable node network for LoadBalancer
+  # Services, so it's excluded regardless of driver.
+  - name: lb
+    when: lb_effective.enabled && workstation.runtime != 'docker-desktop'
+    install:
+      components:
+        - ${lb_effective.driver}
+        - "${lb_effective.driver == 'kube-vip' ? lb_effective.driver + '/' + (network.loadbalancer_mode ?? 'arp') : ''}"
+        - "${lb_effective.driver == 'kube-vip' && topology == 'single-node' ? 'kube-vip/single-node' : ''}"
+      substitutions:
+        loadbalancer_ip_range: "${network.loadbalancer_ips.start + '-' + network.loadbalancer_ips.end}"
+      timeout: 5m
+      interval: 5m
+    resources:
+      - components:
+          - "${lb_effective.driver == 'metallb' ? lb_effective.driver + '/' + (network.loadbalancer_mode ?? 'arp') : ''}"
+        substitutions:
+          loadbalancer_ip_range: "${network.loadbalancer_ips.start + '-' + network.loadbalancer_ips.end}"
+
   - name: telemetry
     when: telemetry.metrics.enabled || telemetry.logs.enabled
     install:

--- a/contexts/_template/facets/platform-docker.yaml
+++ b/contexts/_template/facets/platform-docker.yaml
@@ -105,30 +105,3 @@ terraform:
       worker_config_patches: "${talos_common_docker.worker_config_patches ?? \"\"}"
       controlplane_volumes: ${talos_common.controlplane_volumes ?? []}
       worker_volumes: ${talos_common.worker_volumes ?? []}
-
-# =============================================================================
-# Flux systems — MetalLB / kube-vip for colima / docker / linux runtimes
-# =============================================================================
-# Skipped on docker-desktop (no node-level IP routing). colima/native linux use
-# MetalLB or kube-vip. install ships the driver's controller HelmRelease (plus
-# kube-vip's arp patch); resources ships metallb's IPAddressPool/L2Advertisement CRs.
-flux:
-
-  - name: lb
-    when: workstation.runtime != 'docker-desktop' && lb_effective.enabled
-    install:
-      components:
-        - ${lb_effective.driver}
-        - "${lb_effective.driver == 'kube-vip' ? lb_effective.driver + '/' + (network.loadbalancer_mode ?? 'arp') : ''}"
-        - "${lb_effective.driver == 'kube-vip' && topology == 'single-node' ? 'kube-vip/single-node' : ''}"
-      substitutions:
-        loadbalancer_ip_range: ${network.loadbalancer_ips.start + '-' + network.loadbalancer_ips.end}
-      timeout: 5m
-      interval: 5m
-    resources:
-      - components:
-          - "${lb_effective.driver == 'metallb' ? lb_effective.driver + '/' + (network.loadbalancer_mode ?? 'arp') : ''}"
-        substitutions:
-          loadbalancer_ip_range: ${network.loadbalancer_ips.start + '-' + network.loadbalancer_ips.end}
-        timeout: 5m
-        interval: 5m

--- a/contexts/_template/facets/platform-docker.yaml
+++ b/contexts/_template/facets/platform-docker.yaml
@@ -120,6 +120,7 @@ flux:
       components:
         - ${lb_effective.driver}
         - "${lb_effective.driver == 'kube-vip' ? lb_effective.driver + '/' + (network.loadbalancer_mode ?? 'arp') : ''}"
+        - "${lb_effective.driver == 'kube-vip' && topology == 'single-node' ? 'kube-vip/single-node' : ''}"
       substitutions:
         loadbalancer_ip_range: ${network.loadbalancer_ips.start + '-' + network.loadbalancer_ips.end}
       timeout: 5m

--- a/contexts/_template/facets/platform-hyperv.yaml
+++ b/contexts/_template/facets/platform-hyperv.yaml
@@ -431,6 +431,7 @@ flux:
       components:
         - ${lb_effective.driver}
         - "${lb_effective.driver == 'kube-vip' ? lb_effective.driver + '/' + (network.loadbalancer_mode ?? 'arp') : ''}"
+        - "${lb_effective.driver == 'kube-vip' && topology == 'single-node' ? 'kube-vip/single-node' : ''}"
       substitutions:
         loadbalancer_ip_range: "${network.loadbalancer_ips.start + '-' + network.loadbalancer_ips.end}"
       timeout: 5m

--- a/contexts/_template/facets/platform-hyperv.yaml
+++ b/contexts/_template/facets/platform-hyperv.yaml
@@ -418,28 +418,3 @@ flux:
           - private-issuer/selfsigned
         timeout: 5m
         interval: 5m
-
-  # MetalLB / kube-vip. External switches L2-bridge to the LAN so MetalLB ARP /
-  # Cilium L2 announcements reach it; Internal switches stay host-only.
-  # lb_effective.enabled is false under Cilium (its built-in LB is preferred).
-  # install ships the driver's controller; kube-vip/arp is a patch on that
-  # HelmRelease. resources ships metallb's IPAddressPool / L2Advertisement CRs
-  # (kube-vip needs no resources once install has run).
-  - name: lb
-    when: lb_effective.enabled
-    install:
-      components:
-        - ${lb_effective.driver}
-        - "${lb_effective.driver == 'kube-vip' ? lb_effective.driver + '/' + (network.loadbalancer_mode ?? 'arp') : ''}"
-        - "${lb_effective.driver == 'kube-vip' && topology == 'single-node' ? 'kube-vip/single-node' : ''}"
-      substitutions:
-        loadbalancer_ip_range: "${network.loadbalancer_ips.start + '-' + network.loadbalancer_ips.end}"
-      timeout: 5m
-      interval: 5m
-    resources:
-      - components:
-          - "${lb_effective.driver == 'metallb' ? lb_effective.driver + '/' + (network.loadbalancer_mode ?? 'arp') : ''}"
-        substitutions:
-          loadbalancer_ip_range: "${network.loadbalancer_ips.start + '-' + network.loadbalancer_ips.end}"
-        timeout: 5m
-        interval: 5m

--- a/contexts/_template/facets/platform-incus.yaml
+++ b/contexts/_template/facets/platform-incus.yaml
@@ -143,30 +143,3 @@ terraform:
       # nested VM with slower vCPUs, so higher concurrency floods the apiserver.
       concurrency: ${max(2, min(floor(cluster_resources_effective.controlplanes.cpu / 2), floor(cluster_resources_effective.controlplanes.memory / 2), 10))}
     destroy: false
-
-# =============================================================================
-# Flux systems — MetalLB / kube-vip
-# =============================================================================
-# Incus always has a real bridge network, so MetalLB or kube-vip works whenever
-# an LB is requested. install ships the driver's controller HelmRelease (plus
-# kube-vip's arp patch); resources ships metallb's IPAddressPool/L2Advertisement CRs.
-flux:
-
-  - name: lb
-    when: lb_effective.enabled
-    install:
-      components:
-        - ${lb_effective.driver}
-        - "${lb_effective.driver == 'kube-vip' ? lb_effective.driver + '/' + (network.loadbalancer_mode ?? 'arp') : ''}"
-        - "${lb_effective.driver == 'kube-vip' && topology == 'single-node' ? 'kube-vip/single-node' : ''}"
-      substitutions:
-        loadbalancer_ip_range: "${network.loadbalancer_ips.start + '-' + network.loadbalancer_ips.end}"
-      timeout: 5m
-      interval: 5m
-    resources:
-      - components:
-          - "${lb_effective.driver == 'metallb' ? lb_effective.driver + '/' + (network.loadbalancer_mode ?? 'arp') : ''}"
-        substitutions:
-          loadbalancer_ip_range: "${network.loadbalancer_ips.start + '-' + network.loadbalancer_ips.end}"
-        timeout: 5m
-        interval: 5m

--- a/contexts/_template/facets/platform-incus.yaml
+++ b/contexts/_template/facets/platform-incus.yaml
@@ -158,6 +158,7 @@ flux:
       components:
         - ${lb_effective.driver}
         - "${lb_effective.driver == 'kube-vip' ? lb_effective.driver + '/' + (network.loadbalancer_mode ?? 'arp') : ''}"
+        - "${lb_effective.driver == 'kube-vip' && topology == 'single-node' ? 'kube-vip/single-node' : ''}"
       substitutions:
         loadbalancer_ip_range: "${network.loadbalancer_ips.start + '-' + network.loadbalancer_ips.end}"
       timeout: 5m

--- a/contexts/_template/facets/platform-metal.yaml
+++ b/contexts/_template/facets/platform-metal.yaml
@@ -87,6 +87,7 @@ flux:
       components:
         - ${lb_effective.driver}
         - "${lb_effective.driver == 'kube-vip' ? lb_effective.driver + '/' + (network.loadbalancer_mode ?? 'arp') : ''}"
+        - "${lb_effective.driver == 'kube-vip' && topology == 'single-node' ? 'kube-vip/single-node' : ''}"
       substitutions:
         loadbalancer_ip_range: ${network.loadbalancer_ips.start + '-' + network.loadbalancer_ips.end}
       timeout: 5m

--- a/contexts/_template/facets/platform-metal.yaml
+++ b/contexts/_template/facets/platform-metal.yaml
@@ -71,31 +71,3 @@ terraform:
     inputs:
       concurrency: ${max(4, min(floor(cluster_resources_effective.controlplanes.cpu / 2), floor(cluster_resources_effective.controlplanes.memory / 2), 10))}
     destroy: false
-
-# =============================================================================
-# Flux systems — MetalLB / kube-vip
-# =============================================================================
-# Metal nodes have real IPs, so MetalLB or kube-vip works whenever an LB is
-# requested; skipped when Cilium is the CNI (lb_effective.enabled false). install
-# ships the driver's controller HelmRelease (plus kube-vip's arp patch); resources
-# ships metallb's IPAddressPool/L2Advertisement CRs.
-flux:
-
-  - name: lb
-    when: lb_effective.enabled
-    install:
-      components:
-        - ${lb_effective.driver}
-        - "${lb_effective.driver == 'kube-vip' ? lb_effective.driver + '/' + (network.loadbalancer_mode ?? 'arp') : ''}"
-        - "${lb_effective.driver == 'kube-vip' && topology == 'single-node' ? 'kube-vip/single-node' : ''}"
-      substitutions:
-        loadbalancer_ip_range: ${network.loadbalancer_ips.start + '-' + network.loadbalancer_ips.end}
-      timeout: 5m
-      interval: 5m
-    resources:
-      - components:
-          - "${lb_effective.driver == 'metallb' ? lb_effective.driver + '/' + (network.loadbalancer_mode ?? 'arp') : ''}"
-        substitutions:
-          loadbalancer_ip_range: ${network.loadbalancer_ips.start + '-' + network.loadbalancer_ips.end}
-        timeout: 5m
-        interval: 5m

--- a/contexts/_template/tests/option-single-node.test.yaml
+++ b/contexts/_template/tests/option-single-node.test.yaml
@@ -96,3 +96,69 @@ cases:
             components:
               - cert-manager
               - cert-manager/prometheus
+
+  # kube-vip's per-service leader election has no other node to fail over to on a
+  # single-node cluster, and is the exact mechanism behind a documented, unresolved
+  # upstream bug (kube-vip#475) where a lost lease is never reclaimed.
+  - name: single-node disables kube-vip per-service election
+    values:
+      platform: metal
+      topology: single-node
+      gateway:
+        enabled: true
+        driver: envoy
+      network: *default-network
+      cluster:
+        driver: talos
+        cni:
+          driver: flannel
+        controlplanes:
+          nodes:
+            controlplane-1:
+              endpoint: 10.5.0.10:50000
+              node: 10.5.0.10
+              hostname: controlplane-1
+        workers:
+          volumes:
+            - /var/mnt/local
+    expect:
+      flux:
+        - name: lb
+          install:
+            components:
+              - kube-vip
+              - kube-vip/arp
+              - kube-vip/single-node
+
+  # Note: expect: does subset matching (cli#3103), so this only proves multi-node
+  # still composes kube-vip/arp correctly — it can't assert kube-vip/single-node's
+  # absence. Verified by inspection: the facet's ternary is topology-gated, so it
+  # can only ever add the component, never on multi-node.
+  - name: multi-node topology still composes kube-vip with arp
+    values:
+      platform: metal
+      topology: multi-node
+      gateway:
+        enabled: true
+        driver: envoy
+      network: *default-network
+      cluster:
+        driver: talos
+        cni:
+          driver: flannel
+        controlplanes:
+          nodes:
+            controlplane-1:
+              endpoint: 10.5.0.10:50000
+              node: 10.5.0.10
+              hostname: controlplane-1
+        workers:
+          volumes:
+            - /var/mnt/local
+    expect:
+      flux:
+        - name: lb
+          install:
+            components:
+              - kube-vip
+              - kube-vip/arp

--- a/kustomize/lb/install/kube-vip/single-node/kustomization.yaml
+++ b/kustomize/lb/install/kube-vip/single-node/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: patches/helm-release.yaml

--- a/kustomize/lb/install/kube-vip/single-node/patches/helm-release.yaml
+++ b/kustomize/lb/install/kube-vip/single-node/patches/helm-release.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kube-vip
+  namespace: system-lb
+spec:
+  values:
+    env:
+      svc_election: "false"


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change adds a new opt-in kustomize component that disables kube-vip per-service leader election on single-node clusters; it is purely additive and does not touch multi-node deployments at all.
>
> **Overview**
>
> The PR introduces a `kube-vip/single-node` kustomize component (a HelmRelease patch setting `svc_election: "false"`) and wires it into all four platform facets (docker, hyperv, incus, metal) via an additional ternary expression that fires only when `driver == 'kube-vip' && topology == 'single-node'`. The fix targets a documented upstream bug (kube-vip#475) where a lost service-election lease on a single-node cluster is never reclaimed because there are no other nodes to trigger failover.
>
> The implementation follows the established pattern already used for the `kube-vip/arp` component, and two new test cases cover single-node activation and multi-node pass-through. The test suite acknowledges that subset matching cannot assert the component's absence on multi-node topologies, which is a framework limitation rather than a gap in the fix itself.

<!-- /claude-code-review:summary -->
