### PR TITLE
fix(incus): powercycle reboot for Talos extensions upgrades

### DIFF
--- a/contexts/_template/facets/option-storage.yaml
+++ b/contexts/_template/facets/option-storage.yaml
@@ -32,6 +32,7 @@ terraform:
       controlplanes: ${talos_node_targets.controlplanes ?? []}
       workers: ${talos_node_targets.workers ?? []}
       extensions: ${talos_common.extensions ?? []}
+      powercycle_reboot: ${platform == 'incus'}
 
   # Dependency merge: Flux waits for extensions so CSI DaemonSets find their kernel modules.
   - name: gitops

--- a/contexts/_template/tests/platform-incus.test.yaml
+++ b/contexts/_template/tests/platform-incus.test.yaml
@@ -358,3 +358,36 @@ cases:
           install:
             substitutions:
               k8s_service_host: "10.5.0.10"
+
+  # Regression (#2319): kexec doesn't reliably register as an offline transition
+  # on Incus's nested virtualization, leaving Talos extension upgrades stuck
+  # reporting the node as still online. powercycle_reboot forces a full ACPI
+  # reset instead, only on Incus (other platforms keep the faster kexec default).
+  - name: longhorn storage driver requests powercycle reboot for extensions on incus
+    values:
+      platform: incus
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster:
+        driver: talos
+        controlplanes:
+          nodes:
+            controlplane-1: *cp1-node
+        workers:
+          count: 1
+          volumes:
+            - /var/mnt/longhorn
+        storage:
+          driver: longhorn
+          local_base_path: /var/mnt/longhorn
+    terraformOutputs: *default-terraform-outputs
+    expect:
+      terraform:
+        - name: cluster-extensions
+          path: cluster/talos/extensions
+          inputs:
+            extensions:
+              - siderolabs/iscsi-tools
+              - siderolabs/util-linux-tools
+            powercycle_reboot: true

--- a/contexts/_template/tests/platform-metal.test.yaml
+++ b/contexts/_template/tests/platform-metal.test.yaml
@@ -291,6 +291,7 @@ cases:
             extensions:
               - siderolabs/iscsi-tools
               - siderolabs/util-linux-tools
+            powercycle_reboot: false
             controlplanes:
               - node: 10.5.0.10
                 endpoint: 10.5.0.10:50000

--- a/terraform/cluster/talos/extensions/README.md
+++ b/terraform/cluster/talos/extensions/README.md
@@ -45,6 +45,7 @@ No modules.
 | <a name="input_context_path"></a> [context\_path](#input\_context\_path) | The path to the context folder, where kubeconfig and talosconfig are stored | `string` | `""` | no |
 | <a name="input_controlplanes"></a> [controlplanes](#input\_controlplanes) | List of controlplane nodes to upgrade. Only node and endpoint are required. | <pre>list(object({<br/>    node     = string<br/>    endpoint = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_extensions"></a> [extensions](#input\_extensions) | Talos Image Factory extension names to install (e.g. ["siderolabs/iscsi-tools"]). | `list(string)` | `[]` | no |
+| <a name="input_powercycle_reboot"></a> [powercycle\_reboot](#input\_powercycle\_reboot) | Use a full ACPI power-cycle reboot instead of the default kexec. Needed on platforms where kexec doesn't reliably register as an offline transition (e.g. nested virtualization). | `bool` | `false` | no |
 | <a name="input_talos_version"></a> [talos\_version](#input\_talos\_version) | The talos version to deploy. | `string` | n/a | yes |
 | <a name="input_workers"></a> [workers](#input\_workers) | List of worker nodes to upgrade. Only node and endpoint are required. | <pre>list(object({<br/>    node     = string<br/>    endpoint = string<br/>  }))</pre> | `[]` | no |
 

--- a/terraform/cluster/talos/extensions/main.tf
+++ b/terraform/cluster/talos/extensions/main.tf
@@ -66,7 +66,7 @@ resource "null_resource" "upgrade_controlplane" {
   }
 
   provisioner "local-exec" {
-    command = "windsor upgrade node --node ${each.value.node} --image ${local.upgrade_image} --timeout 15m"
+    command = "windsor upgrade node --node ${each.value.node} --image ${local.upgrade_image} --timeout 15m${var.powercycle_reboot ? " --reboot-mode powercycle" : ""}"
     environment = {
       TALOSCONFIG = local.talosconfig_path
       KUBECONFIG  = local.kubeconfig_path
@@ -84,7 +84,7 @@ resource "null_resource" "upgrade_worker" {
   }
 
   provisioner "local-exec" {
-    command = "windsor upgrade node --node ${each.value.node} --image ${local.upgrade_image} --timeout 15m"
+    command = "windsor upgrade node --node ${each.value.node} --image ${local.upgrade_image} --timeout 15m${var.powercycle_reboot ? " --reboot-mode powercycle" : ""}"
     environment = {
       TALOSCONFIG = local.talosconfig_path
       KUBECONFIG  = local.kubeconfig_path

--- a/terraform/cluster/talos/extensions/variables.tf
+++ b/terraform/cluster/talos/extensions/variables.tf
@@ -36,3 +36,9 @@ variable "workers" {
   }))
   default = []
 }
+
+variable "powercycle_reboot" {
+  description = "Use a full ACPI power-cycle reboot instead of the default kexec. Needed on platforms where kexec doesn't reliably register as an offline transition (e.g. nested virtualization)."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> Change is gated behind a new boolean Terraform variable defaulting to `false`, only ever set `true` on the Incus platform; no other platform's behavior changes.
>
> **Overview**
>
> Talos's default upgrade reboot uses kexec, which doesn't reliably register as an offline transition on Incus's nested virtualization — `windsor upgrade node` polls the node's version endpoint to detect the reboot, and on Incus that poll kept seeing the node as reachable well past its timeout even though the node eventually did come up on the new image. This PR adds `powercycle_reboot` to `terraform/cluster/talos/extensions`, appending `--reboot-mode powercycle` (a flag added in windsorcli/cli#3124) to the `windsor upgrade node` calls for both controlplanes and workers. `option-storage.yaml` sets it to `${platform == 'incus'}`, so only Incus opts into the slower-but-reliable full ACPI reset; every other platform keeps the fast kexec default unchanged.
>
> **Verification**
>
> Live end-to-end on a fresh 1 controlplane + 2 worker Incus cluster with `cluster.storage.driver: longhorn` (which requires the `siderolabs/iscsi-tools` extension): all three nodes upgraded cleanly on the first attempt, and Longhorn came up fully healthy across both workers. Blueprint test coverage pins `powercycle_reboot: true` for Incus and `false` for metal, verified to fail without the facet wiring.
>
> **One thing worth flagging**: `powercycle_reboot` is opt-in per-platform, not auto-detected. If a future platform hits the same nested-virtualization kexec issue, it will need the same explicit `${platform == '...'}` wiring in `option-storage.yaml` rather than inheriting this fix automatically.

<!-- /claude-code-review:summary -->
