### PR TITLE
fix(observability): correct quickwit-datasource plugin checksum for v0.6.3

### DIFF
--- a/kustomize/observability/install/grafana/quickwit/patches/helm-release.yaml
+++ b/kustomize/observability/install/grafana/quickwit/patches/helm-release.yaml
@@ -19,9 +19,9 @@ spec:
           - name: PLUGIN_VERSION
             # renovate: datasource=github-releases depName=quickwit-oss/quickwit-datasource package=quickwit-oss/quickwit-datasource
             value: "0.6.3"
-          # SHA256 of quickwit-quickwit-datasource-0.6.1.zip - update when version changes
+          # SHA256 of quickwit-quickwit-datasource-0.6.3.zip - update when version changes
           - name: PLUGIN_SHA256
-            value: 446cada992d4ecee5d0c50977bf4fcca51e20fd5a62efb9bec1ecbd3ed5e99dc
+            value: 0d5b7ef8298e7b421613dda3d84185fde80a595ba3ff75d0d22e9dcb17bdd18f
         args:
           - $(PLUGIN_NAME)
           - $(PLUGIN_VERSION)


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change corrects a stale SHA256 checksum and comment for the Quickwit Grafana datasource plugin, scoped entirely to one Helm release patch file with no shared-infra impact.
>
> **Overview**
>
> The PR fixes a checksum mismatch introduced when the `PLUGIN_VERSION` was bumped to `0.6.3` but the accompanying `PLUGIN_SHA256` and its comment were left pointing at `0.6.1`. The corrected SHA256 (`0d5b7ef…`) now matches the actual `quickwit-quickwit-datasource-0.6.3.zip` artifact, so the Grafana init container will pass verification instead of failing or silently loading a mismatched plugin.
>
> The fix is purely mechanical and self-contained: only the comment and the env-var value change; the version pin, the plugin name, and all surrounding Kustomize/Helm configuration are untouched.

<!-- /claude-code-review:summary -->
