### PR TITLE
fix(docker): Reserve system resources in constrained environments

### DIFF
--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -88,39 +88,55 @@ config:
               - ignore: true
                 interface: eth0
 
-  # Docker only: the kubelet sizes the node from the Docker daemon's host, not
-  # the container's cgroup quota, so reserve the gap plus a control-plane
-  # slice. Always active (no host-vs-quota check in `when:`: a facet's `when:`
-  # only sees raw schema fields, not terraform outputs or another facet's
-  # computed `_effective` config); extraConfig stays out of the patch when
-  # there's no gap to reserve.
-  - name: talos_common
-    when: cluster.driver == 'talos' && (cluster.enabled ?? true) && platform == 'docker'
-    value:
-      common_patch:
-        machine:
-          kubelet:
-            extraConfig: >-
-              ${(terraform_output("compute", "host_cpu") ?? 0) > cluster_resources_effective.controlplanes.cpu
-                ? {
-                    systemReserved: {
-                      cpu: string(max(500,
-                        ((terraform_output("compute", "host_cpu") ?? 0) - cluster_resources_effective.controlplanes.cpu) * 1000 + 500
-                      )) + 'm',
-                      memory: string(max(1,
-                        (terraform_output("compute", "host_memory") ?? cluster_resources_effective.controlplanes.memory)
-                          - cluster_resources_effective.controlplanes.memory + 1
-                      )) + 'Gi'
-                    }
-                  }
-                : {}}
-
-  # Empty per-role patch slots for platform-docker to populate.
+  # Per-role patch slots for platform-docker to populate. Docker only: every
+  # node's kubelet sizes itself from the shared Docker daemon's host, not its
+  # own container's cgroup quota, so each role reserves its own gap against
+  # that host — computed per role since controlplanes and workers commonly
+  # run different quotas against the same host. `let` keeps host_cpu/
+  # host_memory resolved once per patch; string() only ever marshals them
+  # once they're concrete numbers, never a still-deferred terraform_output
+  # call, so there's nothing left to mis-scan on a later composition pass.
   - name: talos_common_docker
     when: cluster.driver == 'talos' && (cluster.enabled ?? true)
     value:
-      controlplane_config_patches: ""
-      worker_config_patches: ""
+      controlplane_config_patches: >-
+        ${let host_cpu = terraform_output('compute', 'host_cpu') ?? 0;
+          let host_memory = terraform_output('compute', 'host_memory') ?? cluster_resources_effective.controlplanes.memory;
+          let quota_cpu = cluster_resources_effective.controlplanes.cpu;
+          let quota_memory = cluster_resources_effective.controlplanes.memory;
+          platform != 'docker' || (host_cpu <= quota_cpu && host_memory <= quota_memory)
+            ? ''
+            : trimSuffix(string({
+                machine: {
+                  kubelet: {
+                    extraConfig: {
+                      systemReserved: {
+                        cpu: (host_cpu > quota_cpu ? string(max(500, (host_cpu - quota_cpu) * 1000 + 500)) : '0') + 'm',
+                        memory: (host_memory > quota_memory ? string(max(1, host_memory - quota_memory + 1)) : '0') + 'Gi'
+                      }
+                    }
+                  }
+                }
+              }), '\n')}
+      worker_config_patches: >-
+        ${let host_cpu = terraform_output('compute', 'host_cpu') ?? 0;
+          let host_memory = terraform_output('compute', 'host_memory') ?? cluster_resources_effective.workers.memory;
+          let quota_cpu = cluster_resources_effective.workers.cpu;
+          let quota_memory = cluster_resources_effective.workers.memory;
+          platform != 'docker' || (host_cpu <= quota_cpu && host_memory <= quota_memory)
+            ? ''
+            : trimSuffix(string({
+                machine: {
+                  kubelet: {
+                    extraConfig: {
+                      systemReserved: {
+                        cpu: (host_cpu > quota_cpu ? string(max(500, (host_cpu - quota_cpu) * 1000 + 500)) : '0') + 'm',
+                        memory: (host_memory > quota_memory ? string(max(1, host_memory - quota_memory + 1)) : '0') + 'Gi'
+                      }
+                    }
+                  }
+                }
+              }), '\n')}
 
   # Colima-on-Incus is a storage-driver test rig; force flannel (Cilium's eBPF
   # skews tests) and pair with kube-vip so LoadBalancer services still get an IP.

