### PR TITLE
fix(hetzner): pin kubelet nodeIP to the private subnet

### DIFF
--- a/contexts/_template/facets/platform-hetzner.yaml
+++ b/contexts/_template/facets/platform-hetzner.yaml
@@ -50,11 +50,20 @@ config:
   # Cloud block storage (Hetzner Volumes via hcloud-csi) is the default; the
   # control plane sits at CIDR offset 10 so Cilium's k8sServiceHost is stable and
   # reachable over the private network. compute/hcloud pins the first control
-  # plane's private IP to the same offset.
+  # plane's private IP to the same offset. Every node also has a public NIC;
+  # nodeIP.validSubnets pins kubelet to the private one, since with no hint it
+  # picks the default route (public), and the apiserver then can't reach it on
+  # 10250 past the hcloud firewall.
   - name: talos_common
     value:
       storage_driver: "${cluster.storage.driver ?? 'hcloud'}"
       k8s_service_host: "${cidrhost(network.cidr_block ?? '10.5.0.0/16', 10)}"
+      common_patch:
+        machine:
+          kubelet:
+            nodeIP:
+              validSubnets:
+                - "${network.cidr_block ?? '10.5.0.0/16'}"
 
   # vCPU/memory (GB) by Hetzner instance type. Hetzner sizes nodes via
   # instance_type, not cluster.controlplanes.cpu/memory, so this map feeds the

--- a/contexts/_template/tests/platform-hetzner.test.yaml
+++ b/contexts/_template/tests/platform-hetzner.test.yaml
@@ -129,6 +129,9 @@ cases:
                 kubelet:
                   extraArgs:
                     rotate-server-certificates: "true"
+                  nodeIP:
+                    validSubnets:
+                    - 10.5.0.0/16
         # multi-node topology, not the single-node replica count of 1
         - name: cni
           path: cni/cilium


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change is isolated to the Hetzner platform facet template and fixes a concrete kubelet connectivity bug; it is easily reversible and affects no other providers.
>
> **Overview**
>
> Hetzner nodes have both a public and a private NIC. Without a hint, kubelet selects the default-route interface (public), registering its public IP with the apiserver. Because the Hetzner cloud firewall blocks inbound port 10250, the apiserver cannot reach the kubelet for exec, log streaming, or port-forward. The fix adds `kubelet.nodeIP.validSubnets` set to the private network CIDR inside `common_patch`, forcing kubelet to bind to the private interface. A matching test assertion verifies the subnet is merged correctly alongside the existing `extraArgs` in the final `common_config_patches` output.
>
> Existing Hetzner clusters will receive this new machine patch on their next Talos upgrade cycle, which is the expected and intended deployment path.

<!-- /claude-code-review:summary -->
