### PR TITLE
fix(compute/docker): bare volume entries no longer produce an empty container_path

### DIFF
--- a/terraform/compute/docker/main.tf
+++ b/terraform/compute/docker/main.tf
@@ -330,7 +330,7 @@ resource "docker_container" "containers" {
         ),
         "{index}", tostring(each.value.index)
       )
-      container_path = join(":", slice(split(":", volumes.value), 1, length(split(":", volumes.value))))
+      container_path = length(split(":", volumes.value)) > 1 ? join(":", slice(split(":", volumes.value), 1, length(split(":", volumes.value)))) : split(":", volumes.value)[0]
       read_only      = false
     }
   }

--- a/terraform/compute/docker/test.tftest.hcl
+++ b/terraform/compute/docker/test.tftest.hcl
@@ -143,6 +143,48 @@ run "full_configuration" {
   }
 }
 
+# Regression: a bare (colon-less) volume entry — the schema's own default for
+# cluster.workers.volumes — must map host and container path to the same value,
+# not an empty container_path.
+run "bare_path_volume_entry" {
+  command = plan
+
+  variables {
+    context        = "test"
+    network_cidr   = "10.5.0.0/16"
+    create_network = true
+    cluster_nodes = {
+      distribution = "talos"
+      controlplanes = {
+        count     = 1
+        image     = "ghcr.io/siderolabs/talos:v1.11.5"
+        cpu       = 2
+        memory    = 2
+        volumes   = []
+        hostports = []
+      }
+      workers = {
+        count     = 1
+        image     = "ghcr.io/siderolabs/talos:v1.11.5"
+        cpu       = 4
+        memory    = 4
+        volumes   = ["/var/mnt/local"]
+        hostports = []
+      }
+    }
+  }
+
+  assert {
+    condition     = contains([for v in docker_container.containers["worker-1"].volumes : v.container_path], "/var/mnt/local")
+    error_message = "Bare volume entry must set container_path, not an empty string"
+  }
+
+  assert {
+    condition     = contains([for v in docker_container.containers["worker-1"].volumes : v.host_path], "/var/mnt/local")
+    error_message = "Bare volume entry must set host_path to the same value as container_path"
+  }
+}
+
 # Complex: cluster_nodes = null yields no cluster containers; only instances when provided.
 run "no_cluster_nodes_no_containers" {
   command = plan


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This is an isolated, targeted bug fix in the Docker compute module's volume path calculation, with no effect on callers that already use colon-delimited volume strings.
>
> **Overview**
>
> When a volume entry in `cluster_nodes.workers.volumes` contains no colon — a bare path like `/var/mnt/local` — the previous expression sliced an empty range and produced an empty `container_path`, which would cause Docker to reject the container spec. The fix guards with a ternary: if no colon is present the whole string is used as both host and container path, matching Docker's own convention for bare-path bind mounts.
>
> A regression test (`bare_path_volume_entry`) is added alongside the fix. It runs as a plan-only test and asserts that both `container_path` and `host_path` equal `/var/mnt/local` for a single bare-path worker volume, covering the previously broken code path.

<!-- /claude-code-review:summary -->