--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -88,6 +88,33 @@ config:
               - ignore: true
                 interface: eth0
 
+  # Docker only: the kubelet sizes the node from the Docker daemon's host, not
+  # the container's cgroup quota, so reserve the gap plus a control-plane
+  # slice. Always active (no host-vs-quota check in `when:`: a facet's `when:`
+  # only sees raw schema fields, not terraform outputs or another facet's
+  # computed `_effective` config); extraConfig stays out of the patch when
+  # there's no gap to reserve.
+  - name: talos_common
+    when: cluster.driver == 'talos' && (cluster.enabled ?? true) && platform == 'docker'
+    value:
+      common_patch:
+        machine:
+          kubelet:
+            extraConfig: >-
+              ${(terraform_output("compute", "host_cpu") ?? 0) > cluster_resources_effective.controlplanes.cpu
+                ? {
+                    systemReserved: {
+                      cpu: string(max(500,
+                        ((terraform_output("compute", "host_cpu") ?? 0) - cluster_resources_effective.controlplanes.cpu) * 1000 + 500
+                      )) + 'm',
+                      memory: string(max(1,
+                        (terraform_output("compute", "host_memory") ?? cluster_resources_effective.controlplanes.memory)
+                          - cluster_resources_effective.controlplanes.memory + 1
+                      )) + 'Gi'
+                    }
+                  }
+                : {}}
+
   # Empty per-role patch slots for platform-docker to populate.
   - name: talos_common_docker
     when: cluster.driver == 'talos' && (cluster.enabled ?? true)

--- a/contexts/_template/tests/option-cni.test.yaml
+++ b/contexts/_template/tests/option-cni.test.yaml
@@ -358,6 +358,8 @@ cases:
         loadbalancer_driver: kube-vip
         loadbalancer_mode: arp
       cluster: *default-cluster
+    terraformOutputs:
+      compute: {}
     expect:
       flux:
         - <<: *cni-install

--- a/contexts/_template/tests/option-workstation.test.yaml
+++ b/contexts/_template/tests/option-workstation.test.yaml
@@ -81,7 +81,6 @@ cases:
                 kubelet:
                   extraArgs:
                     rotate-server-certificates: "true"
-                  extraConfig: {}
                 registries:
                   config: {}
                   mirrors: {}
@@ -547,7 +546,9 @@ cases:
         - name: gitops
 
   # compute.host_cpu/host_memory (from the Docker daemon, via `docker info`)
-  # exceed the quota: the kubelet reserves the gap plus the control-plane slice.
+  # exceed the quota: the control plane reserves the gap plus the
+  # control-plane slice. Only controlplane_config_patches carries it —
+  # common_config_patches (shared with workers) stays untouched.
   - name: docker workstation reserves the host-to-quota gap for the control plane
     values:
       platform: docker
@@ -581,39 +582,164 @@ cases:
         - name: cluster
           path: cluster/talos
           inputs:
-            common_config_patches: |-
-              cluster:
-                allowSchedulingOnControlPlanes: true
-                controllerManager:
-                  extraArgs:
-                    leader-elect: "false"
-                etcd:
-                  extraArgs:
-                    auto-compaction-mode: revision
-                    auto-compaction-retention: "1000"
-                    max-snapshots: "3"
-                    max-wals: "3"
-                extraManifests:
-                - https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml
-                network:
-                  cni:
-                    name: none
-                proxy:
-                  disabled: true
-                scheduler:
-                  extraArgs:
-                    leader-elect: "false"
+            controlplane_config_patches: |-
               machine:
                 kubelet:
-                  extraArgs:
-                    rotate-server-certificates: "true"
                   extraConfig:
                     systemReserved:
                       cpu: 1500m
                       memory: 9Gi
