### PR TITLE
chore(docs): track docs/adr/ in git, add v0.8.0 ADR sequence and roadmap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,3 @@ contexts/**/.gcp/
 .cursor/
 .vscode/*.local.*
 
-# docs/ is committed, except docs/adr/ and docs/plans/, which are internal
-# records and planning notes kept local.
-docs/adr/
-docs/plans/

--- a/docs/adr/0001-internal-external-gateways-and-dns.md
+++ b/docs/adr/0001-internal-external-gateways-and-dns.md
@@ -1,0 +1,358 @@
+---
+title: "ADR-0001: Split external and internal gateways, DNS, and endpoints"
+description: Replace the single gateway and the global gateway.access flip with two optional gateways (external and internal), each provisioned from its domain and carrying its own load balancer, certificate issuer, and DNS zone, so utility services bind to the internal endpoint and applications choose their gateway per route.
+---
+
+# ADR-0001: Split external and internal gateways, DNS, and endpoints
+
+## Status
+
+Proposed (2026-06-25). A prior attempt landed milestones 1-3 on
+`feat/gateway-external-internal-split`, but that branch was never merged and
+is not an ancestor of `main` — the running code is still exactly the
+pre-ADR single-gateway, single-domain, `gateway.access`-driven model
+described in Context below. All three milestones remain to be done, either
+by rebasing that branch onto current `main` or redoing the work.
+
+## Context
+
+Today the blueprint exposes one Gateway object, named `external`, in
+`system-gateway`. A single global knob, `gateway.access: public | private`,
+decides what that one gateway is. Setting it to `private` cascades through
+several facets at once: the cloud load balancer scheme flips to internal
+(`aws-load-balancer-scheme: internal`, `azure-load-balancer-internal: true`),
+external-dns publishes to `dns.private_domain` instead of `dns.public_domain`,
+and the gateway certificate switches from the `public-acme` issuer to a
+`private` self-signed or CA issuer.
+
+Every HTTPRoute attaches to that one gateway. Utility services
+(`grafana`, `kibana`, the Flux web UI) attach the same way, with hostnames
+resolved from a single `external_domain` substitution that is the public
+domain when set and the private domain otherwise.
+
+The model is all-or-nothing. A cluster is either entirely public or entirely
+private. There is no way to run both at once, which is the normal production
+posture: applications reachable from the internet on `app.example.com`, and
+operational surfaces (dashboards, log viewers, the GitOps UI) reachable only
+from inside the VPC or the operator's network. The current workaround is to
+make the whole cluster private and reach apps some other way, or make it
+public and accept that the dashboards inherit the public gateway's domain and
+exposure.
+
+Three forces make the single-gateway model wrong as the blueprint grows:
+
+- **Exposure is per-service, not per-cluster.** Whether something faces the
+  internet is a property of the individual route, not a cluster-wide setting.
+  A global flip cannot express "these routes external, those routes internal."
+- **Utility services have a fixed answer.** Operational surfaces should never
+  be on an internet-facing endpoint. That intent is currently advisory;
+  nothing in the model enforces it, and on a public cluster the dashboards are
+  published to the public zone.
+- **Local development cannot rehearse the split.** A developer on
+  docker-desktop or Talos has one gateway and one domain (`*.test`), so the
+  external/internal distinction that matters in production is invisible until
+  it reaches a cloud context.
+
+The pieces needed for a split already exist independently. The schema carries
+both `dns.public_domain` and `dns.private_domain`. The PKI layer issues from
+both a public issuer (`public-acme` or `public-selfsigned`) and a private one
+(`private-selfsigned` or `private-ca`). The cloud platform facets already know
+how to annotate a load balancer as internal or internet-facing. What is
+missing is two endpoints to attach these to at the same time.
+
+This follows the common Kubernetes pattern of running two ingress points split
+by audience: an external (internet-facing) one and an internal one, each behind
+its own load balancer, with each workload choosing the one it attaches to. The
+classic form is two ingress controllers split by `ingressClassName`; the
+Gateway API form, which the blueprint already uses, is two `Gateway` objects
+chosen through `parentRefs`.
+
+## Decision
+
+Run two optional gateways, distinguished by audience, each provisioned from its
+domain, and let each route choose which one it attaches to.
+
+### Two optional gateways
+
+Add a second Gateway object alongside the existing `external` one in
+`system-gateway`:
+
+| gateway | audience | provisioned when | domain | issuer | load balancer |
+|---------|----------|------------------|--------|--------|---------------|
+| **external** | internet | `dns.public_domain` set, or a tunnel driver configured | `dns.public_domain`, wildcard `*.<public_domain>` | `public-acme` or `public-selfsigned` | internet-facing scheme / routable IP |
+| **internal** | operators, in-VPC, workstation | `dns.private_domain` set | `dns.private_domain`, wildcard `*.<private_domain>` | `private-ca` or `private-selfsigned` | internal scheme / private IP pool |
+
+Each gateway has the same listener set the single gateway has today (HTTP on
+80, HTTPS on 443, plus the conditional DNS and Flux-webhook listeners where
+they apply), its own terminating TLS Secret, and its own data plane.
+
+### Both gateways are optional and symmetric
+
+Neither gateway is mandatory. Each is provisioned only when its domain is set,
+the same rule on both sides: the external gateway when `dns.public_domain` is
+set (or a tunnel driver is configured, which is the only other way external
+traffic reaches the cluster), the internal gateway when `dns.private_domain` is
+set. A cluster with neither domain has no ingress at all; a cluster with one
+domain has one gateway; a cluster with both has both.
+
+Only workstation/dev mode supplies a default domain: `dns.private_domain`
+defaults to `test` there, so a local cluster comes up with an internal gateway
+without configuration. In every other mode nothing is defaulted; the prior
+fallback of `dns.private_domain` to `dns.domain` is dropped. If neither domain
+is set, no gateway, load balancer, certificate, or DNS record is created.
+`dns.public_domain` is never auto-filled in any mode, so the external gateway
+and its internet-facing load balancer are always opt-in.
+
+### Vocabulary follows each layer's convention
+
+The naming keeps each subsystem's native term rather than forcing one word
+across all of them:
+
+- **Gateways and load balancers** use **external / internal**, matching the
+  Kubernetes ingress-class convention and the cloud load-balancer scheme words
+  (`internet-facing` / `internal`). The existing Gateway is already named
+  `external`, so it keeps its name and the new one is `internal`.
+- **DNS and certificates** use **public / private**, matching
+  `dns.public_domain`, `dns.private_domain`, the public/private hosted zones,
+  and the `public-*` / `private-*` issuer names already in the PKI layer.
+
+The two axes map one to one: external gateway ↔ `public_domain` ↔ public zone ↔
+public issuer ↔ internet-facing load balancer; internal gateway ↔
+`private_domain` ↔ private zone ↔ private issuer ↔ internal load balancer.
+
+### Exposure becomes route binding, not a global flip
+
+A route's audience is the gateway it names in `parentRefs`. This replaces the
+global `gateway.access` knob:
+
+- Utility and system routes bind to the **internal** gateway only. This is
+  fixed in the kustomize components; it is not an operator choice. An
+  internal-only utility therefore needs `dns.private_domain` set: workstation/dev
+  mode supplies `test` automatically, and other modes require the operator to
+  set it, with no internal gateway and no utilities exposed until they do.
+- Application routes name whichever gateway they need. The blueprint does not
+  own application routes, so it imposes no global default; the demo routes it
+  ships bind to the internal gateway.
+
+`gateway.access` is deprecated. Its old values map onto the new domain-driven
+provisioning so existing contexts compose to the same result: a cluster that
+set `gateway.access: private` already has only `dns.private_domain`, so it gets
+exactly one gateway, the internal one. A cluster that set `gateway.access:
+public` with a `dns.public_domain` gets the external gateway, plus an internal
+gateway for its utilities, which is the intended change.
+
+### One load balancer per gateway
+
+Each gateway gets its own load balancer, wired by the platform facet:
+
+- **AWS:** two NLBs. The external gateway's service carries
+  `aws-load-balancer-scheme: internet-facing`; the internal gateway's carries
+  `internal`.
+- **Azure:** two Standard load balancers. The internal gateway's service
+  carries `azure-load-balancer-internal: true`; the external one does not.
+- **metallb / Cilium LBIPAM (Talos, incus, metal):** two addresses, the
+  internal one from the cluster pool and the external one from whatever range
+  is routable for that environment. On a flat home LAN both may sit on the same
+  subnet; "external" is relative to the environment, and that is acceptable.
+- **NodePort (docker-desktop, hyperv):** two node-port sets, both published by
+  the workstation forwarder, so both domains resolve locally.
+- **Tunnel (planned):** a future tunnel driver (cloudflared or equivalent)
+  fronts the external gateway only and its service drops to `ClusterIP`; the
+  internal gateway is never tunneled.
+
+This is the load-balancer side of the framing: an internal load balancer points
+at the internal gateway and an external load balancer points at the external
+one, and routing a service is a matter of which gateway it attaches to.
+
+Today the Envoy load-balancer annotations are set once, globally, on the
+envoy-gateway HelmRelease (`base/envoy/loadbalancer/patches/helm-release.yaml`
+patches the shared `envoyService`). Two gateways with different schemes cannot
+share one global service config. Each gateway must reference its own
+`EnvoyProxy` resource through `spec.infrastructure.parametersRef`, so the
+external and internal data-plane services are provisioned and annotated
+independently. The Cilium driver already gives each Gateway its own service
+through `infrastructure.annotations`, so the LBIPAM IP and a distinct
+sharing-key move onto the per-gateway annotations.
+
+### DNS routes by hostname suffix
+
+external-dns runs with both `dns.public_domain` and `dns.private_domain` in its
+domain filters. External-gateway routes use `*.<public_domain>` hostnames and
+publish to the public zone; internal-gateway routes use `*.<private_domain>`
+hostnames and publish to the private zone. Because the two domains are distinct,
+the suffix selects the zone with no per-gateway external-dns instance. The
+existing cloud zone-id filters continue to scope each zone to its hosted-zone or
+Azure resource id.
+
+Suffix routing assumes the two domains differ, which is the cloud default. When
+they are equal (a single-domain or split-horizon setup), the suffix no longer
+tells the zones apart and each hostname must be unique to one gateway; see Local
+development and the split-horizon alternative.
+
+### Local development
+
+Workstation mode supplies `dns.private_domain: test` by default, so a plain
+local cluster comes up with a single internal gateway at `*.test` and no
+external exposure.
+
+To rehearse both gateways locally, also set `dns.public_domain`. Two
+arrangements work:
+
+- **Distinct domains (recommended):** `dns.private_domain: private.test`,
+  `dns.public_domain: public.test`. The workstation resolver resolves both
+  `*.private.test` and `*.public.test` to the cluster ingress, so
+  `grafana.private.test` lands on the internal gateway and `app.public.test` on
+  the external one. This mirrors the cloud distinct-domain model exactly,
+  including external-dns suffix routing.
+- **Single domain:** the same value, e.g. `local.test`, for both. Both gateways
+  are still provisioned, each from its own domain field. Because the workstation
+  runs one CoreDNS, every unique hostname gets one record pointing at whichever
+  gateway its route binds to (`grafana.local.test` internal, `app.local.test`
+  external). This exercises the single-domain data path that the cloud
+  split-horizon work will later build on.
+
+A single local resolver cannot faithfully reproduce true split-horizon: the
+same FQDN answering with the internal load balancer to in-network clients and
+the external one to outside clients. That depends on two vantage points and two
+zones, which exist only on a cloud platform. Locally, either each hostname lives
+on one gateway (single domain) or the two gateways use distinct domains; the
+same-name-two-answers case is validated in a cloud context.
+
+## Consequences
+
+Operational surfaces are internal by construction. Utility routes name the
+internal gateway in the kustomize component, so a public cluster no longer
+publishes its dashboards to the public zone. This is the central goal.
+
+Operators gain a coherent two-endpoint model and lose the single
+`gateway.access` flip. The migration is quiet: existing private clusters keep
+exactly one gateway (now named `internal` rather than `external`), and existing
+public clusters gain an internal gateway they did not have, which is additive.
+
+In-repo routes that hardcode `name: external` are repointed as part of the
+migration: utility routes to `internal`, demo routes likewise. A private-only
+cluster no longer has a Gateway named `external`, so any out-of-repo route that
+hardcoded that name must move to `internal`. The Gateway name `external` is not
+renamed, but its meaning narrows to internet-facing only.
+
+The Envoy driver needs per-gateway `EnvoyProxy` resources rather than the one
+global `envoyService` patch. This is the largest piece of implementation work
+and touches the `base/envoy/loadbalancer` and `nodeport` patch trees. The
+Cilium driver needs the LBIPAM annotations moved onto each gateway's
+`infrastructure.annotations`, with a distinct sharing-key per gateway.
+
+Up to two certificates are issued, one per provisioned gateway, from two
+issuers. The internal gateway's wildcard comes from the private issuer and the
+external one from the public issuer, which is already how the issuers are
+selected today, now applied once per gateway rather than once per cluster.
+
+The blueprint runs two data planes where it ran one whenever both domains are
+set, which costs additional load-balancer resources on cloud platforms and an
+additional address from the metallb pool. A cluster with only one domain pays
+for only one, since the other gateway is not provisioned.
+
+Application exposure moves into the application's own route definition. This is
+more explicit than a cluster setting and is the correct altitude, since the
+blueprint does not own application routes. A future per-service `expose:
+external | internal | both` field could desugar into the right `parentRefs` if
+authoring sugar proves worthwhile; it is deferred until there is demand.
+
+## Alternatives considered
+
+**Keep one gateway, add per-route external/internal listeners (rejected).** A
+single Gateway can carry both an external and an internal listener, with routes
+attaching to one section. This fails at the load balancer: one Gateway maps to
+one data-plane service and one load balancer, so a single internet-facing LB
+would still front the "internal" listener. The split has to exist at the
+load-balancer boundary, which means two services, which means two gateways.
+
+**Keep `gateway.access` and add a second, parallel knob (rejected).** Adding
+`gateway.internal_access` or similar doubles the global flips without making
+exposure a per-route property. It still cannot express a mix of external and
+internal routes on one cluster, which is the requirement.
+
+**Always provision the internal gateway (rejected).** An earlier draft made the
+internal gateway mandatory and the external one opt-in. Keying both to their
+domains is simpler and symmetric, follows the common convention where neither
+endpoint is special, and lets a public-only cluster exist without an unused
+internal gateway. Because `dns.private_domain` still defaults to `test` in
+workstation/dev mode, the internal gateway is present locally without
+configuration; other modes opt in by setting the domain, the same as the
+external side.
+
+**Force one vocabulary across all layers (rejected).** Renaming
+`dns.public_domain` to `external_domain`, or the Gateway to `public`, would make
+one word span DNS, gateways, and load balancers. Each subsystem already has an
+entrenched convention (public/private hosted zones and issuers; internal/
+external ingress classes and LB schemes), and aligning to those reads more
+naturally to operators than a single coined term. The one-to-one mapping is
+stated once and is easy to follow.
+
+**Split-horizon on a single domain (deferred).** Serving the same domain from
+both a public and a private zone, with the private view resolving to the
+internal gateway, avoids a second domain. It needs per-gateway external-dns
+instances scoped to each zone and careful resolver precedence, and it muddies
+certificate issuance because one name maps to two issuers. Distinct public and
+private domains keep zone routing to a hostname-suffix match and keep one issuer
+per name. Split-horizon can be layered later for operators who require a single
+domain.
+
+**A per-service `expose:` schema field now (deferred).** Cleaner for
+application authors than hand-writing `parentRefs`, but it is sugar over the
+route binding this ADR establishes, and the binding has to exist first. Deferred
+until the two-gateway model is in place and demand is clear.
+
+## Implementation milestones
+
+Each milestone is one PR. The work is core-only; no cli api or composer change
+is needed, since the split is expressed entirely in kustomize routes and facet
+wiring.
+
+1. **core — per-gateway data-plane plumbing.** Refactor the load-balancer
+   wiring so each Gateway carries its own service configuration: a per-gateway
+   `EnvoyProxy` referenced through `spec.infrastructure.parametersRef` for the
+   Envoy driver, and per-gateway `infrastructure.annotations` (with a distinct
+   LBIPAM sharing-key) for Cilium, replacing the global `envoyService` patch.
+   The EnvoyProxy must be self-contained — it carries the Kyverno digest-pin
+   `envoyDeployment` patch as well as the `envoyService` config, and the
+   EnvoyGateway helm config keeps no default `envoyProxy` patch. Attaching an
+   EnvoyProxy makes the controller merge it against the EnvoyGateway defaults,
+   and on 1.8.1 a patch-bearing default breaks that merge (`mergeType:
+   StrategicMerge` errors on the opaque `patch.value.spec`; `JSONMerge`
+   duplicates listener ports). Emptying the default and letting the EnvoyProxy
+   be authoritative renders the same data plane. Verified end-to-end on a live
+   cluster: Gateway `Programmed=True`, ports unchanged, digest pin preserved.
+
+2. **core — split into external and internal gateways.** Turn the single
+   gateway resource into two domain-gated Gateways with their per-platform load
+   balancer schemes, per-gateway issuer and certificate, and the external-dns
+   suffix routing. Deprecate `gateway.access`, mapping its values onto the
+   domain-driven provisioning. Repoint every in-repo route atomically in the
+   same PR (utilities and the DNS and Flux-webhook listeners to `internal`, demo
+   routes likewise), so no commit leaves a route pointing at a gateway that does
+   not exist. Depends on (1). Landable per-driver (envoy, then cilium) or
+   per-platform if review size warrants.
+
+3. **core — local rehearsal and docs.** Extend the workstation resolver to
+   resolve both `*.<private_domain>` and `*.<public_domain>` locally, set
+   `private.test` and `public.test` in the local context values, update the
+   gateway and dns stack READMEs, and move this ADR to Accepted. Depends on (2).
+
+## References
+
+- Current single gateway: `kustomize/gateway/resources/gateway.yaml`,
+  `kustomize/gateway/resources/certificate.yaml`.
+- Global Envoy LB config to be made per-gateway:
+  `kustomize/gateway/base/envoy/loadbalancer/patches/helm-release.yaml`,
+  `kustomize/gateway/base/envoy/nodeport/patches/helm-release.yaml`.
+- Cilium per-gateway annotations:
+  `kustomize/gateway/resources/cilium/patches/gateway.yaml`.
+- Domain, issuer, and access resolution:
+  `contexts/_template/facets/option-gateway.yaml`,
+  `contexts/_template/facets/platform-aws.yaml`,
+  `contexts/_template/facets/platform-azure.yaml`.
+- Utility route to repoint to the internal gateway:
+  `kustomize/observability/grafana/gateway/httproute.yaml`.
+- Schema fields: `dns.public_domain`, `dns.private_domain`, `gateway.access`
+  in `contexts/_template/schema.yaml`.
+</content>

--- a/docs/adr/0002-cluster-secrets-management.md
+++ b/docs/adr/0002-cluster-secrets-management.md
@@ -1,0 +1,229 @@
+---
+title: "ADR-0002: Cluster secrets — ExternalSecret materialization over the shipped sensitive/secrets: mechanism"
+description: "The sensitive: schema marker and the flux: system secrets:/data: mechanism are shipped (plain Secret only, cli #3022/#3091/#3100). This ADR decides how the same facet-authored secrets: entries materialize as an ExternalSecret instead, once ADR-0004 (External Secrets Operator) and ADR-0005 (secrets store) are both enabled — no new driver field, no schema key collision with the existing build-time secrets: block."
+---
+
+# ADR-0002: Cluster secrets — ExternalSecret materialization over the shipped sensitive/secrets: mechanism
+
+## Status
+
+Proposed (2026-07-20). Revised (2026-08-04): the plain-`Secret` path is
+shipped and in production use — the `sensitive:` schema marker and a
+`flux:`-system `secrets:` block already materialize a Kubernetes `Secret`
+end to end (cli #3022, #3091; live in five core facets, see Shipped below).
+This ADR is rescoped to the one thing left: materializing the same
+`secrets:` entries as an `ExternalSecret` instead, once
+[ADR-0004](0004-external-secrets-operator.md) (the controller) and
+[ADR-0005](0005-secrets-store.md) (a store) are both enabled. `sops` is
+dropped from this ADR's scope — no consumer needs it today; see Open
+questions.
+
+## Context
+
+### The problem
+
+A facet often needs a Secret inside a Flux-owned namespace — the
+motivating case was the Alertmanager Slack webhook token in
+`system-telemetry`. Terraform can only write Secrets into namespaces it
+owns (`flux-system`), and each add-on namespace is created later by its
+own Flux Kustomization, so there was no committed-to-git path to get a
+value there. The shipped mechanism below closes that gap; a prior
+Cloudflare-token workaround that cloned a Secret cross-namespace with
+Kyverno is no longer needed for any new consumer.
+
+### Shipped: sensitive properties materialize as a plain Secret
+
+A schema property can be marked **`sensitive: true`** (5 properties in
+`contexts/_template/schema.yaml` today: `hetzner.token`,
+`telemetry.alerts.slack.webhook_url`, `pki.private_ca.cert`/`.key`,
+`gitops.webhook.token`). A facet wires one into a `flux:` system with a
+`secrets:` block — key names the generated `Secret`, `data:` maps its
+keys to sensitive property references, and an optional `namespaces:`
+list targets more than one namespace (used by `addon-private-ca.yaml`
+and `platform-hetzner.yaml`'s `pki` entry to land the same secret in
+`system-pki` alongside its owning system):
+
+```yaml
+# facet
+flux:
+  - name: telemetry
+    secrets:
+      alertmanager-notification-slack:
+        data:
+          url: ${telemetry.alerts.slack.webhook_url}
+```
+
+At composition `cli` resolves the referenced value and writes a plain
+Opaque `Secret` into the target namespace(s), ordered after the owning
+system's `install` Kustomization. Five facets use this today
+(`addon-identity.yaml`, `addon-observability.yaml`,
+`addon-private-ca.yaml`, `platform-hetzner.yaml`, `platform-base.yaml`).
+This ADR is about giving that same `secrets:` entry a second
+materialization, not about changing how a facet author writes one.
+
+### How secret references actually work in `cli` (verified from source)
+
+This matters because earlier drafts of this ADR invented mechanisms
+that don't match it:
+
+- **A secret reference is an expression, written inline where a value
+  is needed** — `secret("vault", "item", "field")`, or dotted sugar
+  `secrets.op.<vault>.<item>.<field>` / `secrets.sops.<key.path>`
+  (`NormalizeExpression`). There is no "named secret catalog" concept.
+- **`secret.`/`secrets.` are reserved expression prefixes.** The
+  evaluator (`evaluator.go:305`) normalizes first; `secrets.op.*` /
+  `secrets.sops.*` resolve as secrets, anything else falls through to a
+  normal config-path lookup. Only `op` and `sops` are recognized
+  providers in the dotted form.
+- **Two-pass evaluation.** During composition `secret()` returns a
+  `DeferredError` and stays raw; after terraform apply,
+  `handler.go:resolveDeferredSubstitutions` re-evaluates with
+  `evaluateDeferred=true` and resolves it into the substitution/ConfigMap.
+- **`cli` can parse without resolving** — `parseSecretNotationParts` /
+  `parseHelperParams` extract `(vault, item, field)` from a `secret()`
+  expression. Needed for the ExternalSecret path, which must keep the
+  coordinates, not fetch the value.
+- **The existing `secrets:` block means one specific thing already** —
+  providers backing build-time `secret()` references (`onepassword.vaults`
+  today). Manager's own schema explicitly flags the collision risk of
+  reusing this key for anything else: *"Core's `secrets` block is the set
+  of providers backing build-time `secret()` references, not an in-cluster
+  secrets backend; a management-side store needs its own key rather than
+  an extra property there."* This ADR takes that warning at face value —
+  no `driver` field goes under `secrets:`. See Decision.
+
+### Namespaces and Flux ordering
+
+A `flux:` **system** compiles to an `install` Kustomization (which owns
+the namespace via `install/namespace.yaml`) plus `resources`
+Kustomizations that implicitly `dependsOn` it. So a secret tied to a
+system lands in that system's namespace, correctly ordered, for free.
+
+## Decision
+
+### 1. No new field on the existing `secrets:` block
+
+The materialization a `flux:`-system `secrets:` entry gets is *implicit*,
+not a schema toggle: plain `Secret` when
+[ADR-0005](0005-secrets-store.md)'s `secrets_store.enabled` is `false`
+(today's shipped behavior, unchanged), `ExternalSecret` when both
+[ADR-0004](0004-external-secrets-operator.md)'s `external_secrets.enabled`
+and `secrets_store.enabled` are `true`. There is no `secrets.driver`
+enum, and nothing is added to the build-time `secrets:` block — avoiding
+exactly the key collision Manager's own schema comment calls out.
+
+### 2. Composition materializes each entry by whether a store is present
+
+At composition, for each `flux:`-system `secrets:` entry, windsor
+resolves the referenced sensitive property to its raw config
+expression:
+
+- **Store absent** — resolve the value (deferred pass), emit a plain
+  `Secret`. Unchanged from today.
+- **Store present** — **parse** the property's `secret()` reference for
+  `(vault, item, field)` *without resolving*, emit an `ExternalSecret`
+  (or one per namespace, for a `secrets:` entry using `namespaces:` —
+  see Open questions): `secretStoreRef` = the `ClusterSecretStore`
+  [ADR-0005](0005-secrets-store.md) creates, `remoteRef.key`/`.property`
+  = `item`/`field`.
+
+This is a new pass in `pkg/composer/blueprint/`. It runs *instead of*
+normal deferred resolution for `secrets:` entries once a store is
+present (it must parse, not resolve); with no store it is exactly the
+resolve path that already ships.
+
+## Implementation surface
+
+**`cli` changes:**
+
+1. Composer (`pkg/composer/blueprint/`): the new pass that, per
+   `flux:`-system `secrets:` entry, checks whether a `ClusterSecretStore`
+   is present and, if so, parses `(vault, item, field)` and emits an
+   `ExternalSecret` instead of resolving and emitting a `Secret`. Scoped
+   to the `secrets:` key; existing `secret()` behavior in
+   substitutions/`.env`/terraform is untouched.
+2. Nothing changes in schema — no `driver` field, no new block.
+
+**core changes:**
+
+1. Facets: `dependsOn` on [ADR-0005](0005-secrets-store.md)'s system
+   under the `secrets_store` capability, so an `ExternalSecret` never
+   composes before its `ClusterSecretStore` exists.
+
+## Consequences
+
+- **Namespace ordering is free** — the secret is tied to a `flux:`
+  system, so it lands in that system's namespace, already ordered by
+  the system's own `resources`→`install` edge. No namespace
+  abstraction.
+- **One cluster-wide switch, not per-secret choices** — every sensitive
+  secret in the cluster moves to `ExternalSecret` together, driven by
+  whether [ADR-0005](0005-secrets-store.md)'s store is enabled. A facet
+  author never picks a materialization.
+- **No schema surface added by this ADR** — the decision lives entirely
+  in composer behavior conditioned on two other addons' enablement.
+- **Fail closed** — a sensitive property whose value isn't a resolvable
+  `secret()` reference when a store is present.
+
+## Open questions
+
+- **Paired namespaces.** The shipped plain-`Secret` path's `namespaces:`
+  list already handles a secret needed in more than one namespace (used
+  by `pki`/`pki-trust` today). The `ExternalSecret` path should follow
+  the same pattern — one `ExternalSecret` per paired namespace — rather
+  than inventing a second mechanism.
+- **`sops` — deferred, not decided against.** A SOPS-encrypted `Secret` +
+  Flux `spec.decryption` is a real third posture (nothing plaintext in
+  git, no operator in the cluster) but has no consumer asking for it
+  today, unlike `ExternalSecret`, which [ADR-0005](0005-secrets-store.md)
+  exists specifically to serve. Revisit if a context needs a
+  git-committed-and-encrypted secret with no runtime store at all.
+- **Value transits the apply host.** The plain-`Secret` path resolves the
+  `secret()` at `windsor apply` time via the operator's provider config,
+  so the plaintext passes through the apply host — acceptable, same as
+  any `secret()` today, but the reason the `ExternalSecret` path (value
+  never leaves the store) is the stronger posture for anything sensitive
+  enough to matter.
+
+## Alternatives considered
+
+- **A `secrets.driver` enum on the existing `secrets:` block** (the
+  original draft of this ADR) — collides with that block's settled
+  meaning (build-time `secret()` provider config), a collision Manager's
+  own schema comments explicitly warn against. Replaced by making the
+  materialization implicit on the other two addons' enablement.
+- **A `secrets.refs`/named-catalog of secret references** (earlier
+  drafts) — invents a construct windsor doesn't have; a reference is an
+  expression at a config path. Replaced by marking the property
+  `sensitive` at its natural location.
+- **Facet-authored `secret()` literals or raw `ExternalSecret` YAML** —
+  hardcodes an operator's vault/item/field into shared content, or
+  couples the facet to ESO's CRD with no clean provenance. The facet
+  only ever names a sensitive property path.
+- **Terraform or the CLI writing Secrets directly into add-on
+  namespaces** — an external imperative write outside GitOps; the repo's
+  principle is that in-cluster objects are managed by Flux or an
+  operator Flux installs.
+- **Kyverno clone for multi-namespace** (the earlier Cloudflare
+  workaround) — `ExternalSecret` per namespace is the native answer and
+  needs no policy engine.
+
+## References
+
+- `cli` `pkg/runtime/secrets/secrets.go` (`SecretRef`, `NormalizeExpression`,
+  `parseSecretNotationParts`), `evaluator.go:305`,
+  `api/v1alpha2/config/secrets/schema.yaml` — the verified
+  secret-reference mechanics.
+- `cli` `pkg/composer/blueprint/` (`composer.go`,
+  `handler.go:resolveDeferredSubstitutions`),
+  `pkg/runtime/config/schemas/artifacts/facets.yaml` (`config:` blocks,
+  `requires:`, `flux:`) — where interpretation happens and how facets
+  declare inputs.
+- [ADR-0004](0004-external-secrets-operator.md),
+  [ADR-0005](0005-secrets-store.md) — the two addons this ADR's
+  materialization depends on.
+- Flux: [Secrets Management](https://fluxcd.io/flux/security/secrets-management/).
+  ESO: [GitOps using FluxCD](https://external-secrets.io/latest/examples/gitops-using-fluxcd/).
+- `contexts/_template/facets/addon-observability.yaml`'s
+  `alertmanager-notification-slack` entry — the shipped plain-`Secret`
+  path's first consumer.

--- a/docs/adr/0003-versioning-and-upgrade-contract.md
+++ b/docs/adr/0003-versioning-and-upgrade-contract.md
@@ -1,0 +1,182 @@
+---
+title: "ADR-0003: Upgrade-path contract over bundled dependencies — autolabeling and Renovate policy"
+description: "core bundles many dependencies (Talos, k8s-versions, CRD-vendored charts) that Renovate updates automatically and release-drafter buckets as patch; some of those are structural — any version change forces a rebuild regardless of the size of the upstream bump — so a nominal patch release can silently break the 0.X.x -> 0.X.(x+1) upgrade contract. Adds autolabeling plus Renovate policy keyed to the same structural files CI already treats specially."
+---
+
+# ADR-0003: Upgrade-path contract over bundled dependencies — autolabeling and Renovate policy
+
+## Status
+
+Proposed. Revised (2026-08-04): the label-mapping fix (`breaking` resolves
+minor, not major) already shipped — `.github/release-drafter.yml`'s
+`version-resolver` matches this ADR's original decision 1. This ADR is
+rescoped to the two pieces still open: autolabeling structural-dependency
+PRs, and a Renovate policy that stops blanket-automerging them.
+
+## Context
+
+### 0ver: major is reserved for a deliberate GA cut
+
+core and cli are both pre-1.0. Neither commits to strict SemVer today. The
+scheme is 0ver: `1.0.0` is a deliberate GA milestone, not a value that falls
+out of a label on some PR; until then a breaking change increments minor
+(`0.7.0` → `0.8.0`), not major. `release-drafter.yml`'s `version-resolver`
+in both repos already reflects this (`breaking` maps to `minor`, `major` is
+label-gated only) — see Shipped below.
+
+### The bundled-dependency problem is a separate, sharper issue
+
+core also bundles many third-party dependencies — Helm charts, Terraform
+providers, `k8s-versions` (aks/eks Kubernetes versions), Talos — and Renovate
+updates most of them automatically. Consumers reasonably expect the same
+kind of contract for those bundled deps that they'd expect from core itself:
+upgrade to the latest patch, then to the latest next minor, and it works.
+
+That expectation is already violated in one concrete, verified case.
+`ci.yaml` (`talos_version_of`, `ci.yaml:236-248`) diffs
+`contexts/_template/facets/config-talos.yaml`'s `talos_version` between base
+and head, and if it changed — **at any granularity, not just a minor
+bump** — skips the in-place upgrade test entirely, because container-mode
+Talos has no in-place upgrade: the control plane must be rebuilt. That PR
+still only carries whatever label Renovate attached (`dependencies`), which
+`version-resolver.patch` picks up. So a nominal `0.7.3` → `0.7.4` release can
+embed a change that forces a cluster rebuild — exactly what a patch bump is
+supposed to rule out.
+
+The risk here isn't proportional to how far upstream moved. For most bundled
+deps, ordinary patch/minor-is-safe expectations hold. For a smaller set —
+Talos being the clearest, verified case — the disruption is structural and
+binary: any version change is disruptive, independent of upstream's own
+versioning discipline. `k8s-versions` (aks/eks) and CRD-vendored charts
+(charts hoisted to vendor scope because `helm show crds` returns
+install-only CRDs) are the other known candidates, though unlike Talos this
+hasn't been verified against a CI check the way `talos_version_of` was.
+
+Today nothing distinguishes "Renovate bumped a Docker digest" from "Renovate
+bumped the Talos node image" at the release-labeling layer. Both land as
+`dependencies` → `patch`.
+
+### Shipped: the label-mapping fix
+
+`.github/release-drafter.yml`'s `version-resolver` already maps `breaking`
+to `minor` and reserves `major` for the `major` label alone. `major` is now
+opt-in only — applied by hand the day a `1.0.0` cut is actually intended —
+rather than something a routine breaking-change PR triggers on its own.
+What remains is distinguishing a structural dependency bump from an
+ordinary one at the labeling layer.
+
+## Decision
+
+### 1. Structural dependency bumps are autolabeled, not left to Renovate's own labels
+
+core adds a release-drafter `autolabeler` rule matching the same files
+`ci.yaml` already treats as structural (starting with
+`contexts/_template/facets/config-talos.yaml`; extended to the
+`k8s-versions` dep file and CRD-vendor paths as those are confirmed).
+Any PR touching one of these files — Renovate-authored or not — gets an
+`upgrade-impact` label automatically. That label maps into
+`version-resolver.minor` and gets its own changelog category, so it's
+visible in release notes instead of folded into the collapsed
+"Dependencies" group.
+
+This reuses the detection `ci.yaml` already performs rather than inventing a
+second source of truth, and doesn't depend on Renovate's package list
+staying exhaustive — a new structural dependency is covered as long as its
+version lives in a file this rule watches.
+
+### 2. Renovate stops blanket-automerging structural dependencies
+
+A `packageRule` in `.github/renovate.json` matches the known structural
+dependencies (Talos, `k8s-versions`) and:
+
+- disables automerge, so a human sees the PR before it merges;
+- applies the `upgrade-impact` label directly, as a second signal alongside
+  the autolabeler;
+- optionally sets `minimumReleaseAge` so a brand-new upstream release isn't
+  pulled in immediately.
+
+Non-structural dependencies (GitHub Actions digests, most Go modules, Docker
+digest-only pins, most Helm chart bumps) keep today's automerge behavior —
+this decision narrows the exception, it doesn't remove blanket automerge.
+
+### 3. Release cadence follows from the contract, not the other way around
+
+`0.X.x` → `0.X.(x+1)` is only a meaningful promise if consecutive releases
+stay close enough together that nobody skips over an accumulation of
+`upgrade-impact` changes between them. `release-drafter.yaml` currently only
+maintains a draft on push to `main`; nothing publishes it. This ADR treats
+"decide a publish cadence" (scheduled, e.g. weekly, or triggered whenever an
+`upgrade-impact`/`minor` PR merges) as a required follow-up, not a nice-to-have
+— left as an open decision below rather than settled here, since it's an
+operational choice, not an architectural one.
+
+## Consequences
+
+- **`breaking` is safe to apply liberally again** — it no longer forces an
+  unwanted major cut, which was the original complaint that prompted this
+  ADR.
+- **`major` needs a human to apply it on purpose.** No automated path
+  (Renovate, autolabeler, or otherwise) should ever attach `major` — if one
+  does by accident, that's a bug in this scheme, not a feature of it.
+- **Renovate PRs for Talos/`k8s-versions` would require manual merge.**
+  Slower than today's full automerge, but matches the fact that CI already
+  can't fully validate these paths (the upgrade test is skipped, not passed).
+- **The structural-file list needs upkeep.** If a new bundled dependency
+  turns out to be rebuild-forcing the way Talos is, both the `ci.yaml`
+  detection and this ADR's autolabeler/Renovate rule need a matching entry.
+  Nothing enforces that they stay in sync today.
+- **Publish cadence is still unresolved** (see Open questions) — this ADR
+  fixes the labeling/detection side of the contract but doesn't by itself
+  guarantee releases are cut often enough to keep any single upgrade step
+  small.
+
+## Open questions
+
+- **Publish cadence.** Scheduled (e.g. weekly) vs. triggered by any
+  `minor`/`upgrade-impact` merge vs. left manual. Not settled here.
+- **CI enforcement, not just detection.** `talos_version_of` today skips the
+  upgrade test silently on a structural change; it could instead fail the
+  PR when the structural file changed but `upgrade-impact` isn't present,
+  closing the loop between "CI knows this needs a rebuild" and "the release
+  is labeled accordingly." Left as a fast-follow, not required for this ADR.
+- **Full structural-file list.** Only Talos is verified against an existing
+  CI check. `k8s-versions` and CRD-vendor paths are plausible candidates but
+  unverified — confirm before adding them to the autolabeler.
+- **`enforce-pr-labels.yaml` lists `minor`/`patch` as accepted labels**, but
+  `version-resolver` has never had a `minor`/`patch` label mapping of its
+  own (only `major`/`breaking`/`feature`/the patch-bucket list) — a PR
+  labeled bare `minor` silently falls through to `default: patch`. Whether
+  to add explicit `minor`/`patch` label mappings is a small follow-up,
+  orthogonal to this ADR's `breaking`/`upgrade-impact` changes.
+
+## Alternatives considered
+
+- **Leave `breaking` under `major`, tell people not to use it carelessly.**
+  Relies on PR-time discipline to not trigger an unwanted GA cut; the
+  incident that prompted this ADR is exactly that discipline failing.
+- **Drop the `breaking` label entirely, rely on `minor` alone.** Loses the
+  changelog signal that a given minor release contains a breaking change —
+  `breaking` should still surface in release notes, it just shouldn't drive
+  version resolution to major.
+- **Tag structural dependencies via Renovate `matchPackageNames` only, no
+  autolabeler.** Fragile: Renovate's package list has to independently track
+  every structural dependency, whereas file-path autolabeling piggybacks on
+  the same watch list `ci.yaml` already needs to maintain for its own
+  detection.
+- **Bump core's own minor version automatically whenever a structural
+  dependency changes, skipping the label step.** Would need release-drafter
+  (or a replacement) to read file diffs directly rather than PR labels,
+  a larger change than this ADR's scope; the label indirection also keeps
+  the signal visible to humans reviewing the PR, not just to tooling.
+
+## References
+
+- `.github/release-drafter.yml` (core and cli) — the shipped
+  `version-resolver` mapping `breaking` to `minor`.
+- [ci.yaml:236-248](../../.github/workflows/ci.yaml#L236-L248)
+  (`talos_version_of`) — the verified structural-dependency detection this
+  ADR's autolabeler reuses.
+- `.github/renovate.json` — current blanket automerge `packageRule`s this
+  ADR narrows for structural dependencies.
+- `.github/workflows/enforce-pr-labels.yaml` — the required-label check
+  referenced in Open questions.

--- a/docs/adr/0004-external-secrets-operator.md
+++ b/docs/adr/0004-external-secrets-operator.md
@@ -1,0 +1,73 @@
+---
+title: "ADR-0004: External Secrets Operator — runtime secret sync addon"
+description: Adds a top-level external_secrets capability that installs External Secrets Operator, install-only, off by default. Closes core#2284. The controller alone does nothing without a ClusterSecretStore; ADR-0005 supplies one.
+---
+
+# ADR-0004: External Secrets Operator — runtime secret sync addon
+
+## Status
+
+Proposed. Formalizes [core#2284](https://github.com/windsorcli/core/issues/2284).
+Depended on by [ADR-0002](0002-cluster-secrets-management.md) (the `externalsecret`
+materialization) and [ADR-0005](0005-secrets-store.md) (the store this controller
+reads from).
+
+## Context
+
+`secret()` resolves build-time references — through the providers under the
+top-level `secrets:` block — into generated values. Nothing syncs a *live*
+credential into a running cluster; anything needing one has it baked in at
+compose time. External Secrets Operator (ESO) is the client half of that gap
+and belongs in core unconditionally: every cluster runs it, standalone or
+not, regardless of what store sits behind it.
+
+## Decision
+
+### 1. A top-level `external_secrets` capability
+
+```yaml
+external_secrets:
+  enabled: false
+```
+
+Top-level, not nested under `addons:` — the `addons` namespace was flattened
+into top-level capability keys ([core#2348](https://github.com/windsorcli/core/issues/2348));
+`identity`, `database`, `object_store` are the precedent.
+
+### 2. Install-only, no store
+
+A `flux:` system installing the operator only — it manages `ExternalSecret`
+and `ClusterSecretStore` CRs and creates none of its own, the same shape as
+`addon-database`'s CloudNativePG install. CRDs vendor under
+`kustomize/crds/external-secrets-<version>/`, matching how cert-manager and
+the AWS LB controller's CRDs are already vendored.
+
+No `ClusterSecretStore` is created here. A store is per-backend and belongs
+to whatever add-on backs it — [ADR-0005](0005-secrets-store.md) for the
+in-repo case.
+
+## Consequences
+
+- Enabling `external_secrets` alone does nothing observable — no
+  `ClusterSecretStore` exists yet, so no `ExternalSecret` can resolve. This
+  is deliberate: the controller and the store are independently enable-able
+  because a cluster can run ESO pointed at a store it doesn't host itself.
+- [ADR-0002](0002-cluster-secrets-management.md)'s `externalsecret`
+  materialization requires both this addon and a store enabled; neither
+  addon depends on the other.
+
+## Alternatives considered
+
+**Bundle the controller and a self-hosted store behind one flag.** Simpler
+surface, but forecloses a cluster pointing ESO at a store it doesn't own —
+exactly the shape a downstream fleet cluster needs when a management
+cluster hosts the shared store. Keeping them separate costs one extra
+toggle and buys that case.
+
+## References
+
+- [core#2284](https://github.com/windsorcli/core/issues/2284) — the issue
+  this ADR formalizes.
+- `contexts/_template/facets/addon-database.yaml` — the install-only,
+  creates-nothing pattern this addon follows.
+- `kustomize/crds/` — the existing vendored-CRD convention.

--- a/docs/adr/0005-secrets-store.md
+++ b/docs/adr/0005-secrets-store.md
@@ -1,0 +1,163 @@
+---
+title: "ADR-0005: secrets_store — self-hosted OpenBao, or an external Vault-API-compatible store"
+description: "Closes core#2285. A top-level secrets_store capability with two drivers: openbao (self-hosted, single-cluster) and external (points a ClusterSecretStore at a Vault-API-compatible instance this cluster doesn't own — the shape a downstream fleet cluster needs to read from Windsor Manager's shared OpenBao). PKI is explicitly out of scope; that's fleet-only work."
+---
+
+# ADR-0005: secrets_store — self-hosted OpenBao, or an external Vault-API-compatible store
+
+## Status
+
+Proposed. Formalizes [core#2285](https://github.com/windsorcli/core/issues/2285),
+extended with an `external` driver. Depends on
+[ADR-0004](0004-external-secrets-operator.md). Depended on by
+[ADR-0002](0002-cluster-secrets-management.md)'s `ExternalSecret`
+materialization.
+
+## Context
+
+[core#2284](https://github.com/windsorcli/core/issues/2284) adds the ESO
+controller. This addon adds the other half — a store for it to read from
+— so a standalone cluster can be self-contained rather than depending on
+an external SaaS secret manager: self-hosting the store is the whole
+point for an airgapped or single-cluster install, which is a legitimate
+consumer even though a fleet would run one shared instance.
+
+**OpenBao rather than Vault, for the self-hosted case.** Vault relicensed
+to BUSL 1.1 in August 2023; OpenBao is the Linux Foundation fork under
+MPL 2.0, matching this repository's own license. Worth being a
+deliberate choice: OpenBao is the driver core installs; HashiCorp Vault
+is not offered as a second self-hosted chart to maintain under a license
+misaligned with this repo's stance.
+
+**But self-hosting is not the only shape this needs to support.** Windsor
+Manager's fleet model (`manager` docs/adr/0003-secrets-and-pki.md) runs
+one shared OpenBao on the management cluster and registers each
+downstream cluster's own API server as a distinct Kubernetes-auth mount,
+scoped to that cluster's secrets — no static credential crosses the
+boundary. From a downstream cluster's own perspective (itself a `core`
+blueprint), that means pointing its `ClusterSecretStore` at an instance
+it does not run and did not install. Since ESO's `vault` provider type is
+API-compatible with both OpenBao and HashiCorp Vault, the same "point at
+an external instance" shape also covers an operator who already runs
+their own Vault and wants nothing self-hosted at all — this ADR treats
+both as the same driver.
+
+**PKI is explicitly out of scope.** core#2285 draws this line itself: a
+PKI secrets engine issuing certificates to other clusters overlaps with
+the existing `pki` addon and `private_ca`, and mounting/operating one is
+fleet-only work (Manager's own ADR-0003, decision 2). This addon installs
+and configures a generic key/value-capable secrets store and its
+`ClusterSecretStore`; it never mounts or manages a `pki` engine.
+
+## Decision
+
+### 1. A top-level `secrets_store` capability, two drivers
+
+```yaml
+secrets_store:
+  enabled: false
+  driver: openbao          # openbao | external
+  openbao:
+    # only consumed when driver: openbao
+  external:
+    url: ""                # Vault-API-compatible address (OpenBao or Vault)
+    kubernetes_auth:
+      mount_path: ""        # auth mount path this cluster was registered under
+      role: ""              # role bound to that mount
+```
+
+Top-level, matching `identity`/`database`/`object_store`/`external_secrets`
+— not nested under `addons:`.
+
+### 2. `driver: openbao` — self-hosted, single cluster
+
+A `flux:` system installing OpenBao (HA gated on `topology == 'ha'`, the
+same expression `addon-database`'s CloudNativePG install already uses),
+depending on `csi` for storage, plus a `resources` tier carrying the
+`ClusterSecretStore` bound to the in-cluster instance. Auth is local: the
+cluster's own OpenBao trusts its own API server via OpenBao's Kubernetes
+auth method — no cross-cluster registration, no static credential.
+
+**Unseal is a bootstrap-ordering problem, solved the way the existing
+`kubernetes` secrets path already solves one.** OpenBao needs its unseal
+material before it will serve anything — before ESO can sync a single
+Secret out of it. A Terraform step generates the unseal (or recovery)
+key once, holds it in state, and a facet `secrets:` block places it as a
+plain `Secret` via [ADR-0002](0002-cluster-secrets-management.md)'s
+already-shipped path — never as an `ExternalSecret`, which would be
+circular. This mirrors the existing `pki.private_ca` keypair's own
+Terraform-generated-then-placed pattern.
+
+### 3. `driver: external` — point at a store this cluster doesn't own
+
+No `install` tier at all. Only a `resources` tier emitting the
+`ClusterSecretStore`, pointed at the operator-supplied `url`, using
+Kubernetes auth against the given `mount_path`/`role`. This is the shape
+a downstream fleet cluster uses to read from Windsor Manager's shared
+OpenBao, and equally the shape for an operator who already runs their
+own HashiCorp Vault and wants core to talk to it rather than install
+anything.
+
+### 4. Requires External Secrets Operator
+
+`secrets_store.enabled` on its own is meaningless without
+[ADR-0004](0004-external-secrets-operator.md)'s controller running to
+read from the `ClusterSecretStore` it creates — a `requires:` gate
+enforces `external_secrets.enabled == true` in the facet, phrased for
+the operator ("the secrets store needs External Secrets turned on too"),
+not in terms of `ClusterSecretStore`/CRD internals.
+
+## Consequences
+
+- One provider family, two topologies. Consumers (ADR-0002's
+  `ExternalSecret` materialization) see the same `ClusterSecretStore`
+  shape regardless of which driver produced it.
+- **`openbao` is the only self-hosted option.** HashiCorp Vault is fully
+  usable via `driver: external` (an operator's own Vault instance), just
+  never installed by this addon.
+- **`external` is the seam Windsor Manager's fleet model depends on.**
+  Without it, a downstream cluster would have to run its own store
+  rather than reading from the fleet's shared one — this driver is what
+  makes core usable as a downstream-cluster blueprint under Manager, not
+  only as a standalone one.
+- Self-hosted OpenBao's unseal material is secured by the same mechanism
+  as any other Terraform-generated, facet-placed secret (a Terraform
+  state file) — an appropriate v0.8.0 answer, not a permanent one for
+  anyone auditing the cluster's root-of-trust story.
+
+## Alternatives considered
+
+**A `driver: vault` self-hosted option alongside `openbao`.** Redundant
+chart to build and maintain for a product under a license this repo
+doesn't otherwise depend on, when OpenBao is the drop-in open
+replacement and `external` already covers anyone who wants to run their
+own Vault.
+
+**Self-hosted only, no `external` driver.** Matches core#2285's original
+scope exactly, but breaks Windsor Manager's fleet model, which
+explicitly needs a downstream cluster reading from a store it doesn't
+own. Adding `external` costs one enum value and a handful of connection
+fields.
+
+**Cloud KMS auto-unseal for the self-hosted case.** Removes the
+Terraform-state-held-key question entirely on AWS/Azure. Rejected as the
+*only* path because it doesn't exist on Hetzner, vSphere, Hyper-V, Incus,
+or metal — core runs on all of those. Worth offering as a per-platform
+override later, not the default.
+
+## References
+
+- [core#2284](https://github.com/windsorcli/core/issues/2284),
+  [core#2285](https://github.com/windsorcli/core/issues/2285) — the
+  issues this ADR and ADR-0004 formalize.
+- [ADR-0002](0002-cluster-secrets-management.md),
+  [ADR-0004](0004-external-secrets-operator.md) — the materialization
+  and controller this store serves.
+- `contexts/_template/facets/addon-database.yaml` — the `topology == 'ha'`
+  gating and `dependsOn: [csi]` pattern this addon's `openbao` driver
+  follows.
+- `contexts/_template/facets/addon-private-ca.yaml` — the
+  Terraform-generate-once, facet-place-as-plain-Secret pattern the
+  unseal material reuses.
+- OpenBao: [openbao.org](https://openbao.org). ESO's `vault` provider:
+  [external-secrets.io](https://external-secrets.io/latest/provider/hashicorp-vault/).

--- a/docs/adr/0006-object-store-seaweedfs.md
+++ b/docs/adr/0006-object-store-seaweedfs.md
@@ -1,0 +1,142 @@
+---
+title: "ADR-0006: SeaweedFS as a second object_store driver"
+description: Adds object_store.driver enum value seaweedfs alongside the shipped minio. No CRD/operator tier like MinIO's Operator+Tenant split — SeaweedFS is Helm-chart-native StatefulSets. HA requires the filer's metadata store to move off embedded LevelDB onto the existing database capability, a dependency MinIO's HA story doesn't have.
+---
+
+# ADR-0006: SeaweedFS as a second `object_store` driver
+
+## Status
+
+Proposed.
+
+## Context
+
+`object_store` today has one driver, `minio` (`contexts/_template/schema.yaml`
+~1336): an Operator-only install (`kustomize/object-store/install/minio/`)
+that provisions no Tenant by default — consumers reference the reference
+Tenant under `resources/common/` or bring their own. Storage class is not
+derived from `topology`; there is no `object_store_effective` or
+cross-facet config block, and no other facet reads `object_store.*` today
+besides the facet's own test.
+
+SeaweedFS is a real second option for platforms where MinIO's
+per-object-on-PVC model and Operator+Tenant split cost more than the
+alternative buys: no community-standard operator/CRD tier at all —
+master, volume, filer, and S3-gateway are plain Helm-chart StatefulSets,
+which is a simpler two-tier story than MinIO's Operator-then-Tenant
+split, not a more complex one.
+
+## Decision
+
+### 1. `driver: seaweedfs` alongside `minio`
+
+```yaml
+object_store:
+  driver:
+    enum: [minio, seaweedfs]
+  seaweedfs:
+    filer_store:
+      enum: [leveldb, postgres]
+      default: leveldb
+    replication:
+      default: "000"
+```
+
+`filer_store` and `replication` are SeaweedFS-specific and nest under
+`object_store.seaweedfs`, the same way `database.postgres.driver` nests
+Postgres-specific fields one level under `database.postgres` rather than
+flattening them onto `object_store` itself.
+
+### 2. Components: master, volume, filer, S3 gateway
+
+```yaml
+flux:
+  - name: object-store
+    when: object_store.driver == 'seaweedfs'
+    dependsOn:
+      - csi
+      - "${object_store.seaweedfs.filer_store == 'postgres' ? 'database' : ''}"
+    install:
+      components:
+        - seaweedfs/master
+        - seaweedfs/volume
+        - seaweedfs/filer
+        - seaweedfs/s3
+        - "${topology == 'ha' ? 'seaweedfs/ha' : ''}"
+```
+
+- **master** — Raft-based metadata/topology coordinator; a 3-replica
+  quorum under `ha`, the same shape as CNPG's HA `Cluster` or Longhorn's
+  `ha/` patch.
+- **volume** — the data-bearing StatefulSet, PVC-backed via `csi`; this
+  is where `replication` (SeaweedFS's placement code — extra copies per
+  rack/data-center/node) applies.
+- **filer** — owns bucket/path metadata, backed by `filer_store`.
+- **s3** — the S3-API-compatible gateway consumers talk to, the
+  SeaweedFS analogue of MinIO's Tenant `Service`.
+
+### 3. `topology: ha` requires `filer_store: postgres`
+
+Embedded LevelDB is local-disk and single-writer — it does not support
+more than one filer replica, so it cannot be made HA. Postgres is
+stateless and horizontally scalable, and it's already a capability this
+repo has (`database`). A `requires:` gate enforces this in operator
+vocabulary — *"object storage HA needs the database service enabled"* —
+rather than silently switching `filer_store` underneath the operator or
+failing deep inside a Helm values render.
+
+This is the one place SeaweedFS's HA story pulls in a dependency MinIO's
+doesn't have: MinIO Tenant HA (more pools/servers) is self-contained.
+
+### 4. `minio` stays the default
+
+SeaweedFS's argument is resource footprint and small-object efficiency
+at the storage layer, which matters most on platforms without cloud CSI
+economics (metal, Hyper-V) — a footprint argument, not a reason to make
+it the default anywhere yet. No existing consumer has a workload MinIO
+can't serve. It ships as an explicit second option, not a
+platform-conditional default.
+
+## Consequences
+
+- Enabling `seaweedfs` with `topology: ha` and no `database` enabled
+  fails validation with a plain-language message rather than silently
+  running a non-HA filer under an HA label.
+- No Operator/CRD tier means no `resources/common`-style "reference,
+  not facet-wired" provisioning step the way MinIO has one — a
+  SeaweedFS object-store is live (master/volume/filer/s3 all running)
+  the moment the facet is enabled, not a dormant operator waiting for a
+  Tenant. This is a materially different "cost of turning it on" than
+  MinIO's today.
+- Erasure-coding placement and rack/data-center-aware scheduling are out
+  of scope for this ADR — this repo has no rack/DC node-labeling
+  convention today, and `replication` codes alone cover the common case.
+  Revisit if a deployment needs true erasure coding.
+- S3-API compatibility gaps between SeaweedFS's gateway and MinIO's are
+  real (some multipart/IAM-policy edge cases lag). Any existing MinIO
+  consumer (Quickwit under `observability`) needs verification against
+  SeaweedFS's gateway before being assumed portable across drivers.
+
+## Alternatives considered
+
+**Make SeaweedFS the default on non-cloud platforms.** No consumer today
+has a workload MinIO can't serve, and this repo has no precedent of a
+platform overriding a driver enum's default. Premature.
+
+**Skip the `filer_store: postgres` dependency and ship HA on embedded
+LevelDB anyway.** LevelDB does not support multiple writers; this would
+either silently run a single-point-of-failure filer under an `ha` label
+or require inventing a new embedded HA metadata store from scratch.
+Reusing `database` costs one dependency and one `requires:` gate.
+
+## References
+
+- `contexts/_template/facets/addon-object-store.yaml`,
+  `kustomize/object-store/install/minio/`,
+  `kustomize/object-store/resources/common/` — the shipped `minio` driver
+  this one sits alongside.
+- `contexts/_template/facets/addon-database.yaml` — the
+  `topology == 'ha'` gating pattern and the `database` capability this
+  ADR's `filer_store: postgres` path depends on.
+- SeaweedFS: [seaweedfs.io](https://github.com/seaweedfs/seaweedfs) —
+  master/volume/filer/S3-gateway architecture, filer store backends.

--- a/docs/adr/0007-backup-restore-velero.md
+++ b/docs/adr/0007-backup-restore-velero.md
@@ -1,0 +1,132 @@
+---
+title: "ADR-0007: Backup and restore — a Velero addon over the existing object_store capability"
+description: "core has no backup capability on any platform today — confirmed absent repo-wide (no velero, restic, or CNPG barmanObjectStore config anywhere). Adds a top-level backup capability installing Velero, targeting the existing object_store addon as its object-storage backend rather than provisioning a second one. Scoped to workload PVCs and CNPG in this ADR; Manager's own state (Omni's etcd, the secrets backend) is fleet-only and out of scope."
+---
+
+# ADR-0007: Backup and restore — a Velero addon over the existing `object_store` capability
+
+## Status
+
+Proposed.
+
+## Context
+
+No platform, cloud or self-hosted, has any backup capability today —
+confirmed by a repo-wide search: no `velero`, `restic`, or
+`barmanObjectStore` anywhere. `kustomize/demo/resources/database/cluster.yaml`
+sets a CloudNativePG `Cluster`'s instances/storage/monitoring with no
+`backup:` block at all. For a blueprint whose stated goal is a coherent,
+production-usable platform across providers, this is the single largest
+capability gap found, and it's uniform — equally absent everywhere,
+rather than inconsistent between platforms the way encryption or audit
+logging are.
+
+Windsor Manager's own roadmap names this directly, for its own state:
+*"Backup and restore for Omni's etcd, the secrets backend, and the
+databases. What Velero covers and what it can't"* (manager
+`docs/roadmap-v0.1.0.md`, ADR slot 0007). That is fleet-only scope
+(Omni, OpenBao, Manager's own CNPG instances) and stays Manager's to
+decide. What core owns is the same capability for a single cluster's
+own workloads — the prerequisite Manager's Velero install layers onto,
+per the layering rule already established (`manager` ADR-0001: "if a
+single cluster would also want the capability, it belongs in Core").
+
+The `object_store` addon already ships an S3-compatible backend
+(MinIO, soon optionally SeaweedFS per [ADR-0006](0006-object-store-seaweedfs.md))
+built for exactly this kind of consumer — Velero's object-storage plugin
+needs nothing more than an S3-compatible endpoint and credentials.
+
+## Decision
+
+### 1. A top-level `backup` capability, Velero as the driver
+
+```yaml
+backup:
+  enabled: false
+  driver: velero
+  schedule: "0 2 * * *"
+  retention: "720h"        # 30 days
+```
+
+Top-level, matching `identity`/`database`/`object_store`.
+
+### 2. Targets the existing `object_store` addon, not a second bucket layer
+
+Velero's `BackupStorageLocation` points at the cluster's own
+`object_store` addon (whichever driver — `minio` or `seaweedfs` — is
+enabled), using the same S3-compatible endpoint and credential pattern
+consumers already use. `backup.enabled == true` requires
+`object_store.enabled == true`; the facet's `requires:` gate says so in
+plain terms — *"backup needs the object storage service enabled"* — not
+in terms of `BackupStorageLocation`/plugin internals. Velero does not
+provision its own object storage.
+
+### 3. Scope: workload PVCs and CloudNativePG, not Manager's fleet state
+
+This ADR covers what a single cluster needs for its own workloads:
+- **Volume snapshots**, via Velero's CSI plugin, for any PVC-backed
+  workload.
+- **CloudNativePG**, via CNPG's own `barmanObjectStore`/plugin backup
+  mechanism, configured to point at the same `object_store` backend —
+  not through Velero's generic PVC snapshot path, which is the wrong
+  tool for a running Postgres instance.
+
+Omni's etcd, the secrets store's own data, and Manager's own databases
+are fleet-only concerns; per the same layering rule, that's Manager's
+ADR to write, over the top of the capability this ADR ships.
+
+### 4. Install-only, off by default
+
+A `flux:` system installing Velero (and its CSI plugin) — no CRs of its
+own beyond the operator's, matching how `addon-database` and
+[ADR-0004](0004-external-secrets-operator.md) ship. `Schedule`/`Backup`
+CRs are the resources tier, generated from `backup.schedule`/`retention`.
+
+## Consequences
+
+- Every cluster gets the same backup mechanism regardless of platform —
+  no cloud-specific snapshot API wiring (EBS snapshots, Azure Disk
+  snapshots) needed as a separate path, since Velero's CSI plugin already
+  abstracts that.
+- CNPG backup is configured through CNPG's own mechanism, not Velero's
+  PVC snapshot path — a running database needs a consistent dump/WAL
+  archive, not a filesystem-level snapshot of its data directory.
+- `object_store` moves from "nice for demo workloads" to "prerequisite
+  for backup" — enabling `backup` without `object_store` fails
+  validation rather than silently having nowhere to write.
+- This ADR does not cover Manager's own state (Omni, the secrets store).
+  That remains Manager's to design, consuming this capability the same
+  way it consumes `identity`/`database` today.
+
+## Alternatives considered
+
+**Provision a dedicated bucket/store just for backups, separate from
+`object_store`.** Doubles the object-storage surface for no real
+benefit — `object_store` already exists as a general-purpose
+S3-compatible backend, and Velero needs nothing beyond that contract.
+
+**Route CNPG backup through Velero's generic PVC snapshot path.**
+Filesystem-level snapshots of a live Postgres data directory are not a
+consistent backup without additional coordination Velero doesn't
+provide for databases; CNPG's own backup mechanism (WAL archiving,
+`barmanObjectStore`) is built for exactly this and already exists
+upstream.
+
+**Cover Manager's fleet state (Omni's etcd, the secrets store) in this
+ADR.** Out of altitude — a single cluster never needs to back up another
+cluster's fleet-management state; that's Manager's own ADR to write, the
+same layering split already drawn for identity and secrets.
+
+## References
+
+- `kustomize/database/install/cloudnativepg/`,
+  `kustomize/demo/resources/database/cluster.yaml` — the CNPG install
+  this ADR's database backup path configures.
+- [ADR-0006](0006-object-store-seaweedfs.md),
+  `contexts/_template/facets/addon-object-store.yaml` — the backend this
+  addon targets.
+- `manager` `docs/roadmap-v0.1.0.md` (ADR slot 0007, "Manager's own
+  state") — the fleet-only scope this ADR explicitly excludes.
+- `manager` `docs/adr/0001-layering-on-core.md` — the "if a single
+  cluster would also want it, it belongs in core" rule this ADR follows.
+- Velero: [velero.io](https://velero.io) — CSI plugin, `BackupStorageLocation`.

--- a/docs/adr/0008-platform-hardening-parity.md
+++ b/docs/adr/0008-platform-hardening-parity.md
@@ -1,0 +1,143 @@
+---
+title: "ADR-0008: Platform hardening parity — disk/etcd encryption, audit logging, default-deny network policy"
+description: "AWS and Azure default to KMS-backed encryption and audit logging; every self-managed Talos platform (Hetzner, vSphere, Hyper-V, Incus, Docker, metal) ships etcd and node disks unencrypted with no audit trail, and no platform has a cluster-wide network-policy default-deny baseline. Sequences three decisions to close the widest present/absent split in the platform table, and records the Hetzner static-credential fallback as an accepted, documented boundary rather than a gap needing a fix."
+---
+
+# ADR-0008: Platform hardening parity — disk/etcd encryption, audit logging, default-deny network policy
+
+## Status
+
+Proposed.
+
+## Context
+
+A platform-by-platform audit of every `platform-*.yaml` facet plus the
+supporting Terraform found the widest present/absent split in the
+repo, uniform across managed-cloud vs self-managed platforms rather than
+random per-platform variance:
+
+| Capability | AWS (EKS) | Azure (AKS) | Hetzner / vSphere / Hyper-V / Incus / Docker / metal (Talos) |
+|---|---|---|---|
+| Etcd/secrets-at-rest encryption | KMS-backed, default on (`terraform/cluster/aws-eks/variables.tf:316-332`) | N/A (managed etcd); node-disk CMK encryption default on (`terraform/cluster/azure-aks/variables.tf:349-352`) | **Absent everywhere** — no LUKS/`systemDiskEncryption` config in `config-talos.yaml` or any Talos platform facet |
+| Node/volume encryption | Default on (`variables.tf:336-341`) | Default on (CMK disk encryption set) | Absent |
+| API-server audit logging | Default on, includes `audit` log type (`main.tf:88-90`) | Diagnostic settings exist but `kube-audit` is excluded by default, only `kube-audit-admin` | **Absent everywhere** — no `--audit-log`/`--audit-policy` machine-config flags anywhere |
+| Cluster-wide network-policy default-deny | Not enforced on any platform | | Only narrow, feature-scoped CiliumNetworkPolicies exist (Keycloak, gitops webhook, gateway UI, CoreDNS-etcd) — no baseline anywhere |
+
+Separately, Hetzner falls back to a static `hcloud` API token Secret for
+its CCM/CSI/DNS controllers (`platform-hetzner.yaml:292-353`), where AWS
+and Azure get IRSA/Workload-Identity federation. This is architecturally
+forced — Hetzner has no workload-identity primitive — not a gap this ADR
+proposes to close; it's recorded below as an accepted, documented
+boundary, the same way [ADR-0005](0005-secrets-store.md) documents
+OpenBao's unseal key as a Terraform-state-held secret rather than
+pretending a fix is pending.
+
+Image signature verification (cosign/Kyverno `verifyImages`) and
+namespace-level `ResourceQuota`/`LimitRange` defaults are also absent
+everywhere, but uniformly so — no platform is worse than another — and
+neither has a concrete consumer asking for it today. They're noted as
+backlog, not sequenced into this ADR's decisions.
+
+## Decision
+
+### 1. STATE/EPHEMERAL partition encryption, static key, Terraform-generated
+
+Every self-managed Talos platform gets `systemDiskEncryption` (LUKS2) on
+the STATE and EPHEMERAL partitions by default, keyed by a static
+passphrase. The passphrase is generated once by Terraform and held in
+state, following the exact pattern already established for
+[ADR-0005](0005-secrets-store.md)'s OpenBao unseal key and
+`pki.private_ca`'s keypair — this is the fourth application of the same
+"Terraform generates once, a facet places it" shape, not a new
+mechanism. A per-platform override to a real KMS-backed key exchange
+(where one exists) is a later, additive option, not required for parity.
+
+### 2. API-server audit logging, shipped through the existing observability pipeline
+
+Talos machine config gets `--audit-log-path`/`--audit-policy-file` set
+by default, writing to a path the existing fluent-bit collection
+(`telemetry`/`observability` addon) already tails — no new log sink,
+reusing the pipeline every Talos platform already runs. Azure's
+`kube-audit` exclusion is corrected to match AWS's default-on posture in
+the same pass, so both managed clouds agree.
+
+### 3. A cluster-wide Cilium default-deny baseline
+
+A single default-deny `CiliumClusterwideNetworkPolicy` (ingress from
+outside the cluster network) ships as part of the `cni` capability,
+default on, with the existing narrow per-feature CiliumNetworkPolicies
+(Keycloak, gitops webhook, gateway UI, CoreDNS-etcd) becoming the
+explicit-allow exceptions to it rather than the only policies that
+exist. A `requires:`-gated escape hatch lets a context turn it off in
+plain language (*"cluster-wide network policy enforcement"*), not by
+deleting the baseline policy by hand.
+
+### 4. Hetzner's static credential — documented, not fixed
+
+Hetzner's CCM/CSI/DNS controllers keep using a static `hcloud` API
+token. No workload-identity-equivalent exists on Hetzner Cloud today, so
+there is nothing to federate to. This ADR records the accepted-risk
+posture explicitly rather than leaving it to be discovered by reading
+`platform-hetzner.yaml` — revisit only if Hetzner ships an
+identity-federation primitive.
+
+## Consequences
+
+- Closes the widest present/absent split in the platform table: every
+  Talos-driven platform gains disk/etcd encryption and audit logging it
+  has none of today, at parity with what AWS and Azure already default
+  to.
+- The default-deny baseline is the one decision with real regression
+  risk — every existing narrow CiliumNetworkPolicy has to be re-verified
+  as a correct, sufficient allow-rule under a default-deny posture,
+  not just an additive rule under today's default-allow one.
+- Static-passphrase disk encryption is a real but bounded improvement
+  over no encryption at all — it protects data at rest against a lost or
+  stolen disk, not against an attacker with access to the Terraform
+  state backend. Worth stating plainly, the same way the OpenBao unseal
+  key's Terraform-state exposure is stated in ADR-0005.
+- Hetzner's static-credential posture remains exactly what it is today;
+  this ADR changes nothing about it beyond writing it down as a
+  deliberate boundary.
+
+## Alternatives considered
+
+**Per-platform KMS-backed disk encryption as the default, rather than a
+static passphrase.** Matches cloud best practice on AWS/Azure but has no
+equivalent on Hetzner, vSphere, Hyper-V, Incus, or metal — all of which
+core supports today. A static Terraform-generated key is the one
+mechanism available on every platform; a real KMS becomes a per-platform
+opt-in later, not the default gating parity on infrastructure most of
+this repo's platforms don't have.
+
+**Ship the default-deny network policy as opt-in rather than default
+on.** Leaves every context that doesn't explicitly turn it on exactly as
+exposed as today, which defeats the point of a parity baseline. Default
+on with an explicit opt-out matches how `policies.require_image_digest`
+and friends already default to enabled.
+
+**Attempt to fix Hetzner's static-credential posture with a
+Kyverno-based workaround or a home-grown token-rotation job.** Invents
+complexity to route around a real platform limitation rather than
+naming it; nothing about a synthetic workaround changes the fact that
+Hetzner Cloud has no IRSA/Workload-Identity equivalent to federate to.
+
+## References
+
+- `terraform/cluster/aws-eks/variables.tf:316-341`,
+  `terraform/cluster/azure-aks/variables.tf:349-393` — the existing
+  cloud-platform encryption/audit defaults this ADR brings Talos
+  platforms to parity with.
+- `contexts/_template/facets/config-talos.yaml`,
+  `contexts/_template/facets/platform-hetzner.yaml`,
+  `platform-vsphere.yaml`, `platform-hyperv.yaml`, `platform-incus.yaml`,
+  `platform-docker.yaml`, `platform-metal.yaml` — the platforms this
+  ADR's decisions 1-2 apply to uniformly.
+- `kustomize/identity/resources/keycloak/cilium/ciliumnetworkpolicy.yaml`,
+  `kustomize/gitops/resources/webhook/gateway/cilium/`,
+  `kustomize/dns/install/coredns/etcd/network-policy.yaml` — the
+  existing narrow CiliumNetworkPolicies decision 3 turns into explicit
+  allow-rules under a default-deny baseline.
+- [ADR-0005](0005-secrets-store.md), `contexts/_template/facets/addon-private-ca.yaml`
+  — the Terraform-generate-once, facet-place pattern decision 1 reuses.
+- Talos: [Disk Encryption](https://www.talos.dev/latest/talos-guides/configuration/disk-encryption/).

--- a/docs/adr/roadmap-v0.8.0.md
+++ b/docs/adr/roadmap-v0.8.0.md
@@ -1,0 +1,96 @@
+---
+title: Release v0.8.0 — Planning & ADR Sequence
+description: Seeds and sequences the ADRs that lead up to the v0.8.0 release. Living planning document, not an ADR.
+---
+
+# Release v0.8.0 — Planning & ADR Sequence
+
+- Status: Drafting
+- Date: 2026-08-04
+- Deciders: Ryan VanGundy
+- Purpose: Track the audit that pruned the prior release cycle's ADRs and plans, and sequence what's carried into v0.8.0. Each numbered ADR in this directory is authored separately.
+
+## Why this release exists
+
+Two things are driving v0.8.0 beyond the carried-forward gateway/secrets/
+versioning work: Windsor Manager has started being built (a fleet-management
+blueprint layered on core — Omni, Talos image factory, Cluster API, Keycloak,
+OpenBao, Harbor, Velero) and is naming concrete things it needs from core;
+and a first cross-platform hardening/completeness pass surfaced real,
+grounded gaps in core's own story. Both are reflected in the ADR sequence
+below rather than left as informal asks.
+
+## Note on ADR/plan numbering and pruning (2026-08-04)
+
+The prior cycle's ADRs (0001-0009) and plans were audited against the shipped codebase.
+
+**Fully implemented, deleted:** ADR-0003 (layered kustomize `crds:`/`install:`/`resources:` tiers — `crds:` is a top-level entry in four facets, the tier syntax is live everywhere), ADR-0005 (`flux:` replacing `kustomize:` as the facet key — no facet uses the old key anymore), ADR-0008 (cluster identity and SSO — the `identity` capability, `addons.keycloak` removal, inferred Grafana/kube-apiserver SSO, and the client-secret copy-Job are all live and tested), and the plans `hetzner-support.md` (compute/CSI/LB/DNS all wired and tested) and `policy-tier-migration.md` (no `policy-base`/`policy-resources` references remain anywhere).
+
+**Speculative, zero code, pruned to backlog notes below rather than carried forward as full documents:** ADR-0001 (tunnel as an independent subsystem), ADR-0002 (Cloudflare auth via static Secret), ADR-0006 (bring-your-own network/DNS — also blocked on an unstarted `cli`-side expression-evaluable `path:` field), the plan `cloudflare-proxy.md`, the plan `vercel-parity.md` (no Knative/buildpack code exists), and the plan `cloud-progressive-scaling.md` (basic pool autoscaling already exists independently of this plan; the multi-AZ/HA and security-tightening transitions it describes are untouched).
+
+**Rejected, deleted:** the plan `blueprint-list-generation.md` — the motivating gap (Alertmanager notification routing) was solved with static per-driver schema fields instead; the doc says so itself.
+
+**Superseded, deleted, with residual open items folded into backlog notes:** the plan `keycloak-idp.md` — its identity/SSO model is superseded by (now-deleted, now-shipped) ADR-0008, but two items it tracked are not yet addressed by any code: Keycloak database sizing/connection-scaling config, and realm reconciliation via `keycloak-config-cli` (today is one-shot import only).
+
+**Carried forward from the prior cycle, renumbered 0001-0003, rescoped to what's actually left:**
+
+| # | Title | What's left |
+|---|---|---|
+| [0001](0001-internal-external-gateways-and-dns.md) | Split external and internal gateways, DNS, and endpoints | All three milestones. A prior attempt (`feat/gateway-external-internal-split`) was never merged and isn't an ancestor of `main`; the running code is still the pre-ADR single-gateway model. |
+| [0002](0002-cluster-secrets-management.md) | Cluster secrets — ExternalSecret materialization | The plain-`Secret` path (sensitive schema properties + facet `secrets:`/`data:` wiring) is shipped and live in five facets. Materializing the same entries as an `ExternalSecret` once ADR-0004 and ADR-0005 are both enabled remains. |
+| [0003](0003-versioning-and-upgrade-contract.md) | Upgrade-path contract over bundled dependencies | The `breaking`→`minor` label-mapping fix is shipped. Autolabeling structural-dependency PRs and a Renovate policy that stops blanket-automerging Talos/`k8s-versions` remain. |
+
+**New this cycle, driven by Windsor Manager's build-out and the hardening audit:**
+
+| # | Title | Why |
+|---|---|---|
+| [0004](0004-external-secrets-operator.md) | External Secrets Operator addon | Formalizes [core#2284](https://github.com/windsorcli/core/issues/2284). Runtime secret sync every cluster wants, standalone or fleet. |
+| [0005](0005-secrets-store.md) | secrets_store — OpenBao or an external Vault-API-compatible store | Formalizes [core#2285](https://github.com/windsorcli/core/issues/2285), extended with an `external` driver — the shape a downstream fleet cluster needs to read from Windsor Manager's shared OpenBao instead of self-hosting its own. |
+| [0006](0006-object-store-seaweedfs.md) | SeaweedFS as a second `object_store` driver | A lighter-weight alternative to MinIO's Operator+Tenant split for platforms without cloud CSI economics. |
+| [0007](0007-backup-restore-velero.md) | Backup and restore — Velero over `object_store` | Confirmed absent on every platform today; the single largest capability gap found. Also the prerequisite Manager's own-state backup (its ADR slot 0007) layers onto. |
+| [0008](0008-platform-hardening-parity.md) | Platform hardening parity | Every self-managed Talos platform ships etcd/disk unencrypted and with no audit trail, where AWS/Azure default both on; no platform has a network-policy default-deny baseline. The widest present/absent split found in the cross-platform audit. |
+
+**Going forward, `docs/adr/` is tracked in git, not gitignored, and there is no
+more `docs/plans/`** (the plan carried from the prior cycle, karpenter
+migration, is folded into this document below rather than kept as a
+separate file — see Active work). ADRs are deleted and the sequence
+restarts after every release; a carried-forward ADR should justify itself
+against the next release's actual scope, not just against "this isn't
+finished yet."
+
+## Active work (not an ADR — a build in progress)
+
+**Karpenter migration** (folded in from the deleted `docs/plans/karpenter-migration.md`).
+Self-hosted Karpenter replaces AWS EKS managed node groups + cluster-autoscaler
+(EKS Auto Mode is incompatible with Windsor's Cilium CNI); the portable `pools`
+schema is redesigned to a Karpenter-native model; Azure converges on AKS Node
+Auto-Provisioning. Status: PR 1 (Terraform substrate — Karpenter IAM, node
+role/instance profile, SQS spot-interruption queue) landed in
+`terraform/cluster/aws-eks/karpenter.tf`, gated behind `enable_karpenter`, but
+no facet or context sets that variable, so it's unreachable through the
+blueprint today. PRs 2-4 (Karpenter deployment + NodePool generation from a
+redesigned `pools` schema, cluster-autoscaler removal, Azure NAP convergence)
+have not started; cluster-autoscaler and the count/min/max `pools` schema are
+both still fully in place. This will get its own ADR once the NodePool schema
+redesign — the load-bearing decision — needs to be written down; until then
+it's tracked here as in-progress work, not a design question.
+
+## Backlog (pruned or considered, no ADR carried)
+
+From the prior cycle's pruning:
+
+- **Tunnel as an independent subsystem** (Cloudflare Tunnel first, ngrok/Tailscale Funnel/Inlets later) — a top-level schema concept and its own namespace, fronting the external gateway once ADR-0001's split lands. Zero code.
+- **Cloudflare auth via static in-cluster Secret** — the only viable auth model until ADR-0005's `external`/vault-compatible driver covers it too. Depends on the tunnel work above.
+- **Bring-your-own network and DNS zone** — sibling `terraform/<layer>/<project>-data` modules for landing in a pre-existing VPC/VNet or hosted zone, selected by an expression-evaluable `path:` field. Needs a `cli`-side change (`collectTerraformComponents` doesn't evaluate `Path` as an expression today) before any core-side work can start.
+- **Vercel parity** — a self-hosted Vercel-like experience (Knative + in-cluster buildpacks + an apps blueprint layered on core). No code exists.
+- **Cloud progressive scaling** — a documented cheap→elastic→HA→hardened upgrade path for AWS/Azure deploys, beyond the pool-level autoscaling that already exists.
+- **Keycloak database sizing/connection scaling** — `identity.keycloak` has no storage/resource or connection-pooler config yet.
+- **Keycloak realm reconciliation** — realm config is one-shot import only; no `keycloak-config-cli`-style continuous reconciliation.
+- **ADR-0008 (deleted, identity)'s own fast-follow items** (not gaps, just not yet started): MinIO console SSO, gateway edge auth via the identity provider, and non-Keycloak `oidc` endpoint-derivation assumptions for providers that don't follow the Keycloak URL convention.
+
+From this cycle's manager/hardening review, considered and not carried as an
+ADR — either not urgent enough or not grounded enough yet:
+
+- **Image signature verification** (cosign/sigstore via Kyverno `verifyImages`) — no consumer asking for it today, but a small, low-risk follow-on once policy work next touches the `policy` addon; `require-image-digest` already gives it a digest to verify against.
+- **Container registry mirror / pull-through cache** — needed for Harbor's disconnected-install story, but Manager's own roadmap explicitly defers Harbor itself ("needed for the disconnected install, not for a first cut that pulls from upstream registries"). Premature until an airgapped install is actually being built.
+- **Service mesh / mTLS, multi-tenancy primitives, FinOps/cost visibility, egress control** — surveyed and found ungrounded: no addon, ADR, or manager reference names any of these as a real near-term need. Not carried.


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This PR touches only documentation — no facets, kustomize resources, Terraform, or CI workflows are modified — so there is no production blast radius.
>
> **Overview**
>
> The change removes `docs/adr/` and `docs/plans/` from `.gitignore` and commits eight proposed ADRs (0001–0008) together with a v0.8.0 release roadmap. The ADRs cover the gateway external/internal split, ExternalSecret materialization, versioning/upgrade contract, External Secrets Operator, secrets store (OpenBao + external driver), SeaweedFS as a second object-store driver, Velero backup, and platform hardening parity across Talos platforms.
>
> All eight ADRs carry **Proposed** status; none describe code already merged. The roadmap explicitly audits the prior cycle's ADRs against the shipped codebase, deleting fully-implemented or speculative documents and carrying forward only what genuinely remains — a useful self-audit that makes the state of each decision traceable.

<!-- /claude-code-review:summary -->
