### PR TITLE
feat(talos): Reserve control-plane headroom on small nodes

### DIFF
--- a/contexts/_template/facets/config-talos.yaml
+++ b/contexts/_template/facets/config-talos.yaml
@@ -39,6 +39,10 @@ config:
       controlplane_disks: "${cluster.controlplanes.disks ?? (talos_common.storage_driver == 'longhorn' ? talos_common.longhorn_default_disk : [])}"
       worker_disks: "${cluster.workers.disks ?? (talos_common.storage_driver == 'longhorn' ? talos_common.longhorn_default_disk : [])}"
 
+      # Small control-plane node: cpu/memory reflect real VM/box sizing here
+      # (cluster.driver == 'talos' excludes managed eks/aks, where they're unused).
+      resource_constrained: "${cluster_resources_effective.controlplanes.cpu <= 4 || cluster_resources_effective.controlplanes.memory <= 12}"
+
       # Kubelet serving-cert rotation via a static (pre-Flux) manifest so certs
       # rotate during bootstrap; the Talos default self-signed certs don't match node IPs.
       cert_rotation:
@@ -104,6 +108,46 @@ config:
               # 3/3 (default 5/5): no peers to catch up, saves ~128 MiB on disk.
               max-snapshots: "3"
               max-wals: "3"
+
+  # Small control plane: reserve a little kubelet/containerd cgroup headroom
+  # (otherwise zero) so bursty pod scheduling during bootstrap doesn't starve
+  # them, and give apiServer/controllerManager/scheduler enough CPU shares
+  # that the kernel favors them under contention. etcd runs outside
+  # kubepods.slice already, so it isn't set here.
+  #
+  # Sized small deliberately: every millicore/Mi reserved here, or requested
+  # by a static pod below, comes straight off Allocatable, and on a genuinely
+  # small box (the case this exists for) that's the same budget workloads
+  # need to schedule at all. kubeReserved only, not systemReserved: docker's
+  # own host-quota-gap correction (option-workstation.yaml) already sets
+  # systemReserved on this platform, and a second value on the same key would
+  # just overwrite this one, not add to it.
+  - name: talos_common
+    when: talos_common.resource_constrained
+    value:
+      common_patch:
+        machine:
+          kubelet:
+            extraConfig:
+              kubeReserved:
+                cpu: 100m
+                memory: 256Mi
+        cluster:
+          apiServer:
+            resources:
+              requests:
+                cpu: 100m
+                memory: 128Mi
+          controllerManager:
+            resources:
+              requests:
+                cpu: 50m
+                memory: 64Mi
+          scheduler:
+            resources:
+              requests:
+                cpu: 50m
+                memory: 64Mi
 
   # API-server OIDC: maps cluster.oidc.* to the kube-apiserver --oidc-* flags.
   # issuer_url/client_id fall back to the hosted Keycloak identity provider when unset.

--- a/contexts/_template/facets/config-talos.yaml
+++ b/contexts/_template/facets/config-talos.yaml
@@ -109,45 +109,51 @@ config:
               max-snapshots: "3"
               max-wals: "3"
 
-  # Small control plane: reserve a little kubelet/containerd cgroup headroom
-  # (otherwise zero) so bursty pod scheduling during bootstrap doesn't starve
-  # them, and give apiServer/controllerManager/scheduler enough CPU shares
-  # that the kernel favors them under contention. etcd runs outside
-  # kubepods.slice already, so it isn't set here.
+  # Small control plane: reserve kubelet/containerd cgroup headroom (otherwise
+  # zero) so bursty pod scheduling during bootstrap doesn't starve them, and
+  # give apiServer/controllerManager/scheduler enough CPU shares that the
+  # kernel favors them under contention. etcd runs outside kubepods.slice
+  # already, so it isn't set here.
   #
-  # Sized small deliberately: every millicore/Mi reserved here, or requested
-  # by a static pod below, comes straight off Allocatable, and on a genuinely
-  # small box (the case this exists for) that's the same budget workloads
-  # need to schedule at all. kubeReserved only, not systemReserved: docker's
-  # own host-quota-gap correction (option-workstation.yaml) already sets
-  # systemReserved on this platform, and a second value on the same key would
-  # just overwrite this one, not add to it.
+  # Two tiers, keyed on whether workloads share this node. A schedulable
+  # control plane (single-node, or controlplanes.schedulable) competes with
+  # real workload Pods for every millicore reserved here, so stays minimal.
+  # A dedicated control plane only shares the node with DaemonSets (CNI/CSI/
+  # log agents), so it can afford the larger reservation for etcd/apiserver
+  # bootstrap stability. kubeReserved only, not systemReserved: docker's own
+  # host-quota-gap correction (option-workstation.yaml) already sets
+  # systemReserved on that platform, and a second value on the same key
+  # would just overwrite this one, not add to it.
   - name: talos_common
     when: talos_common.resource_constrained
     value:
+      cp_reserve: >-
+        ${talos_common.allowSchedulingOnControlPlanes
+          ? {kubelet_cpu: '100m', kubelet_memory: '256Mi', api_cpu: '100m', api_memory: '128Mi', cm_cpu: '50m', cm_memory: '64Mi', sched_cpu: '50m', sched_memory: '64Mi'}
+          : {kubelet_cpu: '500m', kubelet_memory: '512Mi', api_cpu: '250m', api_memory: '256Mi', cm_cpu: '100m', cm_memory: '128Mi', sched_cpu: '100m', sched_memory: '128Mi'}}
       common_patch:
         machine:
           kubelet:
             extraConfig:
               kubeReserved:
-                cpu: 100m
-                memory: 256Mi
+                cpu: ${talos_common.cp_reserve.kubelet_cpu}
+                memory: ${talos_common.cp_reserve.kubelet_memory}
         cluster:
           apiServer:
             resources:
               requests:
-                cpu: 100m
-                memory: 128Mi
+                cpu: ${talos_common.cp_reserve.api_cpu}
+                memory: ${talos_common.cp_reserve.api_memory}
           controllerManager:
             resources:
               requests:
-                cpu: 50m
-                memory: 64Mi
+                cpu: ${talos_common.cp_reserve.cm_cpu}
+                memory: ${talos_common.cp_reserve.cm_memory}
           scheduler:
             resources:
               requests:
-                cpu: 50m
-                memory: 64Mi
+                cpu: ${talos_common.cp_reserve.sched_cpu}
+                memory: ${talos_common.cp_reserve.sched_memory}
 
   # API-server OIDC: maps cluster.oidc.* to the kube-apiserver --oidc-* flags.
   # issuer_url/client_id fall back to the hosted Keycloak identity provider when unset.

--- a/contexts/_template/facets/config-talos.yaml
+++ b/contexts/_template/facets/config-talos.yaml
@@ -39,26 +39,22 @@ config:
       controlplane_disks: "${cluster.controlplanes.disks ?? (talos_common.storage_driver == 'longhorn' ? talos_common.longhorn_default_disk : [])}"
       worker_disks: "${cluster.workers.disks ?? (talos_common.storage_driver == 'longhorn' ? talos_common.longhorn_default_disk : [])}"
 
-      # Small control-plane reservation tiers, keyed on whether the control
-      # plane also runs workloads. Each tier owns both its trigger threshold
-      # and its reserved amounts together, so the two can't drift apart. A
-      # schedulable control plane competes with real Pods for every
-      # millicore reserved, so it counts as small at a larger size and stays
-      # minimal. A dedicated control plane only shares the node with
-      # DaemonSets, so it needs a much smaller box to count as small, but can
-      # then afford a bigger reservation.
+      # Reservation tiers keyed on schedulable vs dedicated. Schedulable
+      # competes with real Pods so stays light; dedicated only shares with
+      # DaemonSets so affords more. max is raw millicores/Mi, scaled below.
       cp_tiers:
         schedulable:
           threshold: { cpu: 4, memory: 12 }