-                registries:
-                  config: {}
-                  mirrors: {}
+
+  # compute.host_cpu exceeds the quota but host_memory matches it: only the
+  # cpu key reserves a gap, memory is omitted (regression for a bug where
+  # the memory floor activated on the cpu gap instead of its own).
+  - name: docker workstation reserves a cpu gap without inflating memory
+    values:
+      platform: docker
+      workstation:
+        runtime: colima
+      dns: *default-dns
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster:
+        driver: talos
+        controlplanes:
+          cpu: 3
+          memory: 8
+          nodes:
+            controlplane-1:
+              endpoint: 10.5.0.10:50000
+              node: 10.5.0.10
+              hostname: controlplane-1
+    terraformOutputs:
+      compute:
+        controlplanes:
+          - endpoint: 10.5.0.10:6443
+            node: 10.5.0.10
+            hostname: controlplane-1
+        workers: []
+        host_cpu: 4
+        host_memory: 8
+    expect:
+      terraform:
+        - name: cluster
+          path: cluster/talos
+          inputs:
+            controlplane_config_patches: |-
+              machine:
+                kubelet:
+                  extraConfig:
+                    systemReserved:
+                      cpu: 1500m
+                      memory: 0Gi
+
+  # compute.host_memory exceeds the quota but host_cpu matches it: only the
+  # memory key reserves a gap. Regression for the mirror-image bug where a
+  # cpu-only gate would have skipped the memory reservation entirely.
+  - name: docker workstation reserves a memory gap without a cpu gap
+    values:
+      platform: docker
+      workstation:
+        runtime: colima
+      dns: *default-dns
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster:
+        driver: talos
+        controlplanes:
+          cpu: 4
+          memory: 8
+          nodes:
+            controlplane-1:
+              endpoint: 10.5.0.10:50000
+              node: 10.5.0.10
+              hostname: controlplane-1
+    terraformOutputs:
+      compute:
+        controlplanes:
+          - endpoint: 10.5.0.10:6443
+            node: 10.5.0.10
+            hostname: controlplane-1
+        workers: []
+        host_cpu: 4
+        host_memory: 10
+    expect:
+      terraform:
+        - name: cluster
+          path: cluster/talos
+          inputs:
+            controlplane_config_patches: |-
+              machine:
+                kubelet:
+                  extraConfig:
+                    systemReserved:
+                      cpu: 0m
+                      memory: 3Gi
+
+  # Controlplanes and workers commonly run different quotas against the same
+  # shared host; each role reserves its own gap independently, not the
+  # controlplane's gap broadcast to every node.
+  - name: docker workstation reserves independent gaps for controlplanes and workers
+    values:
+      platform: docker
+      workstation:
+        runtime: colima
+      dns: *default-dns
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster:
+        driver: talos
+        controlplanes:
+          cpu: 3
+          memory: 8
+          nodes:
+            controlplane-1:
+              endpoint: 10.5.0.10:50000
+              node: 10.5.0.10
+              hostname: controlplane-1
+        workers:
+          count: 1
+          cpu: 6
+          memory: 10
+          nodes:
+            worker-1:
+              endpoint: 10.5.0.20:50000
+              node: 10.5.0.20
+              hostname: worker-1
+    terraformOutputs:
+      compute:
+        controlplanes:
+          - endpoint: 10.5.0.10:6443
+            node: 10.5.0.10
+            hostname: controlplane-1
+        workers:
+          - endpoint: 10.5.0.20:6443
+            node: 10.5.0.20
+            hostname: worker-1
+        host_cpu: 8
+        host_memory: 20
+    expect:
+      terraform:
+        - name: cluster
+          path: cluster/talos
+          inputs:
+            controlplane_config_patches: |-
+              machine:
+                kubelet:
+                  extraConfig:
+                    systemReserved:
+                      cpu: 5500m
+                      memory: 13Gi
+            worker_config_patches: |-
+              machine:
+                kubelet:
+                  extraConfig:
+                    systemReserved:
+                      cpu: 2500m
+                      memory: 11Gi
 
   # compute.host_cpu matches the quota (host and quota are the same size, e.g.
   # a dedicated runner): no gap to reserve.
