### PR TITLE
feat(identity): expose identity_effective.admin_group in the identity contract

### DIFF
--- a/contexts/_template/facets/addon-identity.yaml
+++ b/contexts/_template/facets/addon-identity.yaml
@@ -15,6 +15,7 @@ config:
     value:
       realm: "${identity.keycloak.realm ?? 'platform'}"
       display_name: "${identity.display_name ?? 'SSO'}"
+      admin_group: "${identity.admin_group ?? 'platform-admins'}"
       issuer: >-
         ${(identity.driver ?? 'keycloak') == 'oidc' ? (identity.oidc.issuer ?? '') :
         (((identity.keycloak.hostname ?? '') == '' ?
@@ -155,12 +156,13 @@ flux:
           - "${cluster.oidc.enabled == true && (cluster.oidc.client_id ?? 'kubernetes') == 'kubernetes' ? 'keycloak/realm/clients/kubernetes' : ''}"
           # Dev-only admin/viewer users.
           - "${dev == true ? 'keycloak/realm/dev-user' : ''}"
-          # Dev-only: binds platform-admins to cluster-admin for kubectl OIDC login.
+          # Dev-only: binds the admin group to cluster-admin for kubectl OIDC login.
           - "${dev == true && cluster.oidc.enabled == true && (cluster.oidc.client_id ?? 'kubernetes') == 'kubernetes' ? 'keycloak/realm/clients/kubernetes/dev-rbac' : ''}"
         timeout: 10m
         interval: 5m
         substitutions:
           keycloak_realm: "${identity.keycloak.realm ?? 'platform'}"
+          keycloak_admin_group: "${identity_effective.admin_group}"
           # Grafana client fields for the realm-client patch.
           grafana_url: "${grafana_effective.url ?? ''}"
           grafana_redirect_uri: "${(grafana_effective.url ?? '') + '/login/generic_oauth'}"

--- a/contexts/_template/facets/addon-observability.yaml
+++ b/contexts/_template/facets/addon-observability.yaml
@@ -87,7 +87,7 @@ flux:
         # generic_oauth inputs — the provider label and endpoints come from identity (one
         # place, both drivers); endpoints default to the issuer's standard OIDC path, with
         # per-provider overrides under identity.oidc. client_id is the app name; role
-        # mapping defaults to platform-admins → Grafana Admin. All leaves are null-safe.
+        # mapping promotes the contract's admin group to Grafana Admin. All leaves are null-safe.
         oidc_name: "${identity_effective.display_name ?? 'SSO'}"
         oidc_client_id: grafana
         # Dev: one-click — clicking Grafana goes straight to the SSO login. Off elsewhere
@@ -99,7 +99,10 @@ flux:
         oidc_auth_url: "${(identity.oidc.auth_url ?? '') != '' ? identity.oidc.auth_url : ((identity_effective.issuer ?? '') + '/protocol/openid-connect/auth')}"
         oidc_token_url: "${(identity.oidc.token_url ?? '') != '' ? identity.oidc.token_url : ((identity_effective.backchannel_issuer ?? '') + '/protocol/openid-connect/token')}"
         oidc_userinfo_url: "${(identity.oidc.userinfo_url ?? '') != '' ? identity.oidc.userinfo_url : ((identity_effective.backchannel_issuer ?? '') + '/protocol/openid-connect/userinfo')}"
-        oidc_role_attribute_path: "${observability.grafana.role_attribute_path ?? \"contains(groups[*], '/platform-admins') && 'Admin' || 'Viewer'\"}"
+        oidc_role_attribute_path: >-
+          ${observability.grafana.role_attribute_path ??
+          ("contains(groups[*], '/" + (identity_effective.admin_group ?? 'platform-admins') +
+          "') && 'Admin' || 'Viewer'")}
     resources:
       - timeout: 10m
         interval: 5m

--- a/contexts/_template/schema.yaml
+++ b/contexts/_template/schema.yaml
@@ -1271,6 +1271,10 @@ properties:
         type: string
         default: SSO
         description: Login button label consumers show (e.g. "Sign in with <name>")
+      admin_group:
+        type: string
+        default: platform-admins
+        description: Group whose members SSO consumers treat as administrators
       oidc:
         type: object
         description: External OIDC provider settings (driver oidc)

--- a/contexts/_template/tests/addon-identity.test.yaml
+++ b/contexts/_template/tests/addon-identity.test.yaml
@@ -71,6 +71,7 @@ cases:
                 - keycloak/realm
               substitutions:
                 keycloak_realm: platform
+                keycloak_admin_group: platform-admins
         - name: database
           install:
             components:
@@ -254,6 +255,29 @@ cases:
                 - keycloak/realm
               substitutions:
                 keycloak_realm: corp
+
+  # Custom admin group flows through to the realm import substitution, which names
+  # the realm group, the dev user's membership, and the dev cluster-admin binding.
+  - name: custom admin group overrides the platform-admins default
+    values:
+      platform: metal
+      dns:
+        domain: example.local
+      gateway:
+        enabled: true
+      network: *default-network
+      cluster: *default-cluster
+      identity:
+        enabled: true
+        admin_group: corp-sre
+    expect:
+      flux:
+        - name: identity
+          resources:
+            - components:
+                - keycloak/realm
+              substitutions:
+                keycloak_admin_group: corp-sre
 
   # Inferred SSO (dev): identity + Grafana both on registers the grafana realm client.
   - name: grafana sso is inferred and patches the client into the realm

--- a/contexts/_template/tests/addon-observability.test.yaml
+++ b/contexts/_template/tests/addon-observability.test.yaml
@@ -53,7 +53,62 @@ cases:
               oidc_client_id: grafana
               oidc_auth_url: https://keycloak.example.local/realms/platform/protocol/openid-connect/auth
               oidc_token_url: http://keycloak-service.system-identity:8080/realms/platform/protocol/openid-connect/token
+              oidc_role_attribute_path: contains(groups[*], '/platform-admins') && 'Admin' || 'Viewer'
               grafana_root_url: https://grafana.example.local
+
+  # A custom identity admin group drives Grafana's role mapping.
+  - name: identity admin group drives the grafana role mapping
+    values:
+      platform: metal
+      dns:
+        domain: example.local
+      gateway:
+        enabled: true
+      network: *default-network
+      cluster: *default-cluster
+      identity:
+        enabled: true
+        admin_group: corp-sre
+        keycloak:
+          grafana_client_secret: sup3r-secret-oidc
+      observability:
+        enabled: true
+    expect:
+      flux:
+        - name: observability
+          install:
+            components:
+              - grafana/oidc
+            substitutions:
+              oidc_role_attribute_path: contains(groups[*], '/corp-sre') && 'Admin' || 'Viewer'
+
+  # An explicit role_attribute_path wins over the derived admin-group mapping.
+  - name: explicit role attribute path overrides the derived mapping
+    values:
+      platform: metal
+      dns:
+        domain: example.local
+      gateway:
+        enabled: true
+      network: *default-network
+      cluster: *default-cluster
+      identity:
+        enabled: true
+        admin_group: corp-sre
+        keycloak:
+          grafana_client_secret: sup3r-secret-oidc
+      observability:
+        enabled: true
+        grafana:
+          role_attribute_path: "'Editor'"
+    expect:
+      flux:
+        - name: observability
+          install:
+            components:
+              - grafana/oidc
+            substitutions:
+              oidc_role_attribute_path: "'Editor'"
 
   # External OIDC issuer (identity driver oidc): the effective issuer flows straight
   # through to Grafana's generic_oauth; the external client secret is supplied.

--- a/kustomize/identity/.docs.yaml
+++ b/kustomize/identity/.docs.yaml
@@ -18,7 +18,7 @@ components:
     description: "The `Keycloak` server CR. Keycloak serves HTTP internally (TLS terminates at the gateway) and stores realms in the `keycloak` database."
   keycloak/realm:
     enable_when: "`identity.driver == 'keycloak'`"
-    description: "One-shot `KeycloakRealmImport` for the platform realm (name from `identity.keycloak.realm`, default `platform`): a security baseline (sslRequired, brute-force detection, password policy, token/session lifetimes), a `platform-admins` group mapped to `realm-admin`. Consumers target this realm by name."
+    description: "One-shot `KeycloakRealmImport` for the platform realm (name from `identity.keycloak.realm`, default `platform`): a security baseline (sslRequired, brute-force detection, password policy, token/session lifetimes), and an admin group (name from `identity.admin_group`, default `platform-admins`) mapped to `realm-admin`. Consumers target this realm by name."
   keycloak/realm/clients/grafana:
     enable_when: "identity + Grafana both enabled (`grafana.sso != false`)"
     description: "Registers the `grafana` OIDC client in the platform `KeycloakRealmImport` (v2beta1, no client-admin-api CRDs). The secret resolves from a `GRAFANA_CLIENT_SECRET` placeholder (`spec.placeholders`) backed by `identity.keycloak.grafana_client_secret`, and the same value is copied into Grafana's namespace as `grafana-oidc-client`. One folder per consumer under `realm/clients/`."
@@ -27,10 +27,10 @@ components:
     description: "Registers the `kubernetes` OIDC client (public, PKCE) in the platform `KeycloakRealmImport` for kube-apiserver token validation. `cluster.oidc.issuer_url`/`client_id` are auto-inferred from this realm when unset, so enabling identity plus `cluster.oidc.enabled: true` needs no manual issuer/client config."
   keycloak/realm/dev-user:
     enable_when: "`dev == true`"
-    description: "Dev-only patch seeding standard platform-realm users so local SSO works out of the box: `admin` / `admin-password` (in `platform-admins` → admin everywhere) and `viewer` / `viewer-password` (no group → read-only). Passwords satisfy the realm's length(12) policy. Never applied outside dev."
+    description: "Dev-only patch seeding standard platform-realm users so local SSO works out of the box: `admin` / `admin-password` (in `identity.admin_group` → admin everywhere) and `viewer` / `viewer-password` (no group → read-only). Passwords satisfy the realm's length(12) policy. Never applied outside dev."
   keycloak/realm/clients/kubernetes/dev-rbac:
     enable_when: "`dev == true` and `cluster.oidc.enabled == true`"
-    description: "Dev-only `ClusterRoleBinding` mapping the `platform-admins` group to `cluster-admin`, so the seeded dev `admin` user can do something after logging in via kubectl OIDC. Never applied outside dev."
+    description: "Dev-only `ClusterRoleBinding` mapping the `identity.admin_group` group to `cluster-admin`, so the seeded dev `admin` user can do something after logging in via kubectl OIDC. Never applied outside dev."
   keycloak/gateway:
     enable_when: "`gateway.enabled == true`"
     description: "HTTPRoute publishing `keycloak.${external_domain}` through the shared external Gateway to the operator-managed `keycloak-service`."

--- a/kustomize/identity/README.md
+++ b/kustomize/identity/README.md
@@ -141,16 +141,21 @@ identity:
 Enabling Keycloak also imports a `platform` realm (apps never live in `master`).
 It ships a security baseline — `sslRequired: external`, brute-force detection, a
 `length(12) and notUsername and notEmail` password policy, and short access-token
-plus bounded SSO-session lifetimes — and a `platform-admins` group mapped to the
+plus bounded SSO-session lifetimes — and an admin group mapped to the
 realm-management `realm-admin` role as the one place to grant realm administration.
 Core creates the group; its members are deployment-specific and are not managed in
 git.
 
-Rename the realm to fit an existing naming convention:
+The group name is `identity.admin_group` (default `platform-admins`). Every SSO
+consumer reads it, so renaming it repoints Grafana's role mapping and the dev
+`cluster-admin` binding in one place.
+
+Rename the realm or the admin group to fit an existing naming convention:
 
 ```yaml
 identity:
   enabled: true
+  admin_group: corp-sre
   keycloak:
     realm: corp
 ```
@@ -166,7 +171,7 @@ authenticates against the platform realm, with no per-app flag. Core patches a `
 client into the platform realm import with its secret pinned via
 `identity.keycloak.grafana_client_secret` (a dev default applies in dev mode; required
 otherwise) and copies the same value into Grafana's namespace. The client carries a mapper
-that puts the `platform-admins` group into the token, which Grafana maps to the Admin role.
+that puts the admin group into the token, which Grafana maps to the Admin role.
 
 For an external OIDC provider (`identity.driver: oidc`) there is no realm to generate the
 secret, so supply the client secret from your provider:
@@ -185,19 +190,20 @@ observability:
 
 In dev mode the platform realm seeds standard users so local SSO works out of the box
 across every consumer (Grafana and any future one): **`admin` / `admin-password`** (in
-`platform-admins` → admin) and **`viewer` / `viewer-password`** (no group → read-only), so you can
+the admin group → admin) and **`viewer` / `viewer-password`** (no group → read-only), so you can
 see the role mapping take effect. The `admin` password is shared with the Keycloak console
 admin and is overridable through `identity.keycloak.admin.password`. Grafana also uses
 `auto_login` in dev, so clicking it goes straight to the SSO login. None of this is created
 outside dev.
 
-Opt out or override the role mapping:
+Grafana's role mapping is derived from `identity.admin_group`. Opt out of SSO, or replace
+the mapping outright:
 
 ```yaml
 observability:
   grafana:
     # sso: false                                              # opt out of SSO
-    role_attribute_path: "contains(groups[*], '/platform-admins') && 'Admin' || 'Viewer'"
+    role_attribute_path: "contains(groups[*], '/sre') && 'Admin' || 'Editor'"
 ```
 
 ### API-server (kubectl) single sign-on
@@ -219,8 +225,8 @@ The client is public (PKCE, no secret) — pair it with a `kubectl` OIDC login p
 inference, e.g. to point at a different realm or an already-existing client.
 
 OIDC only authenticates; it grants no RBAC on its own. In `dev`, a `ClusterRoleBinding`
-maps `platform-admins` to `cluster-admin` so the seeded `admin` user can do something
-after logging in. Outside dev, bind `platform-admins` (or another claim) to a role yourself.
+maps the admin group to `cluster-admin` so the seeded `admin` user can do something
+after logging in. Outside dev, bind the admin group (or another claim) to a role yourself.
 
 ### External identity provider
 
@@ -269,7 +275,7 @@ client re-imports the realm.
 - **Realm baseline.** The platform realm enforces `sslRequired: external`, brute-force
   detection, and a `length(12) and notUsername and notEmail` password policy, with
   short access tokens and bounded SSO sessions. Realm administration is granted through
-  the `platform-admins` group (`realm-admin`), not by handing out the master admin.
+  the `identity.admin_group` group (`realm-admin`), not by handing out the master admin.
 - **Client secrets.** SSO client secrets never land in git. For the hosted keycloak driver,
   `identity.keycloak.grafana_client_secret` is pinned into a Secret referenced by the realm
   import's `spec.placeholders`. For an external `oidc` provider, supply it from a store
@@ -288,11 +294,11 @@ client re-imports the realm.
 | `keycloak/database` | `identity.driver == 'keycloak'` | The CloudNativePG `Cluster` backing Keycloak: a `keycloak` database owned by role `keycloak`, published as the `keycloak-db-app` secret and the `keycloak-db-rw` service. Applied by the `identity-resources-database` tier, which gates on the `Cluster`'s `Ready` condition via `healthCheckExprs` and which the server tier waits on. |
 | `keycloak/database/ha` | `topology: ha` | Scales the CloudNativePG `Cluster` to 3 instances with required pod anti-affinity, so each Postgres instance lands on a distinct node. |
 | `keycloak` | `identity.driver == 'keycloak'` | The `Keycloak` server CR. Keycloak serves HTTP internally (TLS terminates at the gateway) and stores realms in the `keycloak` database. |
-| `keycloak/realm` | `identity.driver == 'keycloak'` | One-shot `KeycloakRealmImport` for the platform realm (name from `identity.keycloak.realm`, default `platform`): a security baseline (sslRequired, brute-force detection, password policy, token/session lifetimes), a `platform-admins` group mapped to `realm-admin`. Consumers target this realm by name. |
+| `keycloak/realm` | `identity.driver == 'keycloak'` | One-shot `KeycloakRealmImport` for the platform realm (name from `identity.keycloak.realm`, default `platform`): a security baseline (sslRequired, brute-force detection, password policy, token/session lifetimes), and an admin group (name from `identity.admin_group`, default `platform-admins`) mapped to `realm-admin`. Consumers target this realm by name. |
 | `keycloak/realm/clients/grafana` | identity + Grafana both enabled (`grafana.sso != false`) | Registers the `grafana` OIDC client in the platform `KeycloakRealmImport` (v2beta1, no client-admin-api CRDs). The secret resolves from a `GRAFANA_CLIENT_SECRET` placeholder (`spec.placeholders`) backed by `identity.keycloak.grafana_client_secret`, and the same value is copied into Grafana's namespace as `grafana-oidc-client`. One folder per consumer under `realm/clients/`. |
 | `keycloak/realm/clients/kubernetes` | `cluster.oidc.enabled == true` | Registers the `kubernetes` OIDC client (public, PKCE) in the platform `KeycloakRealmImport` for kube-apiserver token validation. `cluster.oidc.issuer_url`/`client_id` are auto-inferred from this realm when unset, so enabling identity plus `cluster.oidc.enabled: true` needs no manual issuer/client config. |
-| `keycloak/realm/dev-user` | `dev == true` | Dev-only patch seeding standard platform-realm users so local SSO works out of the box: `admin` / `admin-password` (in `platform-admins` → admin everywhere) and `viewer` / `viewer-password` (no group → read-only). Passwords satisfy the realm's length(12) policy. Never applied outside dev. |
-| `keycloak/realm/clients/kubernetes/dev-rbac` | `dev == true` and `cluster.oidc.enabled == true` | Dev-only `ClusterRoleBinding` mapping the `platform-admins` group to `cluster-admin`, so the seeded dev `admin` user can do something after logging in via kubectl OIDC. Never applied outside dev. |
+| `keycloak/realm/dev-user` | `dev == true` | Dev-only patch seeding standard platform-realm users so local SSO works out of the box: `admin` / `admin-password` (in `identity.admin_group` → admin everywhere) and `viewer` / `viewer-password` (no group → read-only). Passwords satisfy the realm's length(12) policy. Never applied outside dev. |
+| `keycloak/realm/clients/kubernetes/dev-rbac` | `dev == true` and `cluster.oidc.enabled == true` | Dev-only `ClusterRoleBinding` mapping the `identity.admin_group` group to `cluster-admin`, so the seeded dev `admin` user can do something after logging in via kubectl OIDC. Never applied outside dev. |
 | `keycloak/gateway` | `gateway.enabled == true` | HTTPRoute publishing `keycloak.${external_domain}` through the shared external Gateway to the operator-managed `keycloak-service`. |
 | `keycloak/cilium` | `gateway.driver == 'cilium'` | CiliumNetworkPolicy restricting Keycloak ingress to the gateway proxy. Cilium-enforced, so gated on the Cilium gateway driver. |
 | `keycloak/admin` | `identity.keycloak.admin.password` set, or `dev == true` | Points the `Keycloak` CR at the `keycloak-bootstrap-admin` secret via `spec.bootstrapAdmin`, instead of the operator's auto-generated temporary admin. The password is the supplied one, or in dev a known default shared with the SSO admin user. Honored only at initial cluster creation. |

--- a/kustomize/identity/resources/keycloak/realm/clients/kubernetes/dev-rbac/clusterrolebinding.yaml
+++ b/kustomize/identity/resources/keycloak/realm/clients/kubernetes/dev-rbac/clusterrolebinding.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: oidc-admin-group
+  name: oidc-platform-admins
 subjects:
   - kind: Group
     name: /${keycloak_admin_group}

--- a/kustomize/identity/resources/keycloak/realm/clients/kubernetes/dev-rbac/clusterrolebinding.yaml
+++ b/kustomize/identity/resources/keycloak/realm/clients/kubernetes/dev-rbac/clusterrolebinding.yaml
@@ -1,12 +1,12 @@
-# Dev-only: binds the seeded platform-admins group to cluster-admin so the
-# dev admin user can actually do something after an OIDC login.
+# Dev-only: binds the seeded admin group to cluster-admin so the dev admin user
+# can actually do something after an OIDC login.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: oidc-platform-admins
+  name: oidc-admin-group
 subjects:
   - kind: Group
-    name: /platform-admins
+    name: /${keycloak_admin_group}
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole

--- a/kustomize/identity/resources/keycloak/realm/dev-user/dev-user.patch.yaml
+++ b/kustomize/identity/resources/keycloak/realm/dev-user/dev-user.patch.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   realm:
     users:
-      # Admin, in platform-admins.
+      # Admin, in the realm's admin group.
       - username: admin
         enabled: true
         emailVerified: true
@@ -20,7 +20,7 @@ spec:
             value: ${dev_admin_password}
             temporary: false
         groups:
-          - /platform-admins
+          - /${keycloak_admin_group}
       # Read-only, no group.
       - username: viewer
         enabled: true

--- a/kustomize/identity/resources/keycloak/realm/realm.yaml
+++ b/kustomize/identity/resources/keycloak/realm/realm.yaml
@@ -36,7 +36,7 @@ spec:
     # scopes (email/profile/…). Each consumer's client assigns the built-ins it needs
     # and carries its own group-membership mapper for role mapping.
     groups:
-      - name: platform-admins
+      - name: ${keycloak_admin_group}
         clientRoles:
           realm-management:
             - realm-admin


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change adds a single, backward-compatible configuration field to the identity stack; the default preserves existing behavior for all existing deployments.
>
> **Overview**
>
> The PR introduces `identity.admin_group` (default `platform-admins`) as the single source of truth for the SSO admin group across all consumers. The value flows through the `identity_effective` contract into a new `keycloak_admin_group` Flux substitution, which updates the Keycloak realm import, the dev-user patch, and the dev `ClusterRoleBinding`. The Grafana `oidc_role_attribute_path` is also updated to derive the group name dynamically instead of hardcoding `platform-admins`.
>
> The dev `ClusterRoleBinding` is renamed from `oidc-platform-admins` to `oidc-admin-group`. In existing dev clusters where Flux pruning is disabled, the old binding is orphaned rather than replaced; with the default group name the two bindings are functionally equivalent, but the stale resource will persist until the cluster is recreated.

<!-- /claude-code-review:summary -->