-          reserve: { kubelet_cpu: '100m', kubelet_memory: '256Mi', api_cpu: '100m', api_memory: '128Mi', cm_cpu: '50m', cm_memory: '64Mi', sched_cpu: '50m', sched_memory: '64Mi' }
+          max: { kubelet_cpu: 100, kubelet_memory: 256, api_cpu: 100, api_memory: 128, cm_cpu: 50, cm_memory: 64, sched_cpu: 50, sched_memory: 64 }
         dedicated:
           threshold: { cpu: 2, memory: 4 }
-          reserve: { kubelet_cpu: '500m', kubelet_memory: '512Mi', api_cpu: '250m', api_memory: '256Mi', cm_cpu: '100m', cm_memory: '128Mi', sched_cpu: '100m', sched_memory: '128Mi' }
+          max: { kubelet_cpu: 500, kubelet_memory: 512, api_cpu: 250, api_memory: 256, cm_cpu: 100, cm_memory: 128, sched_cpu: 100, sched_memory: 128 }
       cp_tier: "${talos_common.allowSchedulingOnControlPlanes ? talos_common.cp_tiers.schedulable : talos_common.cp_tiers.dedicated}"
 
-      # cpu/memory reflect real VM/box sizing (cluster.driver == 'talos' excludes
-      # managed eks/aks, where they're unused).
-      resource_constrained: "${cluster_resources_effective.controlplanes.cpu <= talos_common.cp_tier.threshold.cpu || cluster_resources_effective.controlplanes.memory <= talos_common.cp_tier.threshold.memory}"
+      # Worker reservation: single tier (workers always run Pods). Anchored
+      # to GKE's kubeReserved formula at a 4 CPU/8GB node (80m, 1843Mi).
+      worker_threshold: { cpu: 4, memory: 8 }
+      worker_max: { kubelet_cpu: 80, kubelet_memory: 1843 }
 
       # Kubelet serving-cert rotation via a static (pre-Flux) manifest so certs
       # rotate during bootstrap; the Talos default self-signed certs don't match node IPs.
@@ -92,6 +88,23 @@ config:
       # replacement (incus/docker override with cidrhost). The len() guard keeps
       # this safe to evaluate while platform-metal defers metal-without-nodes.
       k8s_service_host: "${len(cluster.controlplanes.nodes ?? {}) > 0 ? split(values(cluster.controlplanes.nodes)[0].endpoint, ':')[0] : ''}"
+
+  # Reservation tapers linearly from full at the threshold to zero at 2x it,
+  # driven by whichever axis (cpu/memory) is proportionally smaller.
+  - name: talos_common
+    value:
+      cp_cpu_ratio: "${cluster_resources_effective.controlplanes.cpu / talos_common.cp_tier.threshold.cpu}"
+      cp_memory_ratio: "${cluster_resources_effective.controlplanes.memory / talos_common.cp_tier.threshold.memory}"
+      cp_ratio: "${talos_common.cp_cpu_ratio < talos_common.cp_memory_ratio ? talos_common.cp_cpu_ratio : talos_common.cp_memory_ratio}"
+      cp_factor: "${talos_common.cp_ratio > 2 ? 0 : (talos_common.cp_ratio < 1 ? 1 : (2 - talos_common.cp_ratio))}"
+      resource_constrained: "${talos_common.cp_factor > 0}"
+
+      worker_cpu_ratio: "${cluster_resources_effective.workers.cpu / talos_common.worker_threshold.cpu}"
+      worker_memory_ratio: "${cluster_resources_effective.workers.memory / talos_common.worker_threshold.memory}"
+      worker_ratio: "${talos_common.worker_cpu_ratio < talos_common.worker_memory_ratio ? talos_common.worker_cpu_ratio : talos_common.worker_memory_ratio}"
+      worker_factor: "${talos_common.worker_ratio > 2 ? 0 : (talos_common.worker_ratio < 1 ? 1 : (2 - talos_common.worker_ratio))}"
+      worker_constrained: "${talos_common.worker_factor > 0}"
+      worker_patch_needed: "${talos_common.resource_constrained || talos_common.worker_constrained}"
 
   # Cilium machine patch: disable the built-in flannel CNI and kube-proxy.
   - name: talos_common
@@ -137,7 +150,15 @@ config:
   - name: talos_common
     when: talos_common.resource_constrained
     value:
-      cp_reserve: ${talos_common.cp_tier.reserve}
+      cp_reserve:
+        kubelet_cpu: "${string(int(talos_common.cp_tier.max.kubelet_cpu * talos_common.cp_factor + 0.5)) + 'm'}"
+        kubelet_memory: "${string(int(talos_common.cp_tier.max.kubelet_memory * talos_common.cp_factor + 0.5)) + 'Mi'}"
+        api_cpu: "${string(int(talos_common.cp_tier.max.api_cpu * talos_common.cp_factor + 0.5)) + 'm'}"
+        api_memory: "${string(int(talos_common.cp_tier.max.api_memory * talos_common.cp_factor + 0.5)) + 'Mi'}"
+        cm_cpu: "${string(int(talos_common.cp_tier.max.cm_cpu * talos_common.cp_factor + 0.5)) + 'm'}"
+        cm_memory: "${string(int(talos_common.cp_tier.max.cm_memory * talos_common.cp_factor + 0.5)) + 'Mi'}"
+        sched_cpu: "${string(int(talos_common.cp_tier.max.sched_cpu * talos_common.cp_factor + 0.5)) + 'm'}"
+        sched_memory: "${string(int(talos_common.cp_tier.max.sched_memory * talos_common.cp_factor + 0.5)) + 'Mi'}"
       common_patch:
         machine:
           kubelet:
@@ -161,6 +182,24 @@ config:
               requests:
                 cpu: ${talos_common.cp_reserve.sched_cpu}
                 memory: ${talos_common.cp_reserve.sched_memory}
+
+  # Routed to worker_config_patches, not common_patch (shared by every
+  # role): a worker's own size decides this. Later patches override earlier
+  # ones on the same field, so this also corrects the leak from above.
+  - name: talos_common
+    when: talos_common.worker_patch_needed
+    value:
+      worker_reserve:
+        kubelet_cpu: "${string(int(talos_common.worker_max.kubelet_cpu * talos_common.worker_factor + 0.5)) + 'm'}"
+        kubelet_memory: "${string(int(talos_common.worker_max.kubelet_memory * talos_common.worker_factor + 0.5)) + 'Mi'}"
+      worker_patch:
+        machine:
+          kubelet:
+            extraConfig:
+              kubeReserved:
+                cpu: ${talos_common.worker_reserve.kubelet_cpu}
+                memory: ${talos_common.worker_reserve.kubelet_memory}
+      worker_config_patches: "${string(talos_common.worker_patch)}"
 
   # API-server OIDC: maps cluster.oidc.* to the kube-apiserver --oidc-* flags.
   # issuer_url/client_id fall back to the hosted Keycloak identity provider when unset.

--- a/contexts/_template/facets/config-talos.yaml
+++ b/contexts/_template/facets/config-talos.yaml
@@ -39,9 +39,26 @@ config:
       controlplane_disks: "${cluster.controlplanes.disks ?? (talos_common.storage_driver == 'longhorn' ? talos_common.longhorn_default_disk : [])}"
       worker_disks: "${cluster.workers.disks ?? (talos_common.storage_driver == 'longhorn' ? talos_common.longhorn_default_disk : [])}"
 
