### PR TITLE
fix(cni): reuse_values on cilium bootstrap to stop clobbering Flux-owned config

### DIFF
--- a/terraform/cni/cilium/main.tf
+++ b/terraform/cni/cilium/main.tf
@@ -33,18 +33,17 @@ locals {
 # (hubble, gateway, prometheus, l2, bpf perf, cluster identity).
 #
 # The values below deliberately overlap with the Flux HelmRelease base so the two agree on
-# the baseline (IPAM mode, kube-proxy wiring, operator replicas, Talos capabilities). We do
-# *not* use lifecycle.ignore_changes on `values` here: the hashicorp/helm provider rewrites
-# user-supplied values on every apply regardless of that directive, so the only way to
-# prevent drift between `windsor up` and steady-state is to keep the two sides in sync.
-# Feature patches (hubble, gateway, etc.) live only in Flux — Terraform will not stomp them
-# because it doesn't know about them; Flux reconciles them back on top of this baseline
-# within seconds of any bootstrap re-run.
+# the baseline (IPAM mode, kube-proxy wiring, operator replicas, Talos capabilities).
+# reuse_values makes re-applying this baseline (e.g. a later `windsor up`) merge onto
+# whatever Flux has already layered on top, instead of overwriting the release back to
+# this minimal set — so Flux-owned features (hubble, gateway, l2, prometheus) survive
+# a bootstrap re-run instead of disappearing until Flux's next reconcile.
 
 resource "helm_release" "cilium" {
-  repository = "https://helm.cilium.io"
-  chart      = "cilium"
-  name       = "cilium"
+  repository   = "https://helm.cilium.io"
+  chart        = "cilium"
+  name         = "cilium"
+  reuse_values = true
   # renovate: datasource=helm depName=cilium package=cilium helmRepo=https://helm.cilium.io
   version   = var.cilium_version
   namespace = "kube-system"

--- a/terraform/cni/cilium/test.tftest.hcl
+++ b/terraform/cni/cilium/test.tftest.hcl
@@ -78,6 +78,11 @@ run "minimal_configuration" {
     condition     = helm_release.cilium.take_ownership == true
     error_message = "take_ownership should be true so the bootstrap upgrade can adopt unowned resources like cilium-ca instead of erroring"
   }
+
+  assert {
+    condition     = helm_release.cilium.reuse_values == true
+    error_message = "reuse_values should be true so a bootstrap re-apply merges onto Flux-owned values (hubble, gateway, l2) instead of overwriting them"
+  }
 }
 
 # Verifies privileged=false swaps full-privileged mode for an explicit Linux


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> Isolated change to the Cilium bootstrap Terraform module; reversible and scoped to one resource attribute with a matching test assertion.
>
> **Overview**
>
> This PR adds `reuse_values = true` to the `helm_release.cilium` Terraform resource so that re-running the bootstrap (`windsor up`) performs a `helm upgrade --reuse-values` instead of a plain upgrade. The practical effect is that Flux-managed configuration layered on top of the bootstrap baseline — hubble, gateway, l2, prometheus — survives a bootstrap re-run rather than being wiped and then slowly restored by Flux's next reconcile cycle. A corresponding test assertion is added to `test.tftest.hcl` to lock in this behaviour.
>
> The previous approach relied on keeping the Terraform baseline and the Flux HelmRelease values in sync to avoid drift; this approach instead makes Terraform explicitly defer to whatever Helm has in the live release, which is a simpler invariant to maintain.

<!-- /claude-code-review:summary -->
