### PR TITLE
fix(ci): adjust gitops concurrency settings for CI runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -317,10 +317,14 @@ jobs:
       # container mid-test and re-bootstrap fails on the surviving etcd data.
       # gitops.concurrency is pinned low: the CPU-derived formula assumes a
       # roomy host, but here the 3-vCPU quota is most of the runner's own 4
-      # vCPUs, so Flux's default concurrency floods etcd/apiserver.
+      # vCPUs, so Flux's default concurrency floods etcd/apiserver. Falls
+      # back to the plain init if origin/main predates the gitops.concurrency
+      # schema field (this PR adds it).
       - name: Baseline — Windsor Init
         if: matrix.mode == 'upgrade' && steps.infra_diff.outputs.skip != 'true'
-        run: windsor init local --reset --set cluster.controlplanes.cpu=3 --set cluster.controlplanes.memory=8 --set gitops.concurrency=2
+        run: |
+          windsor init local --reset --set cluster.controlplanes.cpu=3 --set cluster.controlplanes.memory=8 --set gitops.concurrency=2 \
+            || windsor init local --reset --set cluster.controlplanes.cpu=3 --set cluster.controlplanes.memory=8
 
       - name: Baseline — Show blueprint
         if: matrix.mode == 'upgrade' && steps.infra_diff.outputs.skip != 'true'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -315,9 +315,12 @@ jobs:
       # Memory is pinned too so the container spec stays identical to the
       # upgrade test's baseline phase — an unpinned change replaces the
       # container mid-test and re-bootstrap fails on the surviving etcd data.
+      # gitops.concurrency is pinned low: the CPU-derived formula assumes a
+      # roomy host, but here the 3-vCPU quota is most of the runner's own 4
+      # vCPUs, so Flux's default concurrency floods etcd/apiserver.
       - name: Baseline — Windsor Init
         if: matrix.mode == 'upgrade' && steps.infra_diff.outputs.skip != 'true'
-        run: windsor init local --reset --set cluster.controlplanes.cpu=3 --set cluster.controlplanes.memory=8
+        run: windsor init local --reset --set cluster.controlplanes.cpu=3 --set cluster.controlplanes.memory=8 --set gitops.concurrency=2
 
       - name: Baseline — Show blueprint
         if: matrix.mode == 'upgrade' && steps.infra_diff.outputs.skip != 'true'
@@ -379,9 +382,10 @@ jobs:
       # The runner's 4 vCPUs host the entire single-node Talos container; a
       # cgroup quota at the runner's core count throttles every pod at once.
       # Memory is pinned alongside it to keep the container spec deterministic.
+      # gitops.concurrency is pinned low: see the baseline init step above.
       - name: Windsor Init
         if: matrix.mode == 'fresh'
-        run: windsor init local --reset --set cluster.controlplanes.cpu=3 --set cluster.controlplanes.memory=8
+        run: windsor init local --reset --set cluster.controlplanes.cpu=3 --set cluster.controlplanes.memory=8 --set gitops.concurrency=2
 
       - name: Show blueprint
         if: matrix.mode == 'fresh'

--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -128,12 +128,16 @@ terraform:
     inputs:
       # Incus runs the cluster in a nested VM with slower vCPUs, so the
       # CPU-derived formula overshoots and floods apiserver. Clamp to 2 there.
+      # gitops.concurrency overrides both: the formula assumes the
+      # container's cpu/memory quota is carved from a roomy host, which
+      # doesn't hold on a constrained host (e.g. a CI runner) where the
+      # quota is most of the host's own capacity.
       concurrency: >-
-        ${platform == 'incus' ? 2 : max(4, min(
+        ${gitops.concurrency ?? (platform == 'incus' ? 2 : max(4, min(
           floor(cluster_resources_effective.controlplanes.cpu / 2),
           floor(cluster_resources_effective.controlplanes.memory / 2),
           10
-        ))}
+        )))}
       git_username: ${workstation.git.username ?? "local"}
       git_password: ${workstation.git.password ?? "local"}
       webhook_token: ${gitops.webhook.token ?? "abcdef123456"}

--- a/contexts/_template/schema.yaml
+++ b/contexts/_template/schema.yaml
@@ -1080,6 +1080,10 @@ properties:
         type: boolean
         default: false
         description: Expose the flux-operator web UI through the gateway at flux.<domain>. The UI is unauthenticated, so only enable it behind a trusted or private gateway. Off by default; always reachable via port-forward regardless.
+      concurrency:
+        type: integer
+        minimum: 1
+        description: Override the CPU/memory-derived Flux controller --concurrent value. For constrained hosts (e.g. CI runners) where the control-plane container's quota is a small slice of the whole host, not just of a roomy dev machine.
     additionalProperties: false
 
   # Gateway configuration

--- a/contexts/_template/tests/option-workstation.test.yaml
+++ b/contexts/_template/tests/option-workstation.test.yaml
@@ -342,6 +342,45 @@ cases:
           inputs:
             concurrency: 4
 
+  # Edge: gitops.concurrency overrides the cpu/memory-derived formula, e.g.
+  # for a CI runner where the container's quota is most of the host's own.
+  - name: gitops.concurrency overrides the derived flux concurrency
+    values:
+      platform: docker
+      workstation:
+        runtime: colima
+      dns: *default-dns
+      gateway:
+        enabled: false
+      network: *default-network
+      gitops:
+        concurrency: 2
+      cluster:
+        driver: talos
+        controlplanes:
+          cpu: 8
+          memory: 8
+          nodes:
+            controlplane-1:
+              endpoint: 10.5.0.10:50000
+              node: 10.5.0.10
+              hostname: controlplane-1
+    terraformOutputs:
+      compute:
+        controlplanes:
+          - endpoint: 10.5.0.10:6443
+            node: 10.5.0.10
+            hostname: controlplane-1
+        workers: []
+      workstation:
+        registries: {}
+    expect:
+      terraform:
+        - name: gitops
+          path: gitops/flux
+          inputs:
+            concurrency: 2
+
   # Edge: docker-desktop — no lb kustomize components. Asserts workstation inputs use 4+len(registries) for IPs.
   - name: docker-desktop workstation has node hostport dns and no lb
     values:


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change adds an optional `gitops.concurrency` override to the Windsor facet system and pins it to `2` in CI, with no effect on deployments that do not set the field.
>
> **Overview**
>
> The PR introduces a new optional `gitops.concurrency` integer field (schema minimum: 1, no default) that short-circuits the CPU/memory-derived Flux controller concurrency formula when set. The facet expression is updated with a `??` nullish-coalescing guard so existing behavior is fully preserved when the field is absent. Both CI `windsor init` calls (fresh and upgrade-baseline modes) are pinned to `concurrency=2` to prevent Flux from flooding etcd/apiserver on the 4-vCPU runner where the 3-vCPU container quota leaves almost no headroom for the host itself. A test case covering the override path is included. The change is clean and self-contained.

<!-- /claude-code-review:summary -->
