### PR TITLE
fix(schema): restore topology-aware cpu/memory defaults for cluster node pools

### DIFF
--- a/contexts/_template/facets/platform-base.yaml
+++ b/contexts/_template/facets/platform-base.yaml
@@ -71,12 +71,14 @@ config:
   # when unset so facets own the defaults). Consumers read cluster_resources_effective
   # rather than cluster.* because some platform facets replace cluster.controlplanes
   # with a terraform list. A controlplane that runs workloads — flagged schedulable
-  # or in a workerless cluster — gets a larger baseline than a dedicated one.
-  # Dedicated memory is 8Gi (not 4) to leave etcd + kube-apiserver headroom.
+  # or in a workerless cluster — gets a larger memory baseline than a dedicated one
+  # (8Gi to leave etcd + kube-apiserver headroom). cpu stays flat: container platforms
+  # (docker) reject a cpus value above the host's real core count at creation time, so
+  # it can't scale with topology the way memory can without knowing the host's capacity.
   - name: cluster_resources_effective
     value:
       controlplanes:
-        cpu: "${cluster.controlplanes.cpu ?? ((cluster_nodes_effective.workers == 0 || (cluster.controlplanes.schedulable ?? false)) ? 8 : 4)}"
+        cpu: "${cluster.controlplanes.cpu ?? 4}"
         memory: "${cluster.controlplanes.memory ?? ((cluster_nodes_effective.workers == 0 || (cluster.controlplanes.schedulable ?? false)) ? 12 : 8)}"
       workers:
         cpu: "${cluster.workers.cpu ?? 4}"

--- a/contexts/_template/schema.yaml
+++ b/contexts/_template/schema.yaml
@@ -127,13 +127,11 @@ $defs:
     cpu:
       type: integer
       minimum: 1
-      default: 4
-      description: CPU cores per node. Default 4 applies to both controlplane and worker pools.
+      description: CPU cores per node. Unset lets cluster_resources_effective apply a topology-aware default.
     memory:
       type: integer
       minimum: 1
-      default: 8
-      description: Memory in GB per node. Default 8 applies to both controlplane and worker pools.
+      description: Memory in GB per node. Unset lets cluster_resources_effective apply a topology-aware default.
     root_disk_size:
       type: integer
       minimum: 1

--- a/contexts/_template/tests/platform-docker.test.yaml
+++ b/contexts/_template/tests/platform-docker.test.yaml
@@ -393,9 +393,9 @@ cases:
             substitutions:
               local_volume_path: /mnt/data
 
-  # Workerless single-node: the controlplane runs everything itself, so it gets the
-  # larger baseline (cluster_resources_effective's schema-unset default, not a flat 4/8).
-  - name: workerless single-node controlplane defaults to the larger cpu/memory baseline
+  # Workerless single-node: the controlplane runs everything itself, so memory gets the
+  # larger baseline; cpu stays flat since it can't scale without knowing host capacity.
+  - name: workerless single-node controlplane defaults to the larger memory baseline
     values:
       platform: docker
       workstation:
@@ -413,7 +413,7 @@ cases:
           inputs:
             cluster_nodes:
               controlplanes:
-                cpu: 8
+                cpu: 4
                 memory: 12
 
   # Dedicated controlplane sharing load with real workers gets the smaller baseline.

--- a/contexts/_template/tests/platform-docker.test.yaml
+++ b/contexts/_template/tests/platform-docker.test.yaml
@@ -393,6 +393,69 @@ cases:
             substitutions:
               local_volume_path: /mnt/data
 
+  # Workerless single-node: the controlplane runs everything itself, so it gets the
+  # larger baseline (cluster_resources_effective's schema-unset default, not a flat 4/8).
+  - name: workerless single-node controlplane defaults to the larger cpu/memory baseline
+    values:
+      platform: docker
+      workstation:
+        runtime: colima
+      dns: *default-dns
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster: *default-cluster
+    terraformOutputs: *default-terraform-outputs
+    expect:
+      terraform:
+        - name: compute
+          path: compute/docker
+          inputs:
+            cluster_nodes:
+              controlplanes:
+                cpu: 8
+                memory: 12
+
+  # Dedicated controlplane sharing load with real workers gets the smaller baseline.
+  - name: controlplane with workers defaults to the dedicated cpu/memory baseline
+    values:
+      platform: docker
+      workstation:
+        runtime: colima
+      dns: *default-dns
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster:
+        driver: talos
+        controlplanes:
+          nodes:
+            controlplane-1: *cp1-node
+        workers:
+          count: 1
+    terraformOutputs:
+      compute:
+        controlplanes:
+          - endpoint: 10.5.0.10:6443
+            node: 10.5.0.10
+            hostname: controlplane-1
+        workers:
+          - endpoint: 10.5.0.20:6443
+            node: 10.5.0.20
+            hostname: worker-1
+    expect:
+      terraform:
+        - name: compute
+          path: compute/docker
+          inputs:
+            cluster_nodes:
+              controlplanes:
+                cpu: 4
+                memory: 8
+              workers:
+                cpu: 4
+                memory: 8
+
   # Edge: docker without workstation yields no cluster and no gitops (gitops always dependsOn cluster; cluster only when workstation enabled).
   - name: docker without workstation has no cluster terraform
     values:


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This change removes schema-level static defaults for `cpu` and `memory` on cluster node pool specs, which alters the resource allocation any existing cluster gets if those fields are not explicitly set.
>
> **Overview**
>
> The PR removes hardcoded `default: 4` (CPU) and `default: 8` (memory) entries from the `$defs` node pool schema in `contexts/_template/schema.yaml`, delegating default resolution entirely to `cluster_resources_effective`. That function can now apply topology-aware logic: a single controlplane with no workers receives a larger baseline (8 CPU / 12 GB), while a dedicated controlplane sharing a cluster with workers receives the former flat default (4 CPU / 8 GB). Two new test cases cover both topologies and document the expected values explicitly.
>
> The behavioural change is limited to users who have not explicitly set `cpu` or `memory` in their cluster configuration — they will now receive different resource allocations depending on topology. The commit message frames this as a restore of prior behaviour rather than a net-new change.

<!-- /claude-code-review:summary -->
