### PR TITLE
fix(observability): pin quickwit searcher to indexer's node to avoid Multi-Attach

### DIFF
--- a/kustomize/observability/install/quickwit/pvc/patches/helm-release.yaml
+++ b/kustomize/observability/install/quickwit/pvc/patches/helm-release.yaml
@@ -24,6 +24,17 @@ spec:
       allowPrivilegeEscalation: true
     searcher:
       replicaCount: 1
+      # quickwit-indexes is ReadWriteOnce, shared with the indexer — pin the
+      # searcher to the indexer's node so both can mount it without a
+      # Multi-Attach failure on multi-node clusters.
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: quickwit
+                  app.kubernetes.io/component: indexer
+              topologyKey: kubernetes.io/hostname
       extraVolumes:
         - name: quickwit-indexes
           persistentVolumeClaim:


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> Isolated Kubernetes scheduling fix scoped to the Quickwit PVC overlay; no data paths, secrets, or cross-cutting infra are touched.
>
> **Overview**
>
> The PR adds a `podAffinity` rule to the Quickwit searcher that requires it to co-schedule on the same node as the indexer. This prevents a Multi-Attach error that occurs on multi-node clusters when the searcher and indexer land on different nodes and both try to mount the same `ReadWriteOnce` PVC (`quickwit-indexes`). The fix is correctly placed in the `pvc/patches/` overlay so it only applies when PVC storage is in use.
>
> One behavioral consequence: `requiredDuringSchedulingIgnoredDuringExecution` makes the searcher strictly unschedulable if no indexer pod is running. If the indexer is evicted or crash-loops, the searcher will enter `Pending` and stay there until the indexer recovers — but this is the correct tradeoff, since without co-location the alternative is both pods failing on mount.

<!-- /claude-code-review:summary -->
