### PR TITLE
fix(workstation/docker): split docker-desktop DNS host/cluster answers by port, not client IP

### DIFF
--- a/terraform/workstation/docker/main.tf
+++ b/terraform/workstation/docker/main.tf
@@ -45,9 +45,11 @@ locals {
   registries = coalesce(var.registries, {})
   # Fixed layout: 1=gateway, 2=dns, 3=git, 4..(node_start_offset-1)=registries, node_start_offset=first node.
   # Registries fill a reserved block so adding/removing one never shifts the first-node IP returned by next_ip.
-  gateway              = cidrhost(var.network_cidr, 1)
-  dns_ip               = cidrhost(var.network_cidr, 2)
-  git_ip               = cidrhost(var.network_cidr, 3)
+  gateway = cidrhost(var.network_cidr, 1)
+  dns_ip  = cidrhost(var.network_cidr, 2)
+  git_ip  = cidrhost(var.network_cidr, 3)
+  # docker-desktop only: internal port the published host port 53 DNATs to.
+  dns_host_answer_port = 5300
   registry_ip_base     = 4
   registry_ip_capacity = var.node_start_offset - local.registry_ip_base
   registry_keys_sorted = sort(keys(local.registries))
@@ -88,7 +90,7 @@ locals {
     host_entries             = local.corefile_host_entries
     dns_forward_target       = local.dns_forward_target
     use_localhost_networking = local.use_localhost_networking
-    gateway                  = local.gateway
+    host_answer_port         = local.dns_host_answer_port
   }) : ""
 }
 
@@ -173,7 +175,7 @@ resource "docker_container" "dns" {
   dynamic "ports" {
     for_each = local.publish_ports ? [1] : []
     content {
-      internal = 53
+      internal = local.dns_host_answer_port
       external = 53
       ip       = "127.0.0.1"
       protocol = "tcp"
@@ -182,7 +184,7 @@ resource "docker_container" "dns" {
   dynamic "ports" {
     for_each = local.publish_ports ? [1] : []
     content {
-      internal = 53
+      internal = local.dns_host_answer_port
       external = 53
       ip       = "127.0.0.1"
       protocol = "udp"

--- a/terraform/workstation/docker/templates/Corefile.tpl
+++ b/terraform/workstation/docker/templates/Corefile.tpl
@@ -1,8 +1,5 @@
 %{ if use_localhost_networking ~}
-${context}:53 {
-    view host {
-        expr client_ip() == '${gateway}'
-    }
+${context}:${host_answer_port} {
     template IN A {
         match "^.*\.${context}\.$"
         answer "{{ .Name }} 60 IN A 127.0.0.1"

--- a/terraform/workstation/docker/test.tftest.hcl
+++ b/terraform/workstation/docker/test.tftest.hcl
@@ -177,8 +177,23 @@ run "full_configuration" {
   }
 
   assert {
-    condition     = strcontains(one(docker_container.dns[0].upload).content, "view host") && strcontains(one(docker_container.dns[0].upload).content, "client_ip() == '10.20.0.1'")
-    error_message = "docker-desktop Corefile should gate the wildcard 127.0.0.1 answer to the bridge gateway IP via a view block"
+    condition     = strcontains(one(docker_container.dns[0].upload).content, "local.dev:5300")
+    error_message = "docker-desktop Corefile should answer the wildcard 127.0.0.1 record on the host-only internal port"
+  }
+
+  assert {
+    condition     = !strcontains(one(docker_container.dns[0].upload).content, "view host")
+    error_message = "docker-desktop Corefile should not gate on client_ip; source IPs are indistinguishable on this platform"
+  }
+
+  assert {
+    condition     = [for p in docker_container.dns[0].ports : p.internal if p.external == 53 && p.protocol == "tcp"][0] == 5300
+    error_message = "Published host port 53 should DNAT to the internal host-only answer port"
+  }
+
+  assert {
+    condition     = [for p in docker_container.dns[0].ports : p.internal if p.external == 53 && p.protocol == "udp"][0] == 5300
+    error_message = "Published host port 53 should DNAT to the internal host-only answer port (udp)"
   }
 }
 

--- a/terraform/workstation/docker/test.tftest.hcl
+++ b/terraform/workstation/docker/test.tftest.hcl
@@ -187,12 +187,12 @@ run "full_configuration" {
   }
 
   assert {
-    condition     = [for p in docker_container.dns[0].ports : p.internal if p.external == 53 && p.protocol == "tcp"][0] == 5300
+    condition     = try([for p in docker_container.dns[0].ports : p.internal if p.external == 53 && p.protocol == "tcp"][0], null) == 5300
     error_message = "Published host port 53 should DNAT to the internal host-only answer port"
   }
 
   assert {
-    condition     = [for p in docker_container.dns[0].ports : p.internal if p.external == 53 && p.protocol == "udp"][0] == 5300
+    condition     = try([for p in docker_container.dns[0].ports : p.internal if p.external == 53 && p.protocol == "udp"][0], null) == 5300
     error_message = "Published host port 53 should DNAT to the internal host-only answer port (udp)"
   }
 }


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change is scoped entirely to the docker workstation provider and only affects local development environments running Docker Desktop.
>
> **Overview**
>
> The PR replaces a fragile `client_ip()`-based split-horizon DNS approach in CoreDNS with a port-based one. Previously, a `view` block gated the wildcard `127.0.0.1` answer on traffic originating from the bridge gateway IP; on Docker Desktop, all source IPs are NAT'd indistinguishably, so that check was unreliable. The fix introduces a dedicated internal port (`5300`) that Docker's DNAT maps from the published host port 53, allowing CoreDNS to distinguish host-facing from cluster-facing queries purely by which port receives them.
>
> The Corefile template loses the `view host` block and gains a `${host_answer_port}` binding parameter; the `gateway` variable is removed from the template args. Tests are updated with four precise assertions covering the port mapping and the absence of the now-incorrect `view` block.

<!-- /claude-code-review:summary -->
