### PR TITLE
chore(ci): treat 'breaking' as a minor bump in release-drafter pre-1.0

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -24,10 +24,10 @@ version-resolver:
   major:
     labels:
       - 'major'
-      - 'breaking'
   minor:
     labels:
       - 'feature'
+      - 'breaking'
   patch:
     labels:
       - 'fix'


### PR DESCRIPTION
## What

`.github/release-drafter.yml`'s `version-resolver` mapped the `breaking` label to a major bump. Only `major` triggers major now; `breaking` maps to minor alongside `feature`.

## Why

PR #2348 (`feat(schema)!: flatten addons.* into top-level capability keys`) carries the `breaking` label, which pushed the auto-drafted next release from `v0.6.0` straight to `v1.0.0`. Pre-1.0 semver already signals "the API can change" at 0.x, so a breaking-change PR shouldn't force a jump to `v1.0.0` on its own — that should be a deliberate decision (the explicit `major` label), not an automatic side effect of labeling a PR accurately.

Once this merges, the next push to `main` reruns `release-drafter` and the stale `v1.0.0` draft recomputes to `v0.7.0` (minor bump from `v0.6.0`, consistent with the `v0.7.0-rc.1` prerelease already cut).

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change touches only release automation configuration and has no effect on running code or infrastructure.
>
> **Overview**
>
> The PR moves the `breaking` label from the `major` bucket to the `minor` bucket in the release-drafter version resolver. The stated motivation is that pre-1.0 semver (0.x) already signals instability, so a PR tagged `breaking` should increment the minor version (e.g. 0.4.0 → 0.5.0) rather than unexpectedly promote the project to v1.0.0. The only way to trigger a major bump is now the explicit `major` label.
>
> One thing to be aware of going forward: the `breaking` label is not listed in any `categories` entry, so PRs carrying it will affect the computed version without appearing as a named section in the generated release notes — but this was true before this change as well.

<!-- /claude-code-review:summary -->