@@ -649,37 +775,6 @@ cases:
       terraform:
         - name: cluster
           path: cluster/talos
-          inputs:
-            common_config_patches: |-
-              cluster:
-                allowSchedulingOnControlPlanes: true
-                controllerManager:
-                  extraArgs:
-                    leader-elect: "false"
-                etcd:
-                  extraArgs:
-                    auto-compaction-mode: revision
-                    auto-compaction-retention: "1000"
-                    max-snapshots: "3"
-                    max-wals: "3"
-                extraManifests:
-                - https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml
-                network:
-                  cni:
-                    name: none
-                proxy:
-                  disabled: true
-                scheduler:
-                  extraArgs:
-                    leader-elect: "false"
-              machine:
-                kubelet:
-                  extraArgs:
-                    rotate-server-certificates: "true"
-                  extraConfig: {}
-                registries:
-                  config: {}
-                  mirrors: {}
 
   # compute.host_cpu absent (e.g. an upgrade where the compute step hasn't
   # re-applied yet): no reservation, not a composition error.
@@ -698,34 +793,3 @@ cases:
       terraform:
         - name: cluster
           path: cluster/talos
-          inputs:
-            common_config_patches: |-
-              cluster:
-                allowSchedulingOnControlPlanes: true
-                controllerManager:
-                  extraArgs:
-                    leader-elect: "false"
-                etcd:
-                  extraArgs:
-                    auto-compaction-mode: revision
-                    auto-compaction-retention: "1000"
-                    max-snapshots: "3"
-                    max-wals: "3"
-                extraManifests:
-                - https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml
-                network:
-                  cni:
-                    name: none
-                proxy:
-                  disabled: true
-                scheduler:
-                  extraArgs:
-                    leader-elect: "false"
-              machine:
-                kubelet:
-                  extraArgs:
-                    rotate-server-certificates: "true"
-                  extraConfig: {}
-                registries:
-                  config: {}
-                  mirrors: {}

--- a/contexts/_template/tests/option-workstation.test.yaml
+++ b/contexts/_template/tests/option-workstation.test.yaml
@@ -81,6 +81,7 @@ cases:
                 kubelet:
                   extraArgs:
                     rotate-server-certificates: "true"
+                  extraConfig: {}
                 registries:
                   config: {}
                   mirrors: {}
@@ -544,3 +545,187 @@ cases:
     exclude:
       flux:
         - name: gitops
