### PR TITLE
fix(identity): set cpu request on realm-import Job

### DIFF
--- a/kustomize/identity/resources/keycloak/realm/realm.yaml
+++ b/kustomize/identity/resources/keycloak/realm/realm.yaml
@@ -14,6 +14,7 @@ spec:
   # One-shot import; own resources instead of inheriting the server's.
   resources:
     requests:
+      cpu: 100m
       memory: 768Mi
     limits:
       memory: 1536Mi


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> Adds a missing CPU request to the Keycloak realm-import Job, a one-shot resource whose scheduling behavior is the only thing affected.
>
> **Overview**
>
> The PR adds `cpu: 100m` to the resource requests of the `realm.yaml` Job spec, which previously declared memory requests and limits but no CPU request. This brings the Job's QoS class in line with its memory configuration and gives the scheduler a concrete CPU hint when placing the import pod.
>
> The realm-import Job runs once at install time, so this change has no effect on the running Keycloak server and is fully reversible by removing the line.

<!-- /claude-code-review:summary -->
