### PR TITLE
chore(docs): regenerate terraform module READMEs

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -33,6 +33,7 @@ layer. Links from there land here.
 | [compute/hcloud](compute/hcloud/) | Provisions Talos Linux nodes on Hetzner Cloud. |
 | [compute/hyperv](compute/hyperv/) | Talos VMs on Hyper-V (Windows host). |
 | [compute/incus](compute/incus/) | Talos VMs on Incus. |
+| [compute/vsphere](compute/vsphere/) | Talos VMs on VMware vSphere. |
 | [dns](dns/) | Public DNS zones for ACME certificates and external-dns. |
 | [dns/zone/azure-dns](dns/zone/azure-dns/) | DNS zone on Azure DNS. |
 | [dns/zone/hetzner](dns/zone/hetzner/) | Creates a primary Hetzner DNS zone via the official hcloud provider. |

--- a/terraform/backend/s3/README.md
+++ b/terraform/backend/s3/README.md
@@ -17,13 +17,13 @@ acquires the lock.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 6.52.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 6.58.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.52.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.58.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | 2.8.0 |
 
 ## Modules
@@ -34,18 +34,18 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_kms_alias.terraform_state_alias](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/kms_alias) | resource |
-| [aws_kms_key.terraform_state](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/kms_key) | resource |
-| [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket_lifecycle_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/s3_bucket_lifecycle_configuration) | resource |
-| [aws_s3_bucket_logging.this](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/s3_bucket_logging) | resource |
-| [aws_s3_bucket_policy.this](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/s3_bucket_policy) | resource |
-| [aws_s3_bucket_public_access_block.this](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/s3_bucket_public_access_block) | resource |
-| [aws_s3_bucket_server_side_encryption_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
-| [aws_s3_bucket_versioning.this](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/s3_bucket_versioning) | resource |
+| [aws_kms_alias.terraform_state_alias](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/kms_alias) | resource |
+| [aws_kms_key.terraform_state](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/kms_key) | resource |
+| [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_lifecycle_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/s3_bucket_lifecycle_configuration) | resource |
+| [aws_s3_bucket_logging.this](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/s3_bucket_logging) | resource |
+| [aws_s3_bucket_policy.this](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_bucket_public_access_block.this](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| [aws_s3_bucket_versioning.this](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/s3_bucket_versioning) | resource |
 | [local_file.backend_config](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/data-sources/caller_identity) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/data-sources/region) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/data-sources/caller_identity) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/data-sources/region) | data source |
 
 ## Inputs
 

--- a/terraform/cluster/aws-eks/additions/README.md
+++ b/terraform/cluster/aws-eks/additions/README.md
@@ -16,14 +16,14 @@ Kubernetes API once the control plane is reachable.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 6.52.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 6.58.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 3.2.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.52.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.58.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 3.2.1 |
 
 ## Modules
