### PR TITLE
fix(incus): derive k8s_service_host from cluster.endpoint on bridged networks

### DIFF
--- a/contexts/_template/facets/platform-incus.yaml
+++ b/contexts/_template/facets/platform-incus.yaml
@@ -20,14 +20,16 @@ config:
 
   # openebs is the default storage: Incus's Talos image has no extensions mechanism
   # (unlike metal/cloud image factories), so longhorn's iscsi-tools requirement can't
-  # be met here. Controlplane sits at CIDR offset 10 for a stable k8s_service_host.
+  # be met here. Controlplane sits at CIDR offset 10 for a stable k8s_service_host,
+  # unless an explicit cluster.endpoint says otherwise (bridged networks often put
+  # the controlplane at a DHCP-reserved address instead).
   - name: talos_common
     value:
       storage_driver: "${cluster.storage.driver ?? 'openebs'}"
       longhorn_default_disk:
         - name: longhorn
           size: 30
-      k8s_service_host: "${cidrhost(network.cidr_block, 10)}"
+      k8s_service_host: "${(cluster.endpoint ?? '') != '' ? split(split(cluster.endpoint, '://')[1], ':')[0] : cidrhost(network.cidr_block, 10)}"
 
   # Derivable only from compute output; empty string otherwise, so the caller
   # falls back to an explicit cluster.endpoint.

--- a/contexts/_template/tests/platform-incus.test.yaml
+++ b/contexts/_template/tests/platform-incus.test.yaml
@@ -315,3 +315,46 @@ cases:
     expect:
       flux:
         - name: csi
+
+  # Regression (#2315): a bridged LAN puts the controlplane at a DHCP-reserved
+  # address, not the CIDR offset 10 the compute module assigns. An explicit
+  # cluster.endpoint must drive k8s_service_host, or kube-proxy-replacement
+  # Cilium never reaches the real API server.
+  - name: explicit cluster.endpoint on a bridged network drives k8s_service_host
+    values:
+      platform: incus
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster:
+        driver: talos
+        endpoint: https://192.168.2.160:6443
+        controlplanes:
+          nodes:
+            controlplane-1: *cp1-node
+        workers: *default-workers
+    terraformOutputs: *default-terraform-outputs
+    expect:
+      flux:
+        - name: cni
+          install:
+            substitutions:
+              k8s_service_host: "192.168.2.160"
+
+  # Without an explicit endpoint, the CIDR-offset-10 fallback still applies
+  # (already covered by the minimal-config case above; asserted again here
+  # to pin it directly against this fix rather than incidentally).
+  - name: no cluster.endpoint falls back to CIDR offset 10 for k8s_service_host
+    values:
+      platform: incus
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster: *default-cluster
+    terraformOutputs: *default-terraform-outputs
+    expect:
+      flux:
+        - name: cni
+          install:
+            substitutions:
+              k8s_service_host: "10.5.0.10"


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> The change is isolated to the Incus platform facet and addresses a specific regression; it is fully covered by new tests and has no impact on other platforms or shared infrastructure.
>
> **Overview**
>
> This PR fixes a regression (#2315) where the `k8s_service_host` value for Cilium's kube-proxy-replacement was always derived from `cidrhost(network.cidr_block, 10)`, even when the controlplane sits at a DHCP-reserved address on a bridged LAN. When `cluster.endpoint` is explicitly set, the expression now extracts the hostname from that URL and uses it instead, falling back to the CIDR-offset-10 formula only when no endpoint is provided.
>
> Two regression test cases are added: one confirming that `https://192.168.2.160:6443` resolves to `192.168.2.160`, and one pinning the CIDR-fallback path that was already covered by the minimal-config case.

<!-- /claude-code-review:summary -->