+
+  # compute.host_cpu/host_memory (from the Docker daemon, via `docker info`)
+  # exceed the quota: the kubelet reserves the gap plus the control-plane slice.
+  - name: docker workstation reserves the host-to-quota gap for the control plane
+    values:
+      platform: docker
+      workstation:
+        runtime: colima
+      dns: *default-dns
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster:
+        driver: talos
+        controlplanes:
+          cpu: 3
+          memory: 8
+          nodes:
+            controlplane-1:
+              endpoint: 10.5.0.10:50000
+              node: 10.5.0.10
+              hostname: controlplane-1
+    terraformOutputs:
+      compute:
+        controlplanes:
+          - endpoint: 10.5.0.10:6443
+            node: 10.5.0.10
+            hostname: controlplane-1
+        workers: []
+        host_cpu: 4
+        host_memory: 16
+    expect:
+      terraform:
+        - name: cluster
+          path: cluster/talos
+          inputs:
+            common_config_patches: |-
+              cluster:
+                allowSchedulingOnControlPlanes: true
+                controllerManager:
+                  extraArgs:
+                    leader-elect: "false"
+                etcd:
+                  extraArgs:
+                    auto-compaction-mode: revision
+                    auto-compaction-retention: "1000"
+                    max-snapshots: "3"
+                    max-wals: "3"
+                extraManifests:
+                - https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml
+                network:
+                  cni:
+                    name: none
+                proxy:
+                  disabled: true
+                scheduler:
+                  extraArgs:
+                    leader-elect: "false"
+              machine:
+                kubelet:
+                  extraArgs:
+                    rotate-server-certificates: "true"
+                  extraConfig:
+                    systemReserved:
+                      cpu: 1500m
+                      memory: 9Gi
+                registries:
+                  config: {}
+                  mirrors: {}
+
+  # compute.host_cpu matches the quota (host and quota are the same size, e.g.
+  # a dedicated runner): no gap to reserve.
+  - name: docker workstation with host at quota size sets no kubelet reservation
+    values:
+      platform: docker
+      workstation:
+        runtime: colima
+      dns: *default-dns
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster:
+        driver: talos
+        controlplanes:
+          cpu: 4
+          memory: 8
+          nodes:
+            controlplane-1:
+              endpoint: 10.5.0.10:50000
+              node: 10.5.0.10
+              hostname: controlplane-1
+    terraformOutputs:
+      compute:
+        controlplanes:
+          - endpoint: 10.5.0.10:6443
+            node: 10.5.0.10
+            hostname: controlplane-1
+        workers: []
+        host_cpu: 4
+        host_memory: 8
+    expect:
+      terraform:
+        - name: cluster
+          path: cluster/talos
+          inputs:
+            common_config_patches: |-
+              cluster:
+                allowSchedulingOnControlPlanes: true
+                controllerManager:
+                  extraArgs:
+                    leader-elect: "false"
+                etcd:
+                  extraArgs:
+                    auto-compaction-mode: revision
+                    auto-compaction-retention: "1000"
+                    max-snapshots: "3"
+                    max-wals: "3"
+                extraManifests:
+                - https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml
+                network:
+                  cni:
+                    name: none
+                proxy:
+                  disabled: true
+                scheduler:
+                  extraArgs:
+                    leader-elect: "false"
+              machine:
+                kubelet:
+                  extraArgs:
+                    rotate-server-certificates: "true"
+                  extraConfig: {}
+                registries:
+                  config: {}
+                  mirrors: {}
+
+  # compute.host_cpu absent (e.g. an upgrade where the compute step hasn't
+  # re-applied yet): no reservation, not a composition error.
+  - name: docker workstation without compute host output sets no kubelet reservation
+    values:
+      platform: docker
+      workstation:
+        runtime: colima
+      dns: *default-dns
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster: *default-cluster
+    terraformOutputs: *default-terraform-outputs
+    expect:
+      terraform:
+        - name: cluster
+          path: cluster/talos
+          inputs:
+            common_config_patches: |-
+              cluster:
+                allowSchedulingOnControlPlanes: true
+                controllerManager:
+                  extraArgs:
+                    leader-elect: "false"
+                etcd:
+                  extraArgs:
+                    auto-compaction-mode: revision
+                    auto-compaction-retention: "1000"
+                    max-snapshots: "3"
+                    max-wals: "3"
+                extraManifests:
+                - https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml
+                network:
+                  cni:
+                    name: none
+                proxy:
+                  disabled: true
+                scheduler:
+                  extraArgs:
+                    leader-elect: "false"
+              machine:
+                kubelet:
+                  extraArgs:
+                    rotate-server-certificates: "true"
+                  extraConfig: {}
+                registries:
+                  config: {}
+                  mirrors: {}

--- a/contexts/_template/tests/platform-docker.test.yaml
+++ b/contexts/_template/tests/platform-docker.test.yaml
@@ -272,7 +272,6 @@ cases:
                 kubelet:
                   extraArgs:
                     rotate-server-certificates: "true"
-                  extraConfig: {}
                 registries:
                   config: {}
                   mirrors:

--- a/contexts/_template/tests/platform-docker.test.yaml
+++ b/contexts/_template/tests/platform-docker.test.yaml
@@ -272,6 +272,7 @@ cases:
                 kubelet:
                   extraArgs:
                     rotate-server-certificates: "true"
