### PR TITLE
fix(quickwit): update log index and descriptions to v0_9

### DIFF
--- a/kustomize/observability/install/grafana/quickwit/patches/patch.json
+++ b/kustomize/observability/install/grafana/quickwit/patches/patch.json
@@ -8,7 +8,7 @@
       "type": "quickwit-quickwit-datasource",
       "url": "http://quickwit-searcher.system-observability.svc.cluster.local:7280/api/v1",
       "jsonData": {
-        "index": "otel-logs-v0_7",
+        "index": "otel-logs-v0_9",
         "logLevelField": "severity_text",
         "logMessageField": "body.message"
       }

--- a/kustomize/observability/resources/fluentd/outputs/quickwit/clusteroutput.yaml
+++ b/kustomize/observability/resources/fluentd/outputs/quickwit/clusteroutput.yaml
@@ -7,5 +7,5 @@ metadata:
 spec:
   outputs:
     - http:
-        endpoint: http://quickwit-indexer.system-observability.svc.cluster.local:7280/api/v1/otel-logs-v0_7/ingest
+        endpoint: http://quickwit-indexer.system-observability.svc.cluster.local:7280/api/v1/otel-logs-v0_9/ingest
         contentType: application/json

--- a/kustomize/observability/resources/grafana/dashboards/logs/quickwit/kustomization.yaml
+++ b/kustomize/observability/resources/grafana/dashboards/logs/quickwit/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
 # Unified logs dashboard for Quickwit
-# Custom dashboard - queries OTEL logs (otel-logs-v0_7) via quickwit-logs datasource
+# Custom dashboard - queries OTEL logs (otel-logs-v0_9) via quickwit-logs datasource
 
 configMapGenerator:
   - name: grafana-dashboards-logs

--- a/kustomize/observability/resources/grafana/dashboards/logs/quickwit/logs.json
+++ b/kustomize/observability/resources/grafana/dashboards/logs/quickwit/logs.json
@@ -64,7 +64,7 @@
       }
     ]
   },
-  "description": "Unified logs overview from Quickwit (otel-logs-v0_7)",
+  "description": "Unified logs overview from Quickwit (otel-logs-v0_9)",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This change updates shared observability infrastructure (Fluentd log ingestion and Grafana dashboards), and if the target Quickwit index does not exist at apply time, log ingestion will silently fail.
>
> **Overview**
>
> The PR updates four files to advance the Quickwit OTEL log index version from `otel-logs-v0_7` to `otel-logs-v0_9`: the Fluentd ClusterOutput ingest endpoint, the Grafana datasource patch, the Grafana dashboard JSON description, and a kustomization comment. The change is narrow and mechanical — every reference to the old index name is updated consistently.
>
> The index version advances by two (skipping `v0_8`), and no Quickwit index definition or migration is included in the diff. The `otel-logs-v0_9` index must therefore be provisioned in Quickwit out-of-band before or alongside this configuration landing; otherwise Fluentd will fail to ingest and Grafana will show no data. Logs stored in `otel-logs-v0_7` will no longer be visible after the Grafana datasource switches.

<!-- /claude-code-review:summary -->