-      # Small control-plane node: cpu/memory reflect real VM/box sizing here
-      # (cluster.driver == 'talos' excludes managed eks/aks, where they're unused).
-      resource_constrained: "${cluster_resources_effective.controlplanes.cpu <= 4 || cluster_resources_effective.controlplanes.memory <= 12}"
+      # Small control-plane reservation tiers, keyed on whether the control
+      # plane also runs workloads. Each tier owns both its trigger threshold
+      # and its reserved amounts together, so the two can't drift apart. A
+      # schedulable control plane competes with real Pods for every
+      # millicore reserved, so it counts as small at a larger size and stays
+      # minimal. A dedicated control plane only shares the node with
+      # DaemonSets, so it needs a much smaller box to count as small, but can
+      # then afford a bigger reservation.
+      cp_tiers:
+        schedulable:
+          threshold: { cpu: 4, memory: 12 }
+          reserve: { kubelet_cpu: '100m', kubelet_memory: '256Mi', api_cpu: '100m', api_memory: '128Mi', cm_cpu: '50m', cm_memory: '64Mi', sched_cpu: '50m', sched_memory: '64Mi' }
+        dedicated:
+          threshold: { cpu: 2, memory: 4 }
+          reserve: { kubelet_cpu: '500m', kubelet_memory: '512Mi', api_cpu: '250m', api_memory: '256Mi', cm_cpu: '100m', cm_memory: '128Mi', sched_cpu: '100m', sched_memory: '128Mi' }
+      cp_tier: "${talos_common.allowSchedulingOnControlPlanes ? talos_common.cp_tiers.schedulable : talos_common.cp_tiers.dedicated}"
+
+      # cpu/memory reflect real VM/box sizing (cluster.driver == 'talos' excludes
+      # managed eks/aks, where they're unused).
+      resource_constrained: "${cluster_resources_effective.controlplanes.cpu <= talos_common.cp_tier.threshold.cpu || cluster_resources_effective.controlplanes.memory <= talos_common.cp_tier.threshold.memory}"
 
       # Kubelet serving-cert rotation via a static (pre-Flux) manifest so certs
       # rotate during bootstrap; the Talos default self-signed certs don't match node IPs.
@@ -113,24 +130,14 @@ config:
   # zero) so bursty pod scheduling during bootstrap doesn't starve them, and
   # give apiServer/controllerManager/scheduler enough CPU shares that the
   # kernel favors them under contention. etcd runs outside kubepods.slice
-  # already, so it isn't set here.
-  #
-  # Two tiers, keyed on whether workloads share this node. A schedulable
-  # control plane (single-node, or controlplanes.schedulable) competes with
-  # real workload Pods for every millicore reserved here, so stays minimal.
-  # A dedicated control plane only shares the node with DaemonSets (CNI/CSI/
-  # log agents), so it can afford the larger reservation for etcd/apiserver
-  # bootstrap stability. kubeReserved only, not systemReserved: docker's own
-  # host-quota-gap correction (option-workstation.yaml) already sets
-  # systemReserved on that platform, and a second value on the same key
+  # already, so it isn't set here. kubeReserved only, not systemReserved:
+  # docker's own host-quota-gap correction (option-workstation.yaml) already
+  # sets systemReserved on that platform, and a second value on the same key
   # would just overwrite this one, not add to it.
   - name: talos_common
     when: talos_common.resource_constrained
     value:
-      cp_reserve: >-
-        ${talos_common.allowSchedulingOnControlPlanes
-          ? {kubelet_cpu: '100m', kubelet_memory: '256Mi', api_cpu: '100m', api_memory: '128Mi', cm_cpu: '50m', cm_memory: '64Mi', sched_cpu: '50m', sched_memory: '64Mi'}
-          : {kubelet_cpu: '500m', kubelet_memory: '512Mi', api_cpu: '250m', api_memory: '256Mi', cm_cpu: '100m', cm_memory: '128Mi', sched_cpu: '100m', sched_memory: '128Mi'}}
+      cp_reserve: ${talos_common.cp_tier.reserve}
       common_patch:
         machine:
           kubelet:

--- a/contexts/_template/facets/config-talos.yaml
+++ b/contexts/_template/facets/config-talos.yaml
@@ -104,7 +104,12 @@ config:
       worker_ratio: "${talos_common.worker_cpu_ratio < talos_common.worker_memory_ratio ? talos_common.worker_cpu_ratio : talos_common.worker_memory_ratio}"
       worker_factor: "${talos_common.worker_ratio > 2 ? 0 : (talos_common.worker_ratio < 1 ? 1 : (2 - talos_common.worker_ratio))}"
       worker_constrained: "${talos_common.worker_factor > 0}"
-      worker_patch_needed: "${talos_common.resource_constrained || talos_common.worker_constrained}"
+      worker_reserve_needed: "${talos_common.resource_constrained || talos_common.worker_constrained}"
+      worker_patch_emit: "${talos_common.worker_reserve_needed || platform == 'docker'}"
+
+      # Base for worker_patch: platform blocks (docker's systemReserved gap)
+      # and the kubeReserved block below each merge a sibling key into this.
+      worker_patch: {}
 
   # Cilium machine patch: disable the built-in flannel CNI and kube-proxy.
   - name: talos_common
@@ -183,15 +188,18 @@ config:
                 cpu: ${talos_common.cp_reserve.sched_cpu}
                 memory: ${talos_common.cp_reserve.sched_memory}
 
-  # Routed to worker_config_patches, not common_patch (shared by every
+  # Merges into worker_patch (base above), not common_patch (shared by every
   # role): a worker's own size decides this. Later patches override earlier
   # ones on the same field, so this also corrects the leak from above.
   - name: talos_common
-    when: talos_common.worker_patch_needed
+    when: talos_common.worker_reserve_needed
     value:
+      # Recomputes the factor from worker_ratio instead of referencing
+      # worker_factor directly: read cross-block, worker_factor evaluates to
+      # cp_factor's value instead of its own (composer bug, not ours).
       worker_reserve:
-        kubelet_cpu: "${string(int(talos_common.worker_max.kubelet_cpu * talos_common.worker_factor + 0.5)) + 'm'}"
-        kubelet_memory: "${string(int(talos_common.worker_max.kubelet_memory * talos_common.worker_factor + 0.5)) + 'Mi'}"
+        kubelet_cpu: "${let f = talos_common.worker_ratio > 2 ? 0 : (talos_common.worker_ratio < 1 ? 1 : (2 - talos_common.worker_ratio)); string(int(talos_common.worker_max.kubelet_cpu * f + 0.5)) + 'm'}"
+        kubelet_memory: "${let f = talos_common.worker_ratio > 2 ? 0 : (talos_common.worker_ratio < 1 ? 1 : (2 - talos_common.worker_ratio)); string(int(talos_common.worker_max.kubelet_memory * f + 0.5)) + 'Mi'}"
       worker_patch:
         machine:
           kubelet:
@@ -199,6 +207,10 @@ config:
               kubeReserved:
                 cpu: ${talos_common.worker_reserve.kubelet_cpu}
                 memory: ${talos_common.worker_reserve.kubelet_memory}
+
+  - name: talos_common
+    when: talos_common.worker_patch_emit
+    value:
       worker_config_patches: "${string(talos_common.worker_patch)}"
 
   # API-server OIDC: maps cluster.oidc.* to the kube-apiserver --oidc-* flags.

--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -88,17 +88,10 @@ config:
               - ignore: true
                 interface: eth0
 
-  # Worker patch slot for platform-docker to populate. Docker only: every
-  # node's kubelet sizes itself from the shared Docker daemon's host, not its
-  # own container's cgroup quota, so the worker role reserves its own gap
-  # against that host. `let` keeps host_cpu/host_memory resolved once;
-  # string() only ever marshals them once they're concrete numbers, never a
-  # still-deferred terraform_output call, so there's nothing left to mis-scan
-  # on a later composition pass. Controlplane's equivalent is inlined
-  # directly into platform-docker.yaml's controlplane_config_patches: it also
-  # has to merge with the oidc CA-file patch, and that merge decision can't
-  # be split across a separate config value the way this one can (see the
-  # comment there).
+  # Sibling reservations under one extraConfig: systemReserved (docker's
+  # host-quota gap) and kubeReserved (talos_common's worker size taper).
+  # One expression, not split fields: host_cpu/host_memory are deferred
+  # until compute applies.
   - name: talos_common_docker
     when: cluster.driver == 'talos' && (cluster.enabled ?? true)
     value:
