### PR TITLE
fix(database): flatten cloudnativepg HA operator values to chart top level

### DIFF
--- a/kustomize/database/.docs.yaml
+++ b/kustomize/database/.docs.yaml
@@ -12,7 +12,7 @@ components:
     description: "Patches the operator HelmRelease to depend on `kube-prometheus-stack` (system-telemetry) and enable `monitoring.podMonitorEnabled: true` with `release: kube-prometheus-stack` discovery labels."
   cloudnativepg/ha:
     enable_when: "`database.postgres.driver == 'cloudnativepg'` AND `topology == 'ha'`"
-    description: "Patches the operator HelmRelease for HA: `operator.replicaCount: 2`, hostname-key pod anti-affinity, PodDisruptionBudget `minAvailable: 1`, rolling update `maxUnavailable: 1`."
+    description: "Patches the operator HelmRelease for HA: `replicaCount: 2`, hostname-key pod anti-affinity, rolling update `maxUnavailable: 1`. Adds a `PodDisruptionBudget` (`minAvailable: 1`) selecting the operator pods."
   cloudnativepg/single-node:
     enable_when: "`database.postgres.driver == 'cloudnativepg'` AND `topology == 'single-node'`"
     description: "Patches the operator HelmRelease to append `--leader-elect=false` via `additionalArgs`. The chart unconditionally passes `--leader-elect`; Go's flag parser is last-wins so the override wins."

--- a/kustomize/database/README.md
+++ b/kustomize/database/README.md
@@ -101,7 +101,7 @@ before reconciling.
 |---|---|---|
 | `cloudnativepg` | `database.postgres.driver == 'cloudnativepg'` | Helm release of CloudNativePG in `system-database`. `clusterWide: true` so the operator reconciles `Cluster` CRs in any namespace. Mutating and validating webhooks default to `failurePolicy: Fail` so misconfigured Clusters are rejected at admission. |
 | `cloudnativepg/prometheus` | `database.postgres.driver == 'cloudnativepg'` AND `observability.enabled: true` | Patches the operator HelmRelease to depend on `kube-prometheus-stack` (system-telemetry) and enable `monitoring.podMonitorEnabled: true` with `release: kube-prometheus-stack` discovery labels. |
-| `cloudnativepg/ha` | `database.postgres.driver == 'cloudnativepg'` AND `topology == 'ha'` | Patches the operator HelmRelease for HA: `operator.replicaCount: 2`, hostname-key pod anti-affinity, PodDisruptionBudget `minAvailable: 1`, rolling update `maxUnavailable: 1`. |
+| `cloudnativepg/ha` | `database.postgres.driver == 'cloudnativepg'` AND `topology == 'ha'` | Patches the operator HelmRelease for HA: `replicaCount: 2`, hostname-key pod anti-affinity, rolling update `maxUnavailable: 1`. Adds a `PodDisruptionBudget` (`minAvailable: 1`) selecting the operator pods. |
 | `cloudnativepg/single-node` | `database.postgres.driver == 'cloudnativepg'` AND `topology == 'single-node'` | Patches the operator HelmRelease to append `--leader-elect=false` via `additionalArgs`. The chart unconditionally passes `--leader-elect`; Go's flag parser is last-wins so the override wins. |
 
 ## Dependencies

--- a/kustomize/database/install/cloudnativepg/ha/kustomization.yaml
+++ b/kustomize/database/install/cloudnativepg/ha/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
+resources:
+  - poddisruptionbudget.yaml
 patches:
   - path: patches/helm-release.yaml
 

--- a/kustomize/database/install/cloudnativepg/ha/patches/helm-release.yaml
+++ b/kustomize/database/install/cloudnativepg/ha/patches/helm-release.yaml
@@ -6,22 +6,18 @@ metadata:
   namespace: system-database
 spec:
   values:
-    operator:
-      replicaCount: 2
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchExpressions:
-                  - key: app.kubernetes.io/name
-                    operator: In
-                    values:
-                      - cloudnative-pg
-              topologyKey: kubernetes.io/hostname
-      podDisruptionBudget:
-        enabled: true
-        minAvailable: 1
-      updateStrategy:
-        rollingUpdate:
-          maxUnavailable: 1
+    replicaCount: 2
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                    - cloudnative-pg
+            topologyKey: kubernetes.io/hostname
+    updateStrategy:
+      rollingUpdate:
+        maxUnavailable: 1
 

--- a/kustomize/database/install/cloudnativepg/ha/poddisruptionbudget.yaml
+++ b/kustomize/database/install/cloudnativepg/ha/poddisruptionbudget.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: cloudnativepg
+  namespace: system-database
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cloudnative-pg
+      app.kubernetes.io/instance: cloudnativepg


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This change restructures Helm values for the CloudNativePG HA operator, correcting a misconfigured nesting that was silently ignored by the chart — but it also drops a `podDisruptionBudget` setting that protected the 2-replica HA operator during node disruptions.
>
> **Overview**
>
> The PR flattens the CloudNativePG HA operator's Helm values from an `operator:` subtree to the chart's top level, fixing a bug where `replicaCount`, `affinity`, and `updateStrategy` were never applied because the chart does not recognize an `operator` key. The structural fix is correct and necessary for the HA settings to take effect.
>
> The `podDisruptionBudget` block (`enabled: true`, `minAvailable: 1`) present in the original was not carried over to the flattened structure. Whether the chart exposes a top-level PDB value or relies on a chart-default PDB should be confirmed; if neither is true, the 2-replica operator deployment loses its eviction guard during node maintenance.

<!-- /claude-code-review:summary -->