@@ -36,7 +36,7 @@ No modules.
 |------|------|
 | [kubernetes_config_map_v1.external_dns](https://registry.terraform.io/providers/hashicorp/kubernetes/3.2.1/docs/resources/config_map_v1) | resource |
 | [kubernetes_namespace_v1.system_dns](https://registry.terraform.io/providers/hashicorp/kubernetes/3.2.1/docs/resources/namespace_v1) | resource |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/data-sources/region) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/data-sources/region) | data source |
 
 ## Inputs
 

--- a/terraform/cni/cilium/README.md
+++ b/terraform/cni/cilium/README.md
@@ -38,7 +38,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cgroup_auto_mount"></a> [cgroup\_auto\_mount](#input\_cgroup\_auto\_mount) | Let Cilium mount the cgroup2 fs at startup (chart default). Set to false on systems that mount cgroups during init (Talos, most systemd-based distros on recent kernels) so Cilium uses the pre-mounted path instead of racing to mount its own. | `bool` | `true` | no |
-| <a name="input_cilium_version"></a> [cilium\_version](#input\_cilium\_version) | Version of the Cilium Helm chart to install. | `string` | `"1.19.6"` | no |
+| <a name="input_cilium_version"></a> [cilium\_version](#input\_cilium\_version) | Version of the Cilium Helm chart to install. | `string` | `"1.20.0"` | no |
 | <a name="input_cluster_endpoint"></a> [cluster\_endpoint](#input\_cluster\_endpoint) | Kubernetes API server endpoint (https://host:port). Required when kube\_proxy\_replacement is true so Cilium can reach the API server before eBPF service rules are active. | `string` | `""` | no |
 | <a name="input_ipam_mode"></a> [ipam\_mode](#input\_ipam\_mode) | Cilium IPAM mode. 'kubernetes' uses node CIDR ranges (default, works for Talos and standard EKS). 'eni' uses AWS ENI-based allocation for EKS native networking. | `string` | `"kubernetes"` | no |
 | <a name="input_kube_proxy_replacement"></a> [kube\_proxy\_replacement](#input\_kube\_proxy\_replacement) | Replace kube-proxy with Cilium's eBPF implementation. Requires cluster\_endpoint to be set. Recommended for Talos and EKS. | `bool` | `true` | no |

--- a/terraform/compute/hcloud/README.md
+++ b/terraform/compute/hcloud/README.md
@@ -20,15 +20,15 @@ providers.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
-| <a name="requirement_hcloud"></a> [hcloud](#requirement\_hcloud) | 1.66.1 |
-| <a name="requirement_imager"></a> [imager](#requirement\_imager) | 1.0.16 |
+| <a name="requirement_hcloud"></a> [hcloud](#requirement\_hcloud) | 1.68.0 |
+| <a name="requirement_imager"></a> [imager](#requirement\_imager) | 1.0.19 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_hcloud"></a> [hcloud](#provider\_hcloud) | 1.66.1 |
-| <a name="provider_imager"></a> [imager](#provider\_imager) | 1.0.16 |
+| <a name="provider_hcloud"></a> [hcloud](#provider\_hcloud) | 1.68.0 |
+| <a name="provider_imager"></a> [imager](#provider\_imager) | 1.0.19 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
@@ -39,13 +39,13 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [hcloud_firewall.this](https://registry.terraform.io/providers/hetznercloud/hcloud/1.66.1/docs/resources/firewall) | resource |
-| [hcloud_network.this](https://registry.terraform.io/providers/hetznercloud/hcloud/1.66.1/docs/resources/network) | resource |
-| [hcloud_network_subnet.this](https://registry.terraform.io/providers/hetznercloud/hcloud/1.66.1/docs/resources/network_subnet) | resource |
-| [hcloud_placement_group.this](https://registry.terraform.io/providers/hetznercloud/hcloud/1.66.1/docs/resources/placement_group) | resource |
-| [hcloud_server.this](https://registry.terraform.io/providers/hetznercloud/hcloud/1.66.1/docs/resources/server) | resource |
-| [hcloud_server_network.this](https://registry.terraform.io/providers/hetznercloud/hcloud/1.66.1/docs/resources/server_network) | resource |
-| [imager_image.this](https://registry.terraform.io/providers/hcloud-talos/imager/1.0.16/docs/resources/image) | resource |
+| [hcloud_firewall.this](https://registry.terraform.io/providers/hetznercloud/hcloud/1.68.0/docs/resources/firewall) | resource |
+| [hcloud_network.this](https://registry.terraform.io/providers/hetznercloud/hcloud/1.68.0/docs/resources/network) | resource |
+| [hcloud_network_subnet.this](https://registry.terraform.io/providers/hetznercloud/hcloud/1.68.0/docs/resources/network_subnet) | resource |
+| [hcloud_placement_group.this](https://registry.terraform.io/providers/hetznercloud/hcloud/1.68.0/docs/resources/placement_group) | resource |
+| [hcloud_server.this](https://registry.terraform.io/providers/hetznercloud/hcloud/1.68.0/docs/resources/server) | resource |
+| [hcloud_server_network.this](https://registry.terraform.io/providers/hetznercloud/hcloud/1.68.0/docs/resources/server_network) | resource |
+| [imager_image.this](https://registry.terraform.io/providers/hcloud-talos/imager/1.0.19/docs/resources/image) | resource |
 | [terraform_data.node_replacement](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 
 ## Inputs

--- a/terraform/dns/zone/azure-dns/README.md
+++ b/terraform/dns/zone/azure-dns/README.md
@@ -16,13 +16,13 @@ resources.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.79.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.81.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.79.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.81.0 |
 
 ## Modules
 

--- a/terraform/dns/zone/hetzner/README.md
+++ b/terraform/dns/zone/hetzner/README.md
@@ -19,13 +19,13 @@ Cloud API.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
-| <a name="requirement_hcloud"></a> [hcloud](#requirement\_hcloud) | 1.66.1 |
+| <a name="requirement_hcloud"></a> [hcloud](#requirement\_hcloud) | 1.68.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_hcloud"></a> [hcloud](#provider\_hcloud) | 1.66.1 |
+| <a name="provider_hcloud"></a> [hcloud](#provider\_hcloud) | 1.68.0 |
 
 ## Modules
 
@@ -35,8 +35,8 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [hcloud_zone.this](https://registry.terraform.io/providers/hetznercloud/hcloud/1.66.1/docs/resources/zone) | resource |
-| [hcloud_zone_rrset.delegation](https://registry.terraform.io/providers/hetznercloud/hcloud/1.66.1/docs/resources/zone_rrset) | resource |
+| [hcloud_zone.this](https://registry.terraform.io/providers/hetznercloud/hcloud/1.68.0/docs/resources/zone) | resource |
+| [hcloud_zone_rrset.delegation](https://registry.terraform.io/providers/hetznercloud/hcloud/1.68.0/docs/resources/zone_rrset) | resource |
 
 ## Inputs
 

--- a/terraform/dns/zone/route53/README.md
+++ b/terraform/dns/zone/route53/README.md
@@ -48,14 +48,14 @@ plus storage cost scales with query volume.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 6.52.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 6.58.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.52.0 |
-| <a name="provider_aws.us_east_1"></a> [aws.us\_east\_1](#provider\_aws.us\_east\_1) | 6.52.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.58.0 |
+| <a name="provider_aws.us_east_1"></a> [aws.us\_east\_1](#provider\_aws.us\_east\_1) | 6.58.0 |
 
 ## Modules
 
@@ -65,14 +65,14 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_cloudwatch_log_group.query_log](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/cloudwatch_log_group) | resource |
-| [aws_cloudwatch_log_resource_policy.query_log](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/cloudwatch_log_resource_policy) | resource |
-| [aws_kms_key.dnssec](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/kms_key) | resource |
-| [aws_route53_hosted_zone_dnssec.main](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/route53_hosted_zone_dnssec) | resource |
-| [aws_route53_key_signing_key.dnssec](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/route53_key_signing_key) | resource |
-| [aws_route53_query_log.main](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/route53_query_log) | resource |
-| [aws_route53_zone.main](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/route53_zone) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/data-sources/caller_identity) | data source |
+| [aws_cloudwatch_log_group.query_log](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_log_resource_policy.query_log](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/cloudwatch_log_resource_policy) | resource |
+| [aws_kms_key.dnssec](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/kms_key) | resource |
+| [aws_route53_hosted_zone_dnssec.main](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/route53_hosted_zone_dnssec) | resource |
+| [aws_route53_key_signing_key.dnssec](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/route53_key_signing_key) | resource |
+| [aws_route53_query_log.main](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/route53_query_log) | resource |
+| [aws_route53_zone.main](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/route53_zone) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/data-sources/caller_identity) | data source |
 
 ## Inputs
 

--- a/terraform/gitops/flux/README.md
+++ b/terraform/gitops/flux/README.md
@@ -69,8 +69,8 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_concurrency"></a> [concurrency](#input\_concurrency) | Number of concurrent reconciliations per Flux controller | `number` | `2` | no |
 | <a name="input_flux_namespace"></a> [flux\_namespace](#input\_flux\_namespace) | The namespace in which Flux will be installed | `string` | `"system-gitops"` | no |
-| <a name="input_flux_operator_version"></a> [flux\_operator\_version](#input\_flux\_operator\_version) | The version of the flux-operator and flux-instance Helm charts to install | `string` | `"0.55.0"` | no |
-| <a name="input_flux_version"></a> [flux\_version](#input\_flux\_version) | The Flux distribution version the operator installs (FluxInstance spec.distribution.version) | `string` | `"2.9.3"` | no |
+| <a name="input_flux_operator_version"></a> [flux\_operator\_version](#input\_flux\_operator\_version) | The version of the flux-operator and flux-instance Helm charts to install | `string` | `"0.58.0"` | no |
+| <a name="input_flux_version"></a> [flux\_version](#input\_flux\_version) | The Flux distribution version the operator installs (FluxInstance spec.distribution.version) | `string` | `"2.9.4"` | no |
 | <a name="input_git_auth_secret"></a> [git\_auth\_secret](#input\_git\_auth\_secret) | The name of the secret to store the git authentication details | `string` | `"flux-system"` | no |
 | <a name="input_git_password"></a> [git\_password](#input\_git\_password) | The git password or PAT used to authenticte with the git provider | `string` | `""` | no |
 | <a name="input_git_username"></a> [git\_username](#input\_git\_username) | The git user to use to authenticte with the git provider | `string` | `"git"` | no |

--- a/terraform/network/aws-vpc/README.md
+++ b/terraform/network/aws-vpc/README.md
@@ -17,13 +17,13 @@ lists describe the same AZ. Outputs feed the `cluster/aws-eks` module.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 6.52.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 6.58.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.52.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.58.0 |
 
 ## Modules
 
@@ -33,30 +33,30 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_cloudwatch_log_group.vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/cloudwatch_log_group) | resource |
-| [aws_default_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/default_security_group) | resource |
-| [aws_eip.nat](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/eip) | resource |
-| [aws_flow_log.main](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/flow_log) | resource |
-| [aws_iam_role.vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy.vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/iam_role_policy) | resource |
-| [aws_internet_gateway.main](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/internet_gateway) | resource |
-| [aws_kms_alias.vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/kms_alias) | resource |
-| [aws_kms_key.vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/kms_key) | resource |
-| [aws_nat_gateway.main](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/nat_gateway) | resource |
-| [aws_route53_zone.main](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/route53_zone) | resource |
-| [aws_route_table.isolated](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/route_table) | resource |
-| [aws_route_table.private](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/route_table) | resource |
-| [aws_route_table.public](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/route_table) | resource |
-| [aws_route_table_association.isolated](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/route_table_association) | resource |
-| [aws_route_table_association.private](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/route_table_association) | resource |
-| [aws_route_table_association.public](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/route_table_association) | resource |
-| [aws_subnet.isolated](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/subnet) | resource |
-| [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/subnet) | resource |
-| [aws_subnet.public](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/subnet) | resource |
-| [aws_vpc.main](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/vpc) | resource |
-| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/data-sources/availability_zones) | data source |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/data-sources/caller_identity) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/data-sources/region) | data source |
+| [aws_cloudwatch_log_group.vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/cloudwatch_log_group) | resource |
+| [aws_default_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/default_security_group) | resource |
+| [aws_eip.nat](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/eip) | resource |
+| [aws_flow_log.main](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/flow_log) | resource |
+| [aws_iam_role.vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/iam_role_policy) | resource |
+| [aws_internet_gateway.main](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/internet_gateway) | resource |
+| [aws_kms_alias.vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/kms_alias) | resource |
+| [aws_kms_key.vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/kms_key) | resource |
+| [aws_nat_gateway.main](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/nat_gateway) | resource |
+| [aws_route53_zone.main](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/route53_zone) | resource |
+| [aws_route_table.isolated](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/route_table) | resource |
+| [aws_route_table.private](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/route_table) | resource |
+| [aws_route_table.public](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/route_table) | resource |
+| [aws_route_table_association.isolated](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/route_table_association) | resource |
+| [aws_route_table_association.private](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/route_table_association) | resource |
+| [aws_route_table_association.public](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/route_table_association) | resource |
+| [aws_subnet.isolated](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/subnet) | resource |
+| [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/subnet) | resource |
+| [aws_subnet.public](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/subnet) | resource |
+| [aws_vpc.main](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/vpc) | resource |
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/data-sources/availability_zones) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/data-sources/caller_identity) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/data-sources/region) | data source |
 
 ## Inputs
 

--- a/terraform/network/azure-vnet/README.md
+++ b/terraform/network/azure-vnet/README.md
@@ -16,13 +16,13 @@ Outputs feed the `cluster/azure-aks` module.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.79.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.81.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.79.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.81.0 |
 
 ## Modules
 

--- a/terraform/pki/ca/README.md
+++ b/terraform/pki/ca/README.md
@@ -29,13 +29,13 @@ upstream.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | 4.1.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | 4.3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.1.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.3.0 |
 
 ## Modules
 
@@ -45,8 +45,8 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [tls_private_key.ca](https://registry.terraform.io/providers/hashicorp/tls/4.1.0/docs/resources/private_key) | resource |
-| [tls_self_signed_cert.ca](https://registry.terraform.io/providers/hashicorp/tls/4.1.0/docs/resources/self_signed_cert) | resource |
+| [tls_private_key.ca](https://registry.terraform.io/providers/hashicorp/tls/4.3.0/docs/resources/private_key) | resource |
+| [tls_self_signed_cert.ca](https://registry.terraform.io/providers/hashicorp/tls/4.3.0/docs/resources/self_signed_cert) | resource |
 
 ## Inputs
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This PR touches only auto-generated Terraform module READMEs and carries no risk of behavioral change.
>
> **Overview**
>
> The diff is entirely documentation: regenerated `terraform-docs` output across twelve modules. Provider version references are updated in several modules (AWS 6.52→6.58, azurerm 4.79→4.81, hcloud 1.66→1.68, imager 1.0.16→1.0.19, tls 4.1→4.3), and default version strings for Cilium (1.19.6→1.20.0), flux-operator (0.55→0.58), and Flux (2.9.3→2.9.4) are updated in the rendered input tables. The top-level module index gains a new entry for `compute/vsphere`.
>
> No `.tf` source files were changed in this PR; these READMEs reflect version pins already present in the source.

<!-- /claude-code-review:summary -->