@@ -107,15 +100,19 @@ config:
           let host_memory = terraform_output('compute', 'host_memory') ?? cluster_resources_effective.workers.memory;
           let quota_cpu = cluster_resources_effective.workers.cpu;
           let quota_memory = cluster_resources_effective.workers.memory;
-          platform != 'docker' || (host_cpu <= quota_cpu && host_memory <= quota_memory)
+          (platform != 'docker' || (host_cpu <= quota_cpu && host_memory <= quota_memory)) && talos_common.worker_factor == 0
             ? ''
             : trimSuffix(string({
                 machine: {
                   kubelet: {
                     extraConfig: {
                       systemReserved: {
-                        cpu: (host_cpu > quota_cpu ? string(max(500, (host_cpu - quota_cpu) * 1000 + 500)) : '0') + 'm',
-                        memory: (host_memory > quota_memory ? string(max(1, host_memory - quota_memory + 1)) : '0') + 'Gi'
+                        cpu: (platform == 'docker' && host_cpu > quota_cpu ? string(max(500, (host_cpu - quota_cpu) * 1000 + 500)) : '0') + 'm',
+                        memory: (platform == 'docker' && host_memory > quota_memory ? string(max(1, host_memory - quota_memory + 1)) : '0') + 'Gi'
+                      },
+                      kubeReserved: {
+                        cpu: string(int(talos_common.worker_max.kubelet_cpu * talos_common.worker_factor + 0.5)) + 'm',
+                        memory: string(int(talos_common.worker_max.kubelet_memory * talos_common.worker_factor + 0.5)) + 'Mi'
                       }
                     }
                   }

--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -88,36 +88,20 @@ config:
               - ignore: true
                 interface: eth0
 
-  # Per-role patch slots for platform-docker to populate. Docker only: every
+  # Worker patch slot for platform-docker to populate. Docker only: every
   # node's kubelet sizes itself from the shared Docker daemon's host, not its
-  # own container's cgroup quota, so each role reserves its own gap against
-  # that host — computed per role since controlplanes and workers commonly
-  # run different quotas against the same host. `let` keeps host_cpu/
-  # host_memory resolved once per patch; string() only ever marshals them
-  # once they're concrete numbers, never a still-deferred terraform_output
-  # call, so there's nothing left to mis-scan on a later composition pass.
+  # own container's cgroup quota, so the worker role reserves its own gap
+  # against that host. `let` keeps host_cpu/host_memory resolved once;
+  # string() only ever marshals them once they're concrete numbers, never a
+  # still-deferred terraform_output call, so there's nothing left to mis-scan
+  # on a later composition pass. Controlplane's equivalent is inlined
+  # directly into platform-docker.yaml's controlplane_config_patches: it also
+  # has to merge with the oidc CA-file patch, and that merge decision can't
+  # be split across a separate config value the way this one can (see the
+  # comment there).
   - name: talos_common_docker
     when: cluster.driver == 'talos' && (cluster.enabled ?? true)
     value:
-      controlplane_config_patches: >-
-        ${let host_cpu = terraform_output('compute', 'host_cpu') ?? 0;
-          let host_memory = terraform_output('compute', 'host_memory') ?? cluster_resources_effective.controlplanes.memory;
-          let quota_cpu = cluster_resources_effective.controlplanes.cpu;
-          let quota_memory = cluster_resources_effective.controlplanes.memory;
-          platform != 'docker' || (host_cpu <= quota_cpu && host_memory <= quota_memory)
-            ? ''
-            : trimSuffix(string({
-                machine: {
-                  kubelet: {
-                    extraConfig: {
-                      systemReserved: {
-                        cpu: (host_cpu > quota_cpu ? string(max(500, (host_cpu - quota_cpu) * 1000 + 500)) : '0') + 'm',
-                        memory: (host_memory > quota_memory ? string(max(1, host_memory - quota_memory + 1)) : '0') + 'Gi'
-                      }
-                    }
-                  }
-                }
-              }), '\n')}
       worker_config_patches: >-
         ${let host_cpu = terraform_output('compute', 'host_cpu') ?? 0;
           let host_memory = terraform_output('compute', 'host_memory') ?? cluster_resources_effective.workers.memory;

--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -88,43 +88,27 @@ config:
               - ignore: true
                 interface: eth0
 
-  # Sibling reservations under one extraConfig: systemReserved (docker's
-  # host-quota gap) and kubeReserved (talos_common's worker size taper).
-  # One expression, not split fields: host_cpu/host_memory are deferred
-  # until compute applies.
-  - name: talos_common_docker
-    when: cluster.driver == 'talos' && (cluster.enabled ?? true)
+  # Docker's own gap against the shared Docker daemon's host, merged as a
+  # sibling of kubeReserved into worker_patch (config-talos.yaml's base).
+  - name: talos_common
+    when: platform == 'docker' && cluster.driver == 'talos' && (cluster.enabled ?? true)
     value:
-      worker_config_patches: >-
-        ${let host_cpu = terraform_output('compute', 'host_cpu') ?? 0;
-          let host_memory = terraform_output('compute', 'host_memory') ?? cluster_resources_effective.workers.memory;
-          let quota_cpu = cluster_resources_effective.workers.cpu;
-          let quota_memory = cluster_resources_effective.workers.memory;
-          let kube_reserved = {
-            cpu: string(int(talos_common.worker_max.kubelet_cpu * talos_common.worker_factor + 0.5)) + 'm',
-            memory: string(int(talos_common.worker_max.kubelet_memory * talos_common.worker_factor + 0.5)) + 'Mi'
-          };
-          platform == 'docker'
-            ? ((host_cpu <= quota_cpu && host_memory <= quota_memory) && talos_common.worker_factor == 0
-                ? ''
-                : trimSuffix(string({
-                    machine: {
-                      kubelet: {
-                        extraConfig: {
-                          systemReserved: {
-                            cpu: (host_cpu > quota_cpu ? string(max(500, (host_cpu - quota_cpu) * 1000 + 500)) : '0') + 'm',
-                            memory: (host_memory > quota_memory ? string(max(1, host_memory - quota_memory + 1)) : '0') + 'Gi'
-                          },
-                          kubeReserved: kube_reserved
-                        }
-                      }
-                    }
-                  }), '\n'))
-            : (talos_common.worker_factor == 0
-                ? ''
-                : trimSuffix(string({
-                    machine: { kubelet: { extraConfig: { kubeReserved: kube_reserved } } }
-                  }), '\n'))}
+      docker_worker_gap:
+        cpu: >-
+          ${let host_cpu = terraform_output('compute', 'host_cpu') ?? 0;
+            let quota_cpu = cluster_resources_effective.workers.cpu;
+            (host_cpu > quota_cpu ? string(max(500, (host_cpu - quota_cpu) * 1000 + 500)) : '0') + 'm'}
+        memory: >-
+          ${let host_memory = terraform_output('compute', 'host_memory') ?? cluster_resources_effective.workers.memory;
+            let quota_memory = cluster_resources_effective.workers.memory;
+            (host_memory > quota_memory ? string(max(1, host_memory - quota_memory + 1)) : '0') + 'Gi'}
+      worker_patch:
+        machine:
+          kubelet:
+            extraConfig:
+              systemReserved:
+                cpu: ${talos_common.docker_worker_gap.cpu}
+                memory: ${talos_common.docker_worker_gap.memory}
 
   # Colima-on-Incus is a storage-driver test rig; force flannel (Cilium's eBPF
   # skews tests) and pair with kube-vip so LoadBalancer services still get an IP.

--- a/contexts/_template/facets/option-workstation.yaml
+++ b/contexts/_template/facets/option-workstation.yaml
@@ -100,24 +100,31 @@ config:
           let host_memory = terraform_output('compute', 'host_memory') ?? cluster_resources_effective.workers.memory;
           let quota_cpu = cluster_resources_effective.workers.cpu;
           let quota_memory = cluster_resources_effective.workers.memory;
-          (platform != 'docker' || (host_cpu <= quota_cpu && host_memory <= quota_memory)) && talos_common.worker_factor == 0
-            ? ''
-            : trimSuffix(string({
-                machine: {
-                  kubelet: {
-                    extraConfig: {
-                      systemReserved: {
-                        cpu: (platform == 'docker' && host_cpu > quota_cpu ? string(max(500, (host_cpu - quota_cpu) * 1000 + 500)) : '0') + 'm',
-                        memory: (platform == 'docker' && host_memory > quota_memory ? string(max(1, host_memory - quota_memory + 1)) : '0') + 'Gi'
-                      },
-                      kubeReserved: {
-                        cpu: string(int(talos_common.worker_max.kubelet_cpu * talos_common.worker_factor + 0.5)) + 'm',
-                        memory: string(int(talos_common.worker_max.kubelet_memory * talos_common.worker_factor + 0.5)) + 'Mi'
+          let kube_reserved = {
+            cpu: string(int(talos_common.worker_max.kubelet_cpu * talos_common.worker_factor + 0.5)) + 'm',
+            memory: string(int(talos_common.worker_max.kubelet_memory * talos_common.worker_factor + 0.5)) + 'Mi'
+          };
+          platform == 'docker'
+            ? ((host_cpu <= quota_cpu && host_memory <= quota_memory) && talos_common.worker_factor == 0
+                ? ''
+                : trimSuffix(string({
+                    machine: {
+                      kubelet: {
+                        extraConfig: {
+                          systemReserved: {
+                            cpu: (host_cpu > quota_cpu ? string(max(500, (host_cpu - quota_cpu) * 1000 + 500)) : '0') + 'm',
+                            memory: (host_memory > quota_memory ? string(max(1, host_memory - quota_memory + 1)) : '0') + 'Gi'
+                          },
+                          kubeReserved: kube_reserved
+                        }
                       }
                     }
-                  }
-                }
-              }), '\n')}
+                  }), '\n'))
+            : (talos_common.worker_factor == 0
+                ? ''
+                : trimSuffix(string({
+                    machine: { kubelet: { extraConfig: { kubeReserved: kube_reserved } } }
+                  }), '\n'))}
 
   # Colima-on-Incus is a storage-driver test rig; force flannel (Cilium's eBPF
   # skews tests) and pair with kube-vip so LoadBalancer services still get an IP.

--- a/contexts/_template/facets/platform-docker.yaml
+++ b/contexts/_template/facets/platform-docker.yaml
@@ -102,16 +102,45 @@ terraform:
       controlplane_disks: ${cluster.controlplanes.disks ?? []}
       worker_disks: ${cluster.workers.disks ?? []}
       common_config_patches: ${talos_common.common_config_patches}
+      # Docker only: the control plane's kubelet sizes itself from the shared
+      # Docker daemon's host, not its own container's cgroup quota, so it
+      # reserves its own gap against that host (host_cpu/host_memory) and
+      # merges that with the oidc CA-file patch when both apply. Inlined as
+      # one expression, not split into a separate config value referenced
+      # here: gap and oidc's own emptiness aren't knowable until compute/pki
+      # actually apply, so any expression that reads a deferred value back
+      # from a different config block sees composition-time placeholder text
+      # instead of the real (possibly empty) result, and branches on it
+      # wrong. One atomic expression either composes fully now or defers
+      # fully to generate time, never a mix of the two.
+      #
       # Both patches are standalone "machine:\n  <child>:..." documents; when
-      # both are present, docker's own patch (with its "machine:" header)
-      # keeps that header and oidc's patch has it stripped so its "files:"
-      # child nests under the same "machine:" instead of starting a second one.
+      # both are present, the gap patch (with its "machine:" header) keeps
+      # that header and oidc's patch has it stripped so its "files:" child
+      # nests under the same "machine:" instead of starting a second one.
       controlplane_config_patches: >-
-        ${(talos_common_docker.controlplane_config_patches ?? '') == ''
-          ? (talos_common.oidc_ca_file_patch ?? '')
-          : (talos_common.oidc_ca_file_patch ?? '') == ''
-            ? talos_common_docker.controlplane_config_patches
-            : talos_common_docker.controlplane_config_patches + '\n' + trimPrefix(talos_common.oidc_ca_file_patch, 'machine:\n')}
+        ${let host_cpu = terraform_output('compute', 'host_cpu') ?? 0;
+          let host_memory = terraform_output('compute', 'host_memory') ?? cluster_resources_effective.controlplanes.memory;
+          let quota_cpu = cluster_resources_effective.controlplanes.cpu;
+          let quota_memory = cluster_resources_effective.controlplanes.memory;
+          let gap = (host_cpu <= quota_cpu && host_memory <= quota_memory)
+            ? ''
+            : trimSuffix(string({
+                machine: {
+                  kubelet: {
+                    extraConfig: {
+                      systemReserved: {
+                        cpu: (host_cpu > quota_cpu ? string(max(500, (host_cpu - quota_cpu) * 1000 + 500)) : '0') + 'm',
+                        memory: (host_memory > quota_memory ? string(max(1, host_memory - quota_memory + 1)) : '0') + 'Gi'
+                      }
+                    }
+                  }
+                }
+              }), '\n');
+          let oidc = talos_common.oidc_ca_file_patch ?? '';
+          gap == ''
+            ? oidc
+            : (oidc == '' ? gap : gap + '\n' + trimPrefix(oidc, 'machine:\n'))}
       worker_config_patches: "${talos_common_docker.worker_config_patches ?? \"\"}"
       controlplane_volumes: ${talos_common.controlplane_volumes ?? []}
       worker_volumes: ${talos_common.worker_volumes ?? []}

--- a/contexts/_template/facets/platform-docker.yaml
+++ b/contexts/_template/facets/platform-docker.yaml
@@ -141,6 +141,6 @@ terraform:
           gap == ''
             ? oidc
             : (oidc == '' ? gap : gap + '\n' + trimPrefix(oidc, 'machine:\n'))}
-      worker_config_patches: "${talos_common_docker.worker_config_patches ?? \"\"}"
+      worker_config_patches: "${talos_common.worker_config_patches ?? ''}"
       controlplane_volumes: ${talos_common.controlplane_volumes ?? []}
       worker_volumes: ${talos_common.worker_volumes ?? []}

--- a/contexts/_template/facets/platform-hetzner.yaml
+++ b/contexts/_template/facets/platform-hetzner.yaml
@@ -108,8 +108,6 @@ config:
 
   # Real per-server_type sizing, not the generic schema default, so
   # config-talos's small-control-plane detection reflects the actual instance.
-  # cpx31, the default instance type, crosses the schedulable-tier threshold,
-  # so a default-sized control plane gets the reservation on reconcile.
   - name: cluster_resources_effective
     value:
       controlplanes: ${hetzner_effective.controlplane_size}

--- a/contexts/_template/facets/platform-hetzner.yaml
+++ b/contexts/_template/facets/platform-hetzner.yaml
@@ -108,6 +108,8 @@ config:
 
   # Real per-server_type sizing, not the generic schema default, so
   # config-talos's small-control-plane detection reflects the actual instance.
+  # cpx31, the default instance type, crosses the schedulable-tier threshold,
+  # so a default-sized control plane gets the reservation on reconcile.
   - name: cluster_resources_effective
     value:
       controlplanes: ${hetzner_effective.controlplane_size}
@@ -250,6 +252,7 @@ terraform:
       worker_disks: ${talos_common.worker_disks}
       common_config_patches: ${talos_common.common_config_patches}
       controlplane_config_patches: "${talos_common.oidc_ca_file_patch ?? ''}"
+      worker_config_patches: "${talos_common.worker_config_patches ?? ''}"
       controlplane_volumes: ${talos_common.controlplane_volumes ?? []}
       worker_volumes: ${talos_common.worker_volumes ?? []}
 

--- a/contexts/_template/facets/platform-hetzner.yaml
+++ b/contexts/_template/facets/platform-hetzner.yaml
@@ -104,6 +104,14 @@ config:
   - name: hetzner_effective
     value:
       controlplane_size: "${get(hetzner_sizes_by_type, cluster.controlplanes.instance_type ?? 'cpx31') ?? { cpu: 4, memory: 8 }}"
+      worker_size: "${get(hetzner_sizes_by_type, cluster.workers.instance_type ?? 'cpx31') ?? { cpu: 4, memory: 8 }}"
+
+  # Real per-server_type sizing, not the generic schema default, so
+  # config-talos's small-control-plane detection reflects the actual instance.
+  - name: cluster_resources_effective
+    value:
+      controlplanes: ${hetzner_effective.controlplane_size}
+      workers: ${hetzner_effective.worker_size}
 
   # Instance types orderable in the US locations (ash, hil): Gen1 CPX and CCX only.
   # Gen2 CPX (cpx*2) and ARM (cax*) are EU/Asia-only. Drives the US requires check.

--- a/contexts/_template/facets/platform-hyperv.yaml
+++ b/contexts/_template/facets/platform-hyperv.yaml
@@ -281,6 +281,7 @@ terraform:
       destination_dir: "${hyperv_effective.images_dir}"
       common_config_patches: ${talos_common.common_config_patches}
       controlplane_config_patches: "${talos_common.oidc_ca_file_patch ?? ''}"
+      worker_config_patches: "${talos_common.worker_config_patches ?? ''}"
       network:
         cidr_block: ${network.cidr_block ?? '10.5.0.0/16'}
         gateway: ${network.gateway}
@@ -388,6 +389,7 @@ terraform:
       controlplane_disks: ${talos_common.controlplane_disks}
       worker_disks: ${talos_common.worker_disks}
       common_config_patches: ${talos_common.common_config_patches}
+      worker_config_patches: "${talos_common.worker_config_patches ?? ''}"
       controlplane_volumes: ${talos_common.controlplane_volumes ?? []}
       worker_volumes: ${talos_common.worker_volumes ?? []}
       # Shared identity from cluster-config: when non-null, cluster/talos skips

--- a/contexts/_template/facets/platform-incus.yaml
+++ b/contexts/_template/facets/platform-incus.yaml
@@ -133,6 +133,7 @@ terraform:
       worker_disks: ${talos_common.worker_disks}
       common_config_patches: ${talos_common.common_config_patches}
       controlplane_config_patches: "${talos_common.oidc_ca_file_patch ?? ''}"
+      worker_config_patches: "${talos_common.worker_config_patches ?? ''}"
       controlplane_volumes: ${talos_common.controlplane_volumes ?? []}
       worker_volumes: ${talos_common.worker_volumes ?? []}
 

--- a/contexts/_template/facets/platform-metal.yaml
+++ b/contexts/_template/facets/platform-metal.yaml
@@ -63,6 +63,7 @@ terraform:
       worker_disks: ${talos_common.worker_disks}
       common_config_patches: ${talos_common.common_config_patches}
       controlplane_config_patches: "${talos_common.oidc_ca_file_patch ?? ''}"
+      worker_config_patches: "${talos_common.worker_config_patches ?? ''}"
       controlplane_volumes: ${talos_common.controlplane_volumes ?? []}
       worker_volumes: ${talos_common.worker_volumes ?? []}
 

--- a/contexts/_template/facets/platform-vsphere.yaml
+++ b/contexts/_template/facets/platform-vsphere.yaml
@@ -274,6 +274,7 @@ terraform:
       controlplane_disks: ${talos_common.controlplane_disks}
       worker_disks: ${talos_common.worker_disks}
       common_config_patches: ${talos_common.common_config_patches}
+      worker_config_patches: "${talos_common.worker_config_patches ?? ''}"
       controlplane_volumes: ${talos_common.controlplane_volumes ?? []}
       worker_volumes: ${talos_common.worker_volumes ?? []}
       # Shared cluster identity from compute — cluster/talos's

--- a/contexts/_template/tests/config-talos.test.yaml
+++ b/contexts/_template/tests/config-talos.test.yaml
@@ -261,6 +261,56 @@ cases:
                       cpu: 500m
                       memory: 512Mi
 
+  - name: control plane constrained on cpu alone still gets the reservation
+    values:
+      platform: metal
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster:
+        <<: *default-cluster
+        controlplanes:
+          cpu: 4
+          memory: 32
+          nodes:
+            controlplane-1:
+              endpoint: 10.5.0.10:50000
+              node: 10.5.0.10
+              hostname: controlplane-1
+    expect:
+      terraform:
+        - name: cluster
+          path: cluster/talos
+          inputs:
+            common_config_patches: |-
+              cluster:
+                allowSchedulingOnControlPlanes: false
+                apiServer:
+                  resources:
+                    requests:
+                      cpu: 250m
+                      memory: 256Mi
+                controllerManager:
+                  resources:
+                    requests:
+                      cpu: 100m
+                      memory: 128Mi
+                extraManifests:
+                - https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml
+                scheduler:
+                  resources:
+                    requests:
+                      cpu: 100m
+                      memory: 128Mi
+              machine:
+                kubelet:
+                  extraArgs:
+                    rotate-server-certificates: "true"
+                  extraConfig:
+                    kubeReserved:
+                      cpu: 500m
+                      memory: 512Mi
+
   - name: small schedulable control plane gets the minimal reservation tier
     values:
       platform: metal

--- a/contexts/_template/tests/config-talos.test.yaml
+++ b/contexts/_template/tests/config-talos.test.yaml
@@ -16,6 +16,10 @@ x-defaults:
   cluster: &default-cluster
     driver: talos
     controlplanes:
+      # Above the resource_constrained thresholds so OIDC cases below don't
+      # also carry the small-control-plane patch (covered separately).
+      cpu: 8
+      memory: 16
       nodes:
         controlplane-1:
           endpoint: 10.5.0.10:50000
@@ -208,6 +212,54 @@ cases:
                   extraArgs:
                     rotate-server-certificates: "true"
             controlplane_config_patches: "machine:\n  files:\n  - op: create\n    path: /var/kubernetes/oidc-ca.crt\n    permissions: 420\n    content: |\n      \n        -----BEGIN CERTIFICATE-----\n        FAKECERT\n        -----END CERTIFICATE-----"
+
+  - name: small control plane adds kubelet reservation and control-plane resource requests
+    values:
+      platform: metal
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster:
+        <<: *default-cluster
+        controlplanes:
+          nodes:
+            controlplane-1:
+              endpoint: 10.5.0.10:50000
+              node: 10.5.0.10
+              hostname: controlplane-1
+    expect:
+      terraform:
+        - name: cluster
+          path: cluster/talos
+          inputs:
+            common_config_patches: |-
+              cluster:
+                allowSchedulingOnControlPlanes: false
+                apiServer:
+                  resources:
+                    requests:
+                      cpu: 100m
+                      memory: 128Mi
+                controllerManager:
+                  resources:
+                    requests:
+                      cpu: 50m
+                      memory: 64Mi
+                extraManifests:
+                - https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml
+                scheduler:
+                  resources:
+                    requests:
+                      cpu: 50m
+                      memory: 64Mi
+              machine:
+                kubelet:
+                  extraArgs:
+                    rotate-server-certificates: "true"
+                  extraConfig:
+                    kubeReserved:
+                      cpu: 100m
+                      memory: 256Mi
 
   - name: oidc username_claim and groups_claim overrides pass through
     values:

--- a/contexts/_template/tests/config-talos.test.yaml
+++ b/contexts/_template/tests/config-talos.test.yaml
@@ -213,7 +213,7 @@ cases:
                     rotate-server-certificates: "true"
             controlplane_config_patches: "machine:\n  files:\n  - op: create\n    path: /var/kubernetes/oidc-ca.crt\n    permissions: 420\n    content: |\n      \n        -----BEGIN CERTIFICATE-----\n        FAKECERT\n        -----END CERTIFICATE-----"
 
-  - name: small control plane adds kubelet reservation and control-plane resource requests
+  - name: small dedicated control plane gets the larger reservation tier
     values:
       platform: metal
       gateway:
@@ -235,6 +235,67 @@ cases:
             common_config_patches: |-
               cluster:
                 allowSchedulingOnControlPlanes: false
+                apiServer:
+                  resources:
+                    requests:
+                      cpu: 250m
+                      memory: 256Mi
+                controllerManager:
+                  resources:
+                    requests:
+                      cpu: 100m
+                      memory: 128Mi
+                extraManifests:
+                - https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml
+                scheduler:
+                  resources:
+                    requests:
+                      cpu: 100m
+                      memory: 128Mi
+              machine:
+                kubelet:
+                  extraArgs:
+                    rotate-server-certificates: "true"
+                  extraConfig:
+                    kubeReserved:
+                      cpu: 500m
+                      memory: 512Mi
+
+  - name: small schedulable control plane gets the minimal reservation tier
+    values:
+      platform: metal
+      # Explicit multi-node + controlplanes.schedulable: isolates this case
+      # from the single-node-topology patches (leader-elect, etcd compaction),
+      # covered separately by option-single-node tests.
+      topology: multi-node
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster:
+        driver: talos
+        controlplanes:
+          schedulable: true
+          nodes:
+            controlplane-1:
+              endpoint: 10.5.0.10:50000
+              node: 10.5.0.10
+              hostname: controlplane-1
+        workers:
+          nodes:
+            worker-1:
+              endpoint: 10.5.0.20:50000
+              node: 10.5.0.20
+              hostname: worker-1
+        cni:
+          driver: flannel
+    expect:
+      terraform:
+        - name: cluster
+          path: cluster/talos
+          inputs:
+            common_config_patches: |-
+              cluster:
+                allowSchedulingOnControlPlanes: true
                 apiServer:
                   resources:
                     requests:

--- a/contexts/_template/tests/config-talos.test.yaml
+++ b/contexts/_template/tests/config-talos.test.yaml
@@ -313,6 +313,210 @@ cases:
                       cpu: 500m
                       memory: 512Mi
 
+  - name: control plane between the threshold and 2x it gets a tapered reservation
+    values:
+      platform: metal
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster:
+        <<: *default-cluster
+        controlplanes:
+          cpu: 3
+          memory: 8
+          nodes:
+            controlplane-1:
+              endpoint: 10.5.0.10:50000
+              node: 10.5.0.10
+              hostname: controlplane-1
+    expect:
+      terraform:
+        - name: cluster
+          path: cluster/talos
+          inputs:
+            common_config_patches: |-
+              cluster:
+                allowSchedulingOnControlPlanes: false
+                apiServer:
+                  resources:
+                    requests:
+                      cpu: 125m
+                      memory: 128Mi
+                controllerManager:
+                  resources:
+                    requests:
+                      cpu: 50m
+                      memory: 64Mi
+                extraManifests:
+                - https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml
+                scheduler:
+                  resources:
+                    requests:
+                      cpu: 50m
+                      memory: 64Mi
+              machine:
+                kubelet:
+                  extraArgs:
+                    rotate-server-certificates: "true"
+                  extraConfig:
+                    kubeReserved:
+                      cpu: 250m
+                      memory: 256Mi
+
+  - name: default-sized worker gets its own kubeReserved independent of the control plane
+    values:
+      platform: metal
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster:
+        <<: *default-cluster
+    expect:
+      terraform:
+        - name: cluster
+          path: cluster/talos
+          inputs:
+            worker_config_patches: |-
+              machine:
+                kubelet:
+                  extraConfig:
+                    kubeReserved:
+                      cpu: 80m
+                      memory: 1843Mi
+
+  - name: large worker gets an explicit zero override, correcting the small control plane's leaked kubeReserved
+    values:
+      platform: metal
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster:
+        driver: talos
+        controlplanes:
+          cpu: 2
+          memory: 4
+          nodes:
+            controlplane-1:
+              endpoint: 10.5.0.10:50000
+              node: 10.5.0.10
+              hostname: controlplane-1
+        workers:
+          cpu: 16
+          memory: 32
+          nodes:
+            worker-1:
+              endpoint: 10.5.0.20:50000
+              node: 10.5.0.20
+              hostname: worker-1
+        cni:
+          driver: flannel
+    expect:
+      terraform:
+        - name: cluster
+          path: cluster/talos
+          inputs:
+            # The small control plane's kubeReserved lands in
+            # common_config_patches, which every role shares.
+            common_config_patches: |-
+              cluster:
+                allowSchedulingOnControlPlanes: false
+                apiServer:
+                  resources:
+                    requests:
+                      cpu: 250m
+                      memory: 256Mi
+                controllerManager:
+                  resources:
+                    requests:
+                      cpu: 100m
+                      memory: 128Mi
+                extraManifests:
+                - https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml
+                scheduler:
+                  resources:
+                    requests:
+                      cpu: 100m
+                      memory: 128Mi
+              machine:
+                kubelet:
+                  extraArgs:
+                    rotate-server-certificates: "true"
+                  extraConfig:
+                    kubeReserved:
+                      cpu: 500m
+                      memory: 512Mi
+            # worker_config_patches applies after common_config_patches, so
+            # this zero override wins on the worker and cancels the leak.
+            worker_config_patches: |-
+              machine:
+                kubelet:
+                  extraConfig:
+                    kubeReserved:
+                      cpu: 0m
+                      memory: 0Mi
+
+  - name: small worker gets its own reservation even when the control plane is comfortably large
+    values:
+      platform: metal
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster:
+        <<: *default-cluster
+        workers:
+          cpu: 2
+          memory: 4
+          nodes:
+            worker-1:
+              endpoint: 10.5.0.20:50000
+              node: 10.5.0.20
+              hostname: worker-1
+          volumes:
+            - /var/mnt/local
+    expect:
+      terraform:
+        - name: cluster
+          path: cluster/talos
+          inputs:
+            worker_config_patches: |-
+              machine:
+                kubelet:
+                  extraConfig:
+                    kubeReserved:
+                      cpu: 80m
+                      memory: 1843Mi
+
+  - name: worker between its threshold and 2x it gets a tapered reservation
+    values:
+      platform: metal
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster:
+        <<: *default-cluster
+        workers:
+          cpu: 6
+          memory: 12
+          nodes:
+            worker-1:
+              endpoint: 10.5.0.20:50000
+              node: 10.5.0.20
+              hostname: worker-1
+          volumes:
+            - /var/mnt/local
+    expect:
+      terraform:
+        - name: cluster
+          path: cluster/talos
+          inputs:
+            worker_config_patches: |-
+              machine:
+                kubelet:
+                  extraConfig:
+                    kubeReserved:
+                      cpu: 40m
+                      memory: 922Mi
+
   - name: default dedicated control plane gets no reservation
     values:
       platform: metal

--- a/contexts/_template/tests/config-talos.test.yaml
+++ b/contexts/_template/tests/config-talos.test.yaml
@@ -222,6 +222,8 @@ cases:
       cluster:
         <<: *default-cluster
         controlplanes:
+          cpu: 2
+          memory: 4
           nodes:
             controlplane-1:
               endpoint: 10.5.0.10:50000
@@ -270,8 +272,8 @@ cases:
       cluster:
         <<: *default-cluster
         controlplanes:
-          cpu: 4
-          memory: 32
+          cpu: 2
+          memory: 64
           nodes:
             controlplane-1:
               endpoint: 10.5.0.10:50000
@@ -310,6 +312,35 @@ cases:
                     kubeReserved:
                       cpu: 500m
                       memory: 512Mi
+
+  - name: default dedicated control plane gets no reservation
+    values:
+      platform: metal
+      gateway:
+        enabled: false
+      network: *default-network
+      cluster:
+        <<: *default-cluster
+        controlplanes:
+          nodes:
+            controlplane-1:
+              endpoint: 10.5.0.10:50000
+              node: 10.5.0.10
+              hostname: controlplane-1
+    expect:
+      terraform:
+        - name: cluster
+          path: cluster/talos
+          inputs:
+            common_config_patches: |-
+              cluster:
+                allowSchedulingOnControlPlanes: false
+                extraManifests:
+                - https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml
+              machine:
+                kubelet:
+                  extraArgs:
+                    rotate-server-certificates: "true"
 
   - name: small schedulable control plane gets the minimal reservation tier
     values:

--- a/contexts/_template/tests/option-cni.test.yaml
+++ b/contexts/_template/tests/option-cni.test.yaml
@@ -192,6 +192,10 @@ cases:
       cluster:
         driver: talos
         controlplanes:
+          # Above the resource_constrained thresholds: isolates this case from
+          # config-talos's small-control-plane patch (covered separately).
+          cpu: 8
+          memory: 16
           nodes:
             controlplane-1: *cp1-node
         workers:
@@ -301,6 +305,10 @@ cases:
       cluster:
         driver: talos
         controlplanes:
+          # Above the resource_constrained thresholds: isolates this case from
+          # config-talos's small-control-plane patch (covered separately).
+          cpu: 8
+          memory: 16
           nodes:
             controlplane-1: *cp1-node
         workers:

--- a/contexts/_template/tests/option-workstation.test.yaml
+++ b/contexts/_template/tests/option-workstation.test.yaml
@@ -18,6 +18,10 @@ x-defaults:
   cluster: &default-cluster
     driver: talos
     controlplanes:
+      # Above the resource_constrained thresholds so common_config_patches
+      # cases below don't also carry config-talos's small-control-plane patch.
+      cpu: 8
+      memory: 16
       nodes:
         controlplane-1: &cp1-node
           endpoint: 10.5.0.10:50000
@@ -217,6 +221,11 @@ cases:
       cluster:
         driver: talos
         controlplanes:
+          # Above the resource_constrained thresholds (isolates this case from
+          # config-talos's small-control-plane patch) while keeping the
+          # concurrency formula's floor(cpu/2)/floor(memory/2) at 2.
+          cpu: 5
+          memory: 13
           nodes:
             controlplane-1:
               endpoint: 10.5.0.10:50000

--- a/contexts/_template/tests/option-workstation.test.yaml
+++ b/contexts/_template/tests/option-workstation.test.yaml
@@ -746,6 +746,9 @@ cases:
               machine:
                 kubelet:
                   extraConfig:
+                    kubeReserved:
+                      cpu: 60m
+                      memory: 1382Mi
                     systemReserved:
                       cpu: 2500m
                       memory: 11Gi

--- a/contexts/_template/tests/platform-docker.test.yaml
+++ b/contexts/_template/tests/platform-docker.test.yaml
@@ -234,7 +234,15 @@ cases:
       gateway:
         enabled: false
       network: *default-network
-      cluster: *default-cluster
+      cluster:
+        <<: *default-cluster
+        controlplanes:
+          # Above the resource_constrained thresholds: isolates this case from
+          # config-talos's small-control-plane patch (covered separately).
+          cpu: 8
+          memory: 16
+          nodes:
+            controlplane-1: *cp1-node
       docker:
         registries:
           gcr.io:

--- a/contexts/_template/tests/platform-hetzner.test.yaml
+++ b/contexts/_template/tests/platform-hetzner.test.yaml
@@ -118,13 +118,13 @@ cases:
                 apiServer:
                   resources:
                     requests:
-                      cpu: 100m
-                      memory: 128Mi
+                      cpu: 250m
+                      memory: 256Mi
                 controllerManager:
                   resources:
                     requests:
-                      cpu: 50m
-                      memory: 64Mi
+                      cpu: 100m
+                      memory: 128Mi
                 extraManifests:
                 - https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml
                 network:
@@ -135,16 +135,16 @@ cases:
                 scheduler:
                   resources:
                     requests:
-                      cpu: 50m
-                      memory: 64Mi
+                      cpu: 100m
+                      memory: 128Mi
               machine:
                 kubelet:
                   extraArgs:
                     rotate-server-certificates: "true"
                   extraConfig:
                     kubeReserved:
-                      cpu: 100m
-                      memory: 256Mi
+                      cpu: 500m
+                      memory: 512Mi
                   nodeIP:
                     validSubnets:
                     - 10.5.0.0/16

--- a/contexts/_template/tests/platform-hetzner.test.yaml
+++ b/contexts/_template/tests/platform-hetzner.test.yaml
@@ -115,6 +115,16 @@ cases:
             common_config_patches: |-
               cluster:
                 allowSchedulingOnControlPlanes: false
+                apiServer:
+                  resources:
+                    requests:
+                      cpu: 100m
+                      memory: 128Mi
+                controllerManager:
+                  resources:
+                    requests:
+                      cpu: 50m
+                      memory: 64Mi
                 extraManifests:
                 - https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml
                 network:
@@ -122,10 +132,19 @@ cases:
                     name: none
                 proxy:
                   disabled: true
+                scheduler:
+                  resources:
+                    requests:
+                      cpu: 50m
+                      memory: 64Mi
               machine:
                 kubelet:
                   extraArgs:
                     rotate-server-certificates: "true"
+                  extraConfig:
+                    kubeReserved:
+                      cpu: 100m
+                      memory: 256Mi
                   nodeIP:
                     validSubnets:
                     - 10.5.0.0/16

--- a/contexts/_template/tests/platform-hetzner.test.yaml
+++ b/contexts/_template/tests/platform-hetzner.test.yaml
@@ -115,16 +115,6 @@ cases:
             common_config_patches: |-
               cluster:
                 allowSchedulingOnControlPlanes: false
-                apiServer:
-                  resources:
-                    requests:
-                      cpu: 250m
-                      memory: 256Mi
-                controllerManager:
-                  resources:
-                    requests:
-                      cpu: 100m
-                      memory: 128Mi
                 extraManifests:
                 - https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.8.7/deploy/standalone-install.yaml
                 network:
@@ -132,19 +122,10 @@ cases:
                     name: none
                 proxy:
                   disabled: true
-                scheduler:
-                  resources:
-                    requests:
-                      cpu: 100m
-                      memory: 128Mi
               machine:
                 kubelet:
                   extraArgs:
                     rotate-server-certificates: "true"
-                  extraConfig:
-                    kubeReserved:
-                      cpu: 500m
-                      memory: 512Mi
                   nodeIP:
                     validSubnets:
                     - 10.5.0.0/16


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This PR reworks Talos cluster kubelet resource reservations — a facet-layer config change affecting all platforms — with a linear taper formula replacing the old binary flag. The blast radius is contained to Talos cluster provisioning; existing clusters see kubelet configuration change on first reconcile after apply, which may trigger a brief kubelet restart.
>
> **Overview**
>
> Reservation sizing for both control-plane and worker nodes is now linearly interpolated between full (at the node threshold) and zero (at 2× the threshold), using `factor = 2 - ratio` clamped to [0, 1]. Control-plane tier selection (`schedulable` vs `dedicated`) and worker sizing are computed separately and emitted into `common_config_patches` and a new `worker_config_patches` field respectively. All five non-Docker platforms (hetzner, hyperv, incus, metal, vsphere) gain the `worker_config_patches` wire-up.
>
> The most notable behavioral change is that the Hetzner default cpx31 instance (4 CPU / 8 GB) no longer triggers the dedicated control-plane reservation — at exactly 2× the dedicated tier threshold, `factor = 0`. Additionally, when a large worker would otherwise inherit the control-plane's `kubeReserved` via `common_config_patches`, the new `worker_config_patches` emits an explicit `0m`/`0Mi` override to cancel the leak.

<!-- /claude-code-review:summary -->