+                  extraConfig: {}
                 registries:
                   config: {}
                   mirrors:

--- a/terraform/compute/docker/.terraform.lock.hcl
+++ b/terraform/compute/docker/.terraform.lock.hcl
@@ -1,6 +1,27 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/external" {
+  version     = "2.4.0"
+  constraints = "~> 2.3"
+  hashes = [
+    "h1:AmY6ZeIvqoTT5ZjzD+P49PeQH6Va1QLMkX+7MUQfYoA=",
+    "zh:0772afb42b658468ac5e15df33bf2080456f8f0b8ab163bfe9c50d2b2ea02135",
+    "zh:0ac31a9aaa43dfcff5944b791596cdc94e153348e4bb4642282d034dff548134",
+    "zh:32d8492b1bdcc956ca3c6d00c6392d0a83942ff11d4820c7ee63ca6796e06950",
+    "zh:3c0482e894429f528ce6655a76ab0d8a9f7c0dacc6c828865e1515d4a7dbb852",
+    "zh:61e68100b4db2f930b31491f23c602126382fd5e51252be1b551f0e17f8ddbee",
+    "zh:6d60f615a0ad85eb962c9eb94f25e3eba7a72684ce276ba5dfb23f36b295a8f8",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9ced2745eb5f1346203027d2dd7bf856ad1d279a25730ff7dbc6eec187aaca0c",
+    "zh:a8378558a177d43f55aa0d79d4fae91a704695122a1b109668c1daa8fb76f09d",
+    "zh:aadd98086133d3ebea67437d56512fdcc6dfb3bd34dfc23f276c0db9272e27b4",
+    "zh:beff701b653841e70441978137768f54e7dc6c27e7bf12a4589087f01f5bbcee",
+    "zh:c91c2223b29fdbc0044d20e1936ccc051d010727a13f2ff1e75e51f09bff33a3",
+    "zh:d491f9c2d32a39dc4031628469ae7c8aec0074312a7c1f0286b173cdcf854a54",
+  ]
+}
+
 provider "registry.terraform.io/kreuzwerker/docker" {
   version     = "4.5.0"
   constraints = "4.5.0"

--- a/terraform/compute/docker/README.md
+++ b/terraform/compute/docker/README.md
@@ -18,12 +18,14 @@ brings up via the Talos API.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_docker"></a> [docker](#requirement\_docker) | 4.5.0 |
+| <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_docker"></a> [docker](#provider\_docker) | 4.5.0 |
+| <a name="provider_external"></a> [external](#provider\_external) | 2.4.0 |
 
 ## Modules
 
@@ -37,6 +39,7 @@ No modules.
 | [docker_image.instances](https://registry.terraform.io/providers/kreuzwerker/docker/4.5.0/docs/resources/image) | resource |
 | [docker_network.main](https://registry.terraform.io/providers/kreuzwerker/docker/4.5.0/docs/resources/network) | resource |
 | [docker_volume.named](https://registry.terraform.io/providers/kreuzwerker/docker/4.5.0/docs/resources/volume) | resource |
+| [external_external.docker_host](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) | data source |
 
 ## Inputs
 
@@ -62,6 +65,8 @@ No modules.
 |------|-------------|
 | <a name="output_container_ports"></a> [container\_ports](#output\_container\_ports) | Port list per container name (for tests: hostports only on first controlplane when no workers, first worker when workers exist). |
 | <a name="output_controlplanes"></a> [controlplanes](#output\_controlplanes) | List of controlplane instances for cluster/talos (hostname, endpoint, node). Consumed by provider-docker → cluster/talos when workstation enabled. |
+| <a name="output_host_cpu"></a> [host\_cpu](#output\_host\_cpu) | CPU cores the Docker daemon reports for its host. |
+| <a name="output_host_memory"></a> [host\_memory](#output\_host\_memory) | Memory in GB the Docker daemon reports for its host. |
 | <a name="output_instances"></a> [instances](#output\_instances) | Flat list of all instances. Same shape as compute/incus (name, hostname, ipv4, ipv6, status, type, image, role). |
 | <a name="output_network_managed"></a> [network\_managed](#output\_network\_managed) | Whether the network was created by this module (true when create\_network is true) |
 | <a name="output_network_name"></a> [network\_name](#output\_network\_name) | The name of the network being used |

--- a/terraform/compute/docker/main.tf
+++ b/terraform/compute/docker/main.tf
@@ -13,6 +13,10 @@ terraform {
       source  = "kreuzwerker/docker"
       version = "4.5.0"
     }
+    external = {
+      source  = "hashicorp/external"
+      version = "~> 2.3"
+    }
   }
 }
 
@@ -226,6 +230,22 @@ locals {
     ])
     : x if x != null
   ])
+}
+
+# =============================================================================
+# Host Detection
+# =============================================================================
+
+# The Docker daemon's own view of its host. The kubelet inside each container
+# reads capacity from this, not from the container's cpu/memory quota, so
+# callers reserve the gap themselves (see cluster/talos systemReserved).
+data "external" "docker_host" {
+  program = ["docker", "info", "--format", "{\"ncpu\":\"{{.NCPU}}\",\"memtotal\":\"{{.MemTotal}}\"}"]
+}
+
+locals {
+  host_cpu    = tonumber(data.external.docker_host.result.ncpu)
+  host_memory = floor(tonumber(data.external.docker_host.result.memtotal) / pow(1024, 3))
 }
 
 # =============================================================================

--- a/terraform/compute/docker/outputs.tf
+++ b/terraform/compute/docker/outputs.tf
@@ -128,3 +128,13 @@ output "container_ports" {
   description = "Port list per container name (for tests: hostports only on first controlplane when no workers, first worker when workers exist)."
   value       = { for k, c in local.containers_by_name : k => coalesce(c.ports, []) }
 }
+
+output "host_cpu" {
+  description = "CPU cores the Docker daemon reports for its host."
+  value       = local.host_cpu
+}
+
+output "host_memory" {
+  description = "Memory in GB the Docker daemon reports for its host."
+  value       = local.host_memory
+}

--- a/terraform/compute/docker/test.tftest.hcl
+++ b/terraform/compute/docker/test.tftest.hcl
@@ -6,6 +6,17 @@ mock_provider "docker" {
   mock_resource "docker_container" {}
 }
 
+# Applies to every run below, so tests don't shell out to a real Docker daemon.
+override_data {
+  target = data.external.docker_host
+  values = {
+    result = {
+      ncpu     = "4"
+      memtotal = "17179869184"
+    }
+  }
+}
+
 # Minimal: required for cluster path — context, network_cidr, create_network, cluster_nodes (1 cp, 0 workers). Default runtime colima.
 run "minimal_configuration" {
   command = plan
@@ -73,6 +84,11 @@ run "minimal_configuration" {
   assert {
     condition     = output.network_name == "windsor-test"
     error_message = "network_name output should match created network"
+  }
+
+  assert {
+    condition     = output.host_cpu == 4 && output.host_memory == 16
+    error_message = "host_cpu/host_memory should come from the docker info override"
   }
 }
 


### PR DESCRIPTION
Closes #2468

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> The change is isolated to Docker-platform Talos workstation configurations and adds a new optional Terraform provider dependency; it has no effect on other platforms or drivers.
>
> **Overview**
>
> This PR adds host-resource detection to the Docker compute module by shelling out to `docker info` via the `hashicorp/external` provider, then exposing the host's CPU core count and memory (in GiB) as Terraform outputs. A new `talos_common` facet entry consumes those outputs to compute a kubelet `systemReserved` block that reserves the gap between the Docker host's real capacity and the container quota, preventing the kubelet from over-reporting available resources. Three new test cases cover the gap, no-gap, and absent-output scenarios.
>
> The `data "external"` source executes at `terraform plan` time, not just apply, so plan runs in environments without an accessible Docker daemon will fail. This is expected for an explicitly Docker-native module but worth noting for CI workflows that run speculative plans remotely.

<!-- /claude-code-review:summary -->
